### PR TITLE
[tx4810] Update the MFT PCI drivers to latest version 4.16.3.

### DIFF
--- a/packages/platforms/delta/arm64/tx4810/modules/builds/src/mst_pciconf.c
+++ b/packages/platforms/delta/arm64/tx4810/modules/builds/src/mst_pciconf.c
@@ -50,17 +50,18 @@
 
 #include "driver_common.h"
 #include "mst_pciconf.h"
-#define  INIT           PCICONF_INIT
-#define  STOP           PCICONF_STOP
-#define  READ4          PCICONF_READ4
-#define  READ4_NEW      PCICONF_READ4_NEW
-#define  WRITE4         PCICONF_WRITE4
-#define  WRITE4_NEW     PCICONF_WRITE4_NEW
-#define  MODIFY         PCICONF_MODIFY
-#define  READ4_BUFFER   PCICONF_READ4_BUFFER
-#define  WRITE4_BUFFER  PCICONF_WRITE4_BUFFER
-#define  MST_PARAMS     PCICONF_MST_PARAMS
-#define  MST_META_DATA  PCICONF_MST_META_DATA
+#define  INIT               PCICONF_INIT
+#define  STOP               PCICONF_STOP
+#define  READ4              PCICONF_READ4
+#define  READ4_NEW          PCICONF_READ4_NEW
+#define  WRITE4             PCICONF_WRITE4
+#define  WRITE4_NEW         PCICONF_WRITE4_NEW
+#define  MODIFY             PCICONF_MODIFY
+#define  READ4_BUFFER       PCICONF_READ4_BUFFER
+#define  READ4_BUFFER_EX    PCICONF_READ4_BUFFER_EX
+#define  WRITE4_BUFFER      PCICONF_WRITE4_BUFFER
+#define  MST_PARAMS         PCICONF_MST_PARAMS
+#define  MST_META_DATA      PCICONF_MST_META_DATA
 
 /* Versions */
 #define MST_HDR_VERSION 1
@@ -800,6 +801,7 @@ static int ioctl (struct inode *inode, struct file *file, unsigned int opcode, u
             ret=put_user(d,&(m_udata->old_data))?-EFAULT:0;
             goto fin;
         }
+    case READ4_BUFFER_EX:
     case READ4_BUFFER:
     {
         struct mst_read4_buffer_st read4_buf;

--- a/packages/platforms/delta/arm64/tx4810/modules/builds/src/mst_pciconf.h
+++ b/packages/platforms/delta/arm64/tx4810/modules/builds/src/mst_pciconf.h
@@ -91,6 +91,7 @@ struct mst_modify_st {
 };
 
 #define PCICONF_READ4_BUFFER  _IOR (PCICONF_MAGIC,4,struct mst_read4_st)
+#define PCICONF_READ4_BUFFER_EX  _IOR (PCICONF_MAGIC,4,struct mst_read4_buffer_st)
 struct mst_read4_buffer_st {
         unsigned int address_space;
         unsigned int offset;


### PR DESCRIPTION
Since the kernel 5.8 used by tx4810 is removed \[1\], the tx4810 was configured to work on kernel 5.10. But the MFT PCI drivers on tx4810 are failed to create device node of "/dev/mst/mt52100_pciconf0" with kernel 5.10. The error logs like below:

```
ioctl (PCICONF_INIT): Inappropriate ioctl for device
ioctl (PCI_INIT): Inappropriate ioctl for device
cat: /dev/mst/mt52100_pci_cr0: No such file or directory
ioctl (PCICONF_INIT): Inappropriate ioctl for device
ioctl (PCI_INIT): Inappropriate ioctl for device
cat: /dev/mst/mt52100_pci_cr0: No such file or directory
ioctl (PCICONF_INIT): Inappropriate ioctl for device
ioctl (PCI_INIT): Inappropriate ioctl for device
cat: /dev/mst/mt52100_pci_cr0: No such file or directory
```

To fix this, we have to update MFT PCI drivers to its latest version from Mellanox official website [2] and the source codes can be found in downlaod MFT package [3].

\[1\]: https://github.com/dentproject/dentOS/pull/59
\[2\]: https://www.mellanox.com/products/adapter-software/firmware-tools
\[3\]: https://github.com/dentproject/dentOS/pull/63#issuecomment-815822791

Test log:
[dentOS_tx4810_test_onlp_with_mft_pci_driver_v4.16.3_20210408.log](https://github.com/dentproject/dentOS/files/6277011/dentOS_tx4810_test_onlp_with_mft_pci_driver_v4.16.3_20210408.log)


Signed-off-by: Chenglin Tsai <chenglin.tsai@deltaww.com>