### PR TITLE
fix start networking.service before network is marked online

### DIFF
--- a/builds/any/rootfs/stretch/common/overlay/etc/systemd/system/networking.service.d/switchdev-online.conf
+++ b/builds/any/rootfs/stretch/common/overlay/etc/systemd/system/networking.service.d/switchdev-online.conf
@@ -1,2 +1,3 @@
 [Unit]
-After=network-pre.target
+After=local-fs.target network-pre.target
+Before=shutdown.target network.target network-online.target


### PR DESCRIPTION
ifupdown2 didn't ensure that it will start before network.target and network-online.target.
after local-fs.target because ifupdown2 need to read config file from local filesystem
Other network services will not start after networking.service and fail because no interface is up.
(e.g isc-dhcp-server, tftp-hpa)

related to #56
related to https://github.com/CumulusNetworks/ifupdown2/pull/190

Signed-off-by: Date Huang <tjjh89017@hotmail.com>