### PR TITLE
Add method `modprobe` to vendor-config-onl and use it

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
@@ -192,7 +192,7 @@ class OnlPlatformBase(object):
     def baseconfig(self):
         return True
 
-    def insmod(self, module, required=True, params={}):
+    def modprobe(self, module, required=True, params={}):
         cmd = "modprobe %s" % module
         subprocess.check_call(cmd, shell=True)
 

--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
@@ -193,6 +193,10 @@ class OnlPlatformBase(object):
         return True
 
     def insmod(self, module, required=True, params={}):
+        cmd = "modprobe %s" % module
+        subprocess.check_call(cmd, shell=True)
+
+    def insmod(self, module, required=True, params={}):
         #
         # Search for modules in this order:
         #

--- a/packages/platforms/delta/x86-64/agc7646slv1b/platform-config/r0/src/python/x86_64_delta_agc7646slv1b_r0/__init__.py
+++ b/packages/platforms/delta/x86-64/agc7646slv1b/platform-config/r0/src/python/x86_64_delta_agc7646slv1b_r0/__init__.py
@@ -20,7 +20,7 @@ class OnlPlatform_x86_64_delta_agc7646slv1b_r0(OnlPlatformDelta, OnlPlatformPort
         os.system("echo 1 > /sys/bus/pci/rescan")
 
         #Insert tmp401(tmp431/tmp432) module
-        os.system('modprobe tmp401')
+        self.modprobe('tmp401')
 
         #Insert platform module
         self.insmod('delta_agc7646slv1b_platform')

--- a/packages/platforms/delta/x86-64/agc7646v1/platform-config/r0/src/python/x86_64_delta_agc7646v1_r0/__init__.py
+++ b/packages/platforms/delta/x86-64/agc7646v1/platform-config/r0/src/python/x86_64_delta_agc7646v1_r0/__init__.py
@@ -20,7 +20,7 @@ class OnlPlatform_x86_64_delta_agc7646v1_r0(OnlPlatformDelta, OnlPlatformPortCon
         os.system("echo 1 > /sys/bus/pci/rescan")
 
         #Insert tmp401(tmp431/tmp432) module
-        os.system('modprobe tmp401')
+        self.modprobe('modprobe tmp401')
 
         #Insert platform module
         self.insmod('delta_agc7646v1_platform')

--- a/packages/platforms/wnc/x86-64/x86-64-wnc-rseb-w1-32/platform-config/r0/src/python/x86_64_wnc_rseb_w1_32_r0/__init__.py
+++ b/packages/platforms/wnc/x86-64/x86-64-wnc-rseb-w1-32/platform-config/r0/src/python/x86_64_wnc_rseb_w1_32_r0/__init__.py
@@ -9,10 +9,10 @@ class OnlPlatform_x86_64_wnc_rseb_w1_32_r0(OnlPlatformWNC,
 
     def baseconfig(self):
 
-        os.system("modprobe pmbus")
-        os.system("modprobe jc42")
-        os.system("modprobe ads7828")
-        os.system("modprobe ucd9000")
+        self.modprobe("pmbus")
+        self.modprobe("jc42")
+        self.modprobe("ads7828")
+        self.modprobe("ucd9000")
         self.insmod("rseb-w1-32-system_cpld")
         self.insmod("tps53681")
         self.insmod("rseb-w1-32_psu")


### PR DESCRIPTION
Instead of sprinkling `os.system()` all over the place, add the method `modprobe` to follow `insmod`, which looks at different paths though.

Signed-off-by: Paul Menzel <pmenzel@molgen.mpg.de>