### PR TITLE
[tn48m/tn48m-dn] Fix onlp issues

### DIFF
--- a/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/eeprom_info.c
+++ b/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/eeprom_info.c
@@ -78,7 +78,7 @@ int eeprom_info_get(uint8_t *eeprom, int len, char *type, char *v)
     char model[PSU_MODEL_LEN+1]    = {'\0'};
     const char psu_model_key[]     = "DPS";
     const char psu_200_series_key[]= "GQHD";
-    const char psu_920_series_key[]= "XXXD";
+    const char psu_920_series_key[]= "JRYD";
 
     if (!eeprom || !type || !v)
         return -1;

--- a/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/fani.c
+++ b/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/fani.c
@@ -38,6 +38,7 @@ static int _psu_fan_present(void *e);
 static plat_fan_t plat_fans[] = {
     [PLAT_FAN_ID_1] = {
         .name = "Chassis Fan 1",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan1_input",
@@ -51,6 +52,7 @@ static plat_fan_t plat_fans[] = {
     },
     [PLAT_FAN_ID_2] = {
         .name = "Chassis Fan 2",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan2_input",
@@ -64,6 +66,7 @@ static plat_fan_t plat_fans[] = {
     },
     [PLAT_FAN_ID_3] = {
         .name = "Chassis Fan 3",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan3_input",
@@ -170,6 +173,8 @@ int onlp_fani_info_get(onlp_oid_t id, onlp_fan_info_t* info)
     if (fan->name)
         snprintf(info->hdr.description, sizeof(info->hdr.description),
                  "%s", fan->name);
+    if (fan->model)
+        snprintf(info->model, sizeof(info->model), "%s", fan->model);
 
     info->caps = fan->caps;
     if (fan->rpm_get_path) info->caps |= ONLP_FAN_CAPS_GET_RPM;

--- a/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/platform_lib.h
+++ b/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/platform_lib.h
@@ -122,6 +122,7 @@ typedef enum plat_fan_state {
 
 typedef struct plat_fan {
     char *name;
+    char *model;
 
     hook_present present;
     void *present_data;

--- a/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/platform_lib.h
+++ b/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/platform_lib.h
@@ -157,6 +157,13 @@ typedef enum plat_psu_id {
     PLAT_PSU_ID_MAX
 } plat_psu_id_t;
 
+typedef enum plat_psu_type {
+    PLAT_PSU_TYPE_AC = 0,
+    PLAT_PSU_TYPE_DC12,
+    PLAT_PSU_TYPE_DC48,
+    PLAT_PSU_TYPE_MAX
+} plat_psu_type_t;
+
 typedef enum plat_psu_state {
     PLAT_PSU_STATE_PRESENT = 0,
     PLAT_PSU_STATE_UNPRESENT,
@@ -174,6 +181,8 @@ typedef enum plat_psu_event {
 
 typedef struct plat_psu {
     char *name;
+
+    plat_psu_type_t type;
 
     hook_present present;
     char *present_path;

--- a/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/psui.c
+++ b/packages/platforms/delta/arm64/tn48m-dn/src/arm64_delta_tn48m_dn/module/src/psui.c
@@ -33,6 +33,7 @@ static int _psu_event(void *e, int ev);
 static plat_psu_t plat_tn48m_dn_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU",
+        .type = PLAT_PSU_TYPE_AC,
         .power_status_path = "/sys/bus/i2c/devices/0-0041/psu2_powergood",
         .state = PLAT_PSU_STATE_PRESENT,
     },
@@ -41,6 +42,7 @@ static plat_psu_t plat_tn48m_dn_psus[] = {
 static plat_psu_t plat_tn48m_poe_dn_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu1_present",
 
@@ -67,6 +69,7 @@ static plat_psu_t plat_tn48m_poe_dn_psus[] = {
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu2_present",
 
@@ -98,6 +101,7 @@ static plat_psu_t plat_tn48m_poe_dn_psus[] = {
 static plat_psu_t plat_tn4810m_dn_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/5-0041/psu1_present",
 
@@ -111,6 +115,7 @@ static plat_psu_t plat_tn4810m_dn_psus[] = {
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/5-0041/psu2_present",
 
@@ -365,9 +370,20 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
                 info->status |= ONLP_PSU_STATUS_FAILED;
         }
 
-        // TODO : auto detect AC / DC type
-        // Just do a guess
+        // Auto detect AC / DC type
+        // The PSU capability is decided by Vin value
         info->caps |= _psu_vin_type_guess(info->mvin);
+    } else {
+        // The PSU capability is decided by configuration
+        if (psu->type == PLAT_PSU_TYPE_AC) {
+            info->caps |= ONLP_PSU_CAPS_AC;
+        } else if (psu->type == PLAT_PSU_TYPE_DC12) {
+            info->caps |= ONLP_PSU_CAPS_DC12;
+        } else if (psu->type == PLAT_PSU_TYPE_DC48) {
+            info->caps |= ONLP_PSU_CAPS_DC48;
+        } else {
+            info->status |= ONLP_PSU_STATUS_FAILED;
+        }
     }
 
     //// If VIN is not ok, skip other

--- a/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/eeprom_info.c
+++ b/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/eeprom_info.c
@@ -78,7 +78,7 @@ int eeprom_info_get(uint8_t *eeprom, int len, char *type, char *v)
     char model[PSU_MODEL_LEN+1]    = {'\0'};
     const char psu_model_key[]     = "DPS";
     const char psu_200_series_key[]= "GQHD";
-    const char psu_920_series_key[]= "XXXD";
+    const char psu_920_series_key[]= "JRYD";
 
     if (!eeprom || !type || !v)
         return -1;

--- a/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/fani.c
+++ b/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/fani.c
@@ -38,6 +38,7 @@ static int _psu_fan_present(void *e);
 static plat_fan_t plat_fans[] = {
     [PLAT_FAN_ID_1] = {
         .name = "Chassis Fan 1",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan1_input",
@@ -51,6 +52,7 @@ static plat_fan_t plat_fans[] = {
     },
     [PLAT_FAN_ID_2] = {
         .name = "Chassis Fan 2",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan2_input",
@@ -64,6 +66,7 @@ static plat_fan_t plat_fans[] = {
     },
     [PLAT_FAN_ID_3] = {
         .name = "Chassis Fan 3",
+        .model = "ADT7473",
         .present = _fan_present,
         .present_data = NULL,
         .rpm_get_path = "/sys/bus/i2c/devices/1-002e/hwmon/*/fan3_input",
@@ -170,6 +173,8 @@ int onlp_fani_info_get(onlp_oid_t id, onlp_fan_info_t* info)
     if (fan->name)
         snprintf(info->hdr.description, sizeof(info->hdr.description),
                  "%s", fan->name);
+    if (fan->model)
+        snprintf(info->model, sizeof(info->model), "%s", fan->model);
 
     info->caps = fan->caps;
     if (fan->rpm_get_path) info->caps |= ONLP_FAN_CAPS_GET_RPM;

--- a/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/platform_lib.h
+++ b/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/platform_lib.h
@@ -159,6 +159,13 @@ typedef enum plat_psu_id {
     PLAT_PSU_ID_MAX
 } plat_psu_id_t;
 
+typedef enum plat_psu_type {
+    PLAT_PSU_TYPE_AC = 0,
+    PLAT_PSU_TYPE_DC12,
+    PLAT_PSU_TYPE_DC48,
+    PLAT_PSU_TYPE_MAX
+} plat_psu_type_t;
+
 typedef enum plat_psu_state {
     PLAT_PSU_STATE_PRESENT = 0,
     PLAT_PSU_STATE_UNPRESENT,
@@ -176,6 +183,8 @@ typedef enum plat_psu_event {
 
 typedef struct plat_psu {
     char *name;
+
+    plat_psu_type_t type;
 
     hook_present present;
     char *present_path;

--- a/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/platform_lib.h
+++ b/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/platform_lib.h
@@ -124,6 +124,7 @@ typedef enum plat_fan_state {
 
 typedef struct plat_fan {
     char *name;
+    char *model;
 
     hook_present present;
     void *present_data;

--- a/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/psui.c
+++ b/packages/platforms/delta/arm64/tn48m/src/arm64_delta_tn48m/module/src/psui.c
@@ -33,6 +33,7 @@ static int _psu_event(void *e, int ev);
 static plat_psu_t plat_tn48m_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU",
+	.type = PLAT_PSU_TYPE_AC,
         .power_status_path = "/sys/bus/i2c/devices/0-0041/psu2_powergood",
         .state = PLAT_PSU_STATE_PRESENT,
     },
@@ -41,6 +42,7 @@ static plat_psu_t plat_tn48m_psus[] = {
 static plat_psu_t plat_tn48m_poe_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu1_present",
 
@@ -67,6 +69,7 @@ static plat_psu_t plat_tn48m_poe_psus[] = {
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu2_present",
 
@@ -98,6 +101,7 @@ static plat_psu_t plat_tn48m_poe_psus[] = {
 static plat_psu_t plat_tn4810m_pvt_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/5-0041/psu1_present",
 
@@ -111,6 +115,7 @@ static plat_psu_t plat_tn4810m_pvt_psus[] = {
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/5-0041/psu2_present",
 
@@ -127,6 +132,7 @@ static plat_psu_t plat_tn4810m_pvt_psus[] = {
 static plat_psu_t plat_tn4810m_nonpvt_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu1_present",
 
@@ -140,6 +146,7 @@ static plat_psu_t plat_tn4810m_nonpvt_psus[] = {
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .present = _psu_present,
         .present_path = "/sys/bus/i2c/devices/0-0041/psu2_present",
 
@@ -156,11 +163,13 @@ static plat_psu_t plat_tn4810m_nonpvt_psus[] = {
 static plat_psu_t plat_tn48m2_psus[] = {
     [PLAT_PSU_ID_1] = {
         .name = "PSU1",
+        .type = PLAT_PSU_TYPE_AC,
         .power_status_path = "/sys/bus/i2c/devices/0-0041/psu1_powergood",
         .state = PLAT_PSU_STATE_PRESENT,
     },
     [PLAT_PSU_ID_2] = {
         .name = "PSU2",
+        .type = PLAT_PSU_TYPE_AC,
         .power_status_path = "/sys/bus/i2c/devices/0-0041/psu2_powergood",
         .state = PLAT_PSU_STATE_PRESENT,
     },
@@ -410,9 +419,20 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
                 info->status |= ONLP_PSU_STATUS_FAILED;
         }
 
-        // TODO : auto detect AC / DC type
-        // Just do a guess
+        // Auto detect AC / DC type
+        // The PSU capability is decided by Vin value
         info->caps |= _psu_vin_type_guess(info->mvin);
+    } else {
+        // The PSU capability is decided by configuration
+        if (psu->type == PLAT_PSU_TYPE_AC) {
+            info->caps |= ONLP_PSU_CAPS_AC;
+        } else if (psu->type == PLAT_PSU_TYPE_DC12) {
+            info->caps |= ONLP_PSU_CAPS_DC12;
+        } else if (psu->type == PLAT_PSU_TYPE_DC48) {
+            info->caps |= ONLP_PSU_CAPS_DC48;
+        } else {
+            info->status |= ONLP_PSU_STATUS_FAILED;
+        }
     }
 
     //// If VIN is not ok, skip other


### PR DESCRIPTION
Fix the below onlp issues reported by Amazon Chandrasekaran Paraneetharan.
1. Wrong PSU serial key on tn48m-poe and tn48m-poe-dn.
2. PSU capabilities are not listed on tn48m/tn48m-dn and tn4810m/tn4810m-dn.
3. Fan model is not reported on tn48m and tn48m-dn series.

Test logs:
[dentOS_tn48m-poe_fix_onlp_issues_2021_0219.log](https://github.com/dentproject/dentOS/files/6008395/dentOS_tn48m-poe_fix_onlp_issues_2021_0219.log)
[dentOS_tn48m_fix_onlp_issues_2021_0219.log](https://github.com/dentproject/dentOS/files/6008396/dentOS_tn48m_fix_onlp_issues_2021_0219.log)
[dentOS_tn4810m_fix_onlp_issues_2021_0219.log](https://github.com/dentproject/dentOS/files/6008397/dentOS_tn4810m_fix_onlp_issues_2021_0219.log)
