### PR TITLE
arm64: Enable keepalived package

### DIFF
--- a/builds/any/rootfs/stretch/common/arm64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/arm64-base-packages.yml
@@ -13,3 +13,4 @@
 - dnsutils
 - mft
 - mrvl-fw-image
+- keepalived


### PR DESCRIPTION
arm64: Enable keepalived package
    
Keepalived is used to configure VRRP on Marvell [1] and Mellanox [2] platforms

Use the arm64 package from [dent-artifacts][3], as the version 1.3.2-1 in Debian 9 (stretch) is too old. Also, dent-artifacts only contains the build for arm64 and not amd64.
    
[1] https://github.com/Marvell-switching/Switchdev-prestera/wiki/virtual-router-redundancy-protocol-(vrrp)
[2] https://github.com/Mellanox/mlxsw/wiki/Virtual-Router-Redundancy-Protocol-%28VRRP%29
[3] https://github.com/dentproject/dent-artifacts/blob/master/REPO/stretch/packages/binary-arm64/keepalived_2.0.10-1_arm64.deb
