### PR TITLE
[QSD61_AOM_A_48/QSA72_AOM_A_48P] Upgrade kernel to 5.10 and support ethtool

### DIFF
--- a/packages/base/any/kernels/5.10-lts/patches/0010-wnc-qsd61-aom-a-48.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0010-wnc-qsd61-aom-a-48.patch
@@ -1,6 +1,23 @@
+From d48213123a4743a6727d76785a7300874c348e62 Mon Sep 17 00:00:00 2001
+From: Clement Chu <Clement.Chu@wnc.com.tw>
+Date: Mon, 3 May 2021 11:24:26 +0800
+Subject: [PATCH] Add QSD61_AOM_A_48 device tree
+
+1. Add prestera driver related description for support ethtool.
+Include driver, onie_eeprom and pcie mapping information.
+2. Add gpio-i2c driver and SFP cage interface (port 1~48) description.
+3. Disable eth0 and eth1 interface to avoid the security issues.
+---
+ .../boot/dts/marvell/wnc-qsd61-aom-a-48.dts   | 1893 +++++++++++++++++
+ 1 file changed, 1893 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
+
+diff --git a/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts b/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
+new file mode 100644
+index 0000000..bd256f2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,1893 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (C) 2016 Marvell Technology Group Ltd.
@@ -27,9 +44,9 @@
 +		ethernet0 = &cp0_eth0;
 +		ethernet1 = &cp0_eth1;
 +		ethernet2 = &cp0_eth2;
-+		i2c0 = &cp0_i2c0;
++		i2c0 = &i2c0;
 +		i2c1 = &cp0_i2c1;
-+		i2c2 = &i2c0;
++		i2c2 = &cp0_i2c0;
 +	};
 +
 +	cp0_utmi: utmi@580000 {
@@ -46,13 +63,1703 @@
 +			status = "disabled";
 +		};
 +    };
++
++	switch-cpu {
++		compatible = "marvell,prestera-switch-rxtx-sdma";
++		status = "okay";
++	};
++
++	onie_eeprom: onie-eeprom {
++		compatible = "onie-nvmem-cells";
++		status = "okay";
++
++		nvmem = <&eeprom_at24>;
++	};
++
++	prestera {
++		compatible = "marvell,prestera";
++		status = "okay";
++
++		base-mac-provider = <&onie_eeprom>;
++		ports {
++			port1 {
++        		prestera,port-num = <1>;
++        		sfp = <&sfp1>;
++			};
++			port2 {
++        		prestera,port-num = <2>;
++        		sfp = <&sfp2>;
++			};
++			port3 {
++        		prestera,port-num = <3>;
++        		sfp = <&sfp3>;
++			};
++			port4 {
++        		prestera,port-num = <4>;
++        		sfp = <&sfp4>;
++			};
++			port5 {
++        		prestera,port-num = <5>;
++        		sfp = <&sfp5>;
++			};
++			port6 {
++        		prestera,port-num = <6>;
++        		sfp = <&sfp6>;
++			};
++			port7 {
++        		prestera,port-num = <7>;
++        		sfp = <&sfp7>;
++			};
++			port8 {
++        		prestera,port-num = <8>;
++        		sfp = <&sfp8>;
++			};
++			port9 {
++        		prestera,port-num = <9>;
++        		sfp = <&sfp9>;
++			};
++			port10 {
++        		prestera,port-num = <10>;
++        		sfp = <&sfp10>;
++			};
++			port11 {
++        		prestera,port-num = <11>;
++        		sfp = <&sfp11>;
++			};
++			port12 {
++        		prestera,port-num = <12>;
++        		sfp = <&sfp12>;
++			};
++			port13 {
++        		prestera,port-num = <13>;
++        		sfp = <&sfp13>;
++			};
++			port14 {
++        		prestera,port-num = <14>;
++        		sfp = <&sfp14>;
++			};
++			port15 {
++        		prestera,port-num = <15>;
++        		sfp = <&sfp15>;
++			};
++			port16 {
++        		prestera,port-num = <16>;
++        		sfp = <&sfp16>;
++			};
++			port17 {
++        		prestera,port-num = <17>;
++        		sfp = <&sfp17>;
++			};
++			port18 {
++        		prestera,port-num = <18>;
++        		sfp = <&sfp18>;
++			};
++			port19 {
++        		prestera,port-num = <19>;
++        		sfp = <&sfp19>;
++			};
++			port20 {
++        		prestera,port-num = <20>;
++        		sfp = <&sfp20>;
++			};
++			port21 {
++        		prestera,port-num = <21>;
++        		sfp = <&sfp21>;
++			};
++			port22 {
++        		prestera,port-num = <22>;
++        		sfp = <&sfp22>;
++			};
++			port23 {
++        		prestera,port-num = <23>;
++        		sfp = <&sfp23>;
++			};
++			port24 {
++        		prestera,port-num = <24>;
++        		sfp = <&sfp24>;
++			};
++			port25 {
++        		prestera,port-num = <25>;
++        		sfp = <&sfp25>;
++			};
++			port26 {
++        		prestera,port-num = <26>;
++        		sfp = <&sfp26>;
++			};
++			port27 {
++        		prestera,port-num = <27>;
++        		sfp = <&sfp27>;
++			};
++			port28 {
++        		prestera,port-num = <28>;
++        		sfp = <&sfp28>;
++			};
++			port29 {
++        		prestera,port-num = <29>;
++        		sfp = <&sfp29>;
++			};
++			port30 {
++        		prestera,port-num = <30>;
++        		sfp = <&sfp30>;
++			};
++			port31 {
++        		prestera,port-num = <31>;
++        		sfp = <&sfp31>;
++			};
++			port32 {
++        		prestera,port-num = <32>;
++        		sfp = <&sfp32>;
++			};
++			port33 {
++        		prestera,port-num = <33>;
++        		sfp = <&sfp33>;
++			};
++			port34 {
++        		prestera,port-num = <34>;
++        		sfp = <&sfp34>;
++			};
++			port35 {
++        		prestera,port-num = <35>;
++        		sfp = <&sfp35>;
++			};
++			port36 {
++        		prestera,port-num = <36>;
++        		sfp = <&sfp36>;
++			};
++			port37 {
++        		prestera,port-num = <37>;
++        		sfp = <&sfp37>;
++			};
++			port38 {
++        		prestera,port-num = <38>;
++        		sfp = <&sfp38>;
++			};
++			port39 {
++        		prestera,port-num = <39>;
++        		sfp = <&sfp39>;
++			};
++			port40 {
++        		prestera,port-num = <40>;
++        		sfp = <&sfp40>;
++			};
++			port41 {
++        		prestera,port-num = <41>;
++        		sfp = <&sfp41>;
++			};
++			port42 {
++        		prestera,port-num = <42>;
++        		sfp = <&sfp42>;
++			};
++			port43 {
++        		prestera,port-num = <43>;
++        		sfp = <&sfp43>;
++			};
++			port44 {
++        		prestera,port-num = <44>;
++        		sfp = <&sfp44>;
++			};
++			port45 {
++        		prestera,port-num = <45>;
++        		sfp = <&sfp45>;
++			};
++			port46 {
++        		prestera,port-num = <46>;
++        		sfp = <&sfp46>;
++			};
++			port47 {
++        		prestera,port-num = <47>;
++        		sfp = <&sfp47>;
++			};
++			port48 {
++        		prestera,port-num = <48>;
++        		sfp = <&sfp48>;
++			};
++    	};
++	};
++
++	sfp1: sfp-1 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp0>;
++
++    	los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
++	};
++	sfp2: sfp-2 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp1>;
++
++    	los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
++	};
++	sfp3: sfp-3 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp2>;
++
++    	los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
++	};
++	sfp4: sfp-4 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp3>;
++
++    	los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
++	};
++	sfp5: sfp-5 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp4>;
++
++    	los-gpio = <&gpio_i2c 12 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 13 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 14 GPIO_ACTIVE_HIGH>;
++	};
++	sfp6: sfp-6 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp5>;
++
++    	los-gpio = <&gpio_i2c 15 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 16 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 17 GPIO_ACTIVE_HIGH>;
++	};
++	sfp7: sfp-7 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp6>;
++
++    	los-gpio = <&gpio_i2c 18 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 19 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 20 GPIO_ACTIVE_HIGH>;
++	};
++	sfp8: sfp-8 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp7>;
++
++    	los-gpio = <&gpio_i2c 21 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 22 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 23 GPIO_ACTIVE_HIGH>;
++	};
++	sfp9: sfp-9 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp8>;
++
++    	los-gpio = <&gpio_i2c 24 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 25 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 26 GPIO_ACTIVE_HIGH>;
++	};
++	sfp10: sfp-10 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp9>;
++
++    	los-gpio = <&gpio_i2c 27 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 28 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 29 GPIO_ACTIVE_HIGH>;
++	};
++	sfp11: sfp-11 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp10>;
++
++    	los-gpio = <&gpio_i2c 30 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 31 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 32 GPIO_ACTIVE_HIGH>;
++	};
++	sfp12: sfp-12 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp11>;
++
++    	los-gpio = <&gpio_i2c 33 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 34 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 35 GPIO_ACTIVE_HIGH>;
++	};
++	sfp13: sfp-13 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp12>;
++
++    	los-gpio = <&gpio_i2c 36 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 37 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 38 GPIO_ACTIVE_HIGH>;
++	};
++	sfp14: sfp-14 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp13>;
++
++    	los-gpio = <&gpio_i2c 39 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 40 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 41 GPIO_ACTIVE_HIGH>;
++	};
++	sfp15: sfp-15 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp14>;
++
++    	los-gpio = <&gpio_i2c 42 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 43 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 44 GPIO_ACTIVE_HIGH>;
++	};
++	sfp16: sfp-16 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp15>;
++
++    	los-gpio = <&gpio_i2c 45 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 46 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 47 GPIO_ACTIVE_HIGH>;
++	};
++	sfp17: sfp-17 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp16>;
++
++    	los-gpio = <&gpio_i2c 48 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 49 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 50 GPIO_ACTIVE_HIGH>;
++	};
++	sfp18: sfp-18 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp17>;
++
++    	los-gpio = <&gpio_i2c 51 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 52 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 53 GPIO_ACTIVE_HIGH>;
++	};
++	sfp19: sfp-19 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp18>;
++
++    	los-gpio = <&gpio_i2c 54 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 55 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 56 GPIO_ACTIVE_HIGH>;
++	};
++	sfp20: sfp-20 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp19>;
++
++    	los-gpio = <&gpio_i2c 57 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 58 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 59 GPIO_ACTIVE_HIGH>;
++	};
++	sfp21: sfp-21 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp20>;
++
++    	los-gpio = <&gpio_i2c 60 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 61 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 62 GPIO_ACTIVE_HIGH>;
++	};
++	sfp22: sfp-22 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp21>;
++
++    	los-gpio = <&gpio_i2c 63 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 64 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 65 GPIO_ACTIVE_HIGH>;
++	};
++	sfp23: sfp-23 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp22>;
++
++    	los-gpio = <&gpio_i2c 66 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 67 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 68 GPIO_ACTIVE_HIGH>;
++	};
++	sfp24: sfp-24 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp23>;
++
++    	los-gpio = <&gpio_i2c 69 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 70 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 71 GPIO_ACTIVE_HIGH>;
++	};
++	sfp25: sfp-25 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp24>;
++
++    	los-gpio = <&gpio_i2c 72 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 73 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 74 GPIO_ACTIVE_HIGH>;
++	};
++	sfp26: sfp-26 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp25>;
++
++    	los-gpio = <&gpio_i2c 75 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 76 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 77 GPIO_ACTIVE_HIGH>;
++	};
++	sfp27: sfp-27 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp26>;
++
++    	los-gpio = <&gpio_i2c 78 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 79 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 80 GPIO_ACTIVE_HIGH>;
++	};
++	sfp28: sfp-28 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp27>;
++
++    	los-gpio = <&gpio_i2c 81 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 82 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 83 GPIO_ACTIVE_HIGH>;
++	};
++	sfp29: sfp-29 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp28>;
++
++    	los-gpio = <&gpio_i2c 84 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 85 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 86 GPIO_ACTIVE_HIGH>;
++	};
++	sfp30: sfp-30 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp29>;
++
++    	los-gpio = <&gpio_i2c 87 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 88 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 89 GPIO_ACTIVE_HIGH>;
++	};
++	sfp31: sfp-31 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp30>;
++
++    	los-gpio = <&gpio_i2c 90 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 91 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 92 GPIO_ACTIVE_HIGH>;
++	};
++	sfp32: sfp-32 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp31>;
++
++    	los-gpio = <&gpio_i2c 93 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 94 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 95 GPIO_ACTIVE_HIGH>;
++	};
++	sfp33: sfp-33 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp32>;
++
++    	los-gpio = <&gpio_i2c 96 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 97 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 98 GPIO_ACTIVE_HIGH>;
++	};
++	sfp34: sfp-34 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp33>;
++
++    	los-gpio = <&gpio_i2c 99 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 100 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 101 GPIO_ACTIVE_HIGH>;
++	};
++	sfp35: sfp-35 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp34>;
++
++    	los-gpio = <&gpio_i2c 102 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 103 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 104 GPIO_ACTIVE_HIGH>;
++	};
++	sfp36: sfp-36 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp35>;
++
++    	los-gpio = <&gpio_i2c 105 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 106 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 107 GPIO_ACTIVE_HIGH>;
++	};
++	sfp37: sfp-37 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp36>;
++
++    	los-gpio = <&gpio_i2c 108 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 109 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 110 GPIO_ACTIVE_HIGH>;
++	};
++	sfp38: sfp-38 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp37>;
++
++    	los-gpio = <&gpio_i2c 111 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 112 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 113 GPIO_ACTIVE_HIGH>;
++	};
++	sfp39: sfp-39 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp38>;
++
++    	los-gpio = <&gpio_i2c 114 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 115 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 116 GPIO_ACTIVE_HIGH>;
++	};
++	sfp40: sfp-40 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp39>;
++
++    	los-gpio = <&gpio_i2c 117 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 118 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 119 GPIO_ACTIVE_HIGH>;
++	};
++	sfp41: sfp-41 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp40>;
++
++    	los-gpio = <&gpio_i2c 120 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 121 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 122 GPIO_ACTIVE_HIGH>;
++	};
++	sfp42: sfp-42 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp41>;
++
++    	los-gpio = <&gpio_i2c 123 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 124 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 125 GPIO_ACTIVE_HIGH>;
++	};
++	sfp43: sfp-43 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp42>;
++
++    	los-gpio = <&gpio_i2c 126 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 127 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 128 GPIO_ACTIVE_HIGH>;
++	};
++	sfp44: sfp-44 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp43>;
++
++    	los-gpio = <&gpio_i2c 129 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 130 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 131 GPIO_ACTIVE_HIGH>;
++	};
++	sfp45: sfp-45 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp44>;
++
++    	los-gpio = <&gpio_i2c 132 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 133 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 134 GPIO_ACTIVE_HIGH>;
++	};
++	sfp46: sfp-46 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp45>;
++
++    	los-gpio = <&gpio_i2c 135 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 136 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 137 GPIO_ACTIVE_HIGH>;
++	};
++	sfp47: sfp-47 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp46>;
++
++    	los-gpio = <&gpio_i2c 138 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 139 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 140 GPIO_ACTIVE_HIGH>;
++	};
++	sfp48: sfp-48 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp47>;
++
++    	los-gpio = <&gpio_i2c 141 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 142 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 143 GPIO_ACTIVE_HIGH>;
++	};
++
++	gpio_i2c: gpio-i2c {
++    	compatible = "qsd61_48_gpio_i2c";
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	gpio-controller;
++    	#gpio-cells = <2>;
++    	/* reg = <0x40>; */  /* CPLD/MUX I2C address */
++
++    	gpio-map {
++			/* sfp0 */
++			sfp00_gpio00_loss {
++        		reg-map = <0x08 (1 << 0)>; /* 0xA6=register in the CPLD, (1 << 0)=Selected bit */
++        		gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
++			};
++			sfp00_gpio01_pres {
++        		reg-map = <0x02 (1 << 0)>; /* reg mask */
++        		gpio-num = <1>;
++			};
++			sfp00_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 0)>; /* reg mask */
++        		gpio-num = <2>;
++			};
++
++			/* sfp1 */
++			sfp01_gpio00_sfp_loss {
++        		reg-map = <0x08 (1 << 1)>; /* reg mask */
++        		gpio-num = <3>;
++			};
++			sfp01_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 1)>; /* reg mask */
++        		gpio-num = <4>;
++			};
++			sfp01_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 1)>; /* reg mask */
++        		gpio-num = <5>;
++			};
++
++			/* sfp2 */
++			sfp02_gpio00_loss {
++        		reg-map = <0x08 (1 << 2)>; /* reg mask */
++        		gpio-num = <6>;
++			};
++			sfp02_gpio01_pres {
++        		reg-map = <0x02 (1 << 2)>; /* reg mask */
++        		gpio-num = <7>;
++			};
++			sfp02_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 2)>; /* reg mask */
++        		gpio-num = <8>;
++			};
++
++			/* sfp3 */
++			sfp03_gpio00_loss {
++        		reg-map = <0x08 (1 << 3)>; /* reg mask */
++        		gpio-num = <9>;
++			};
++			sfp03_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 3)>; /* reg mask */
++        		gpio-num = <10>;
++			};
++			sfp03_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 3)>; /* reg mask */
++        		gpio-num = <11>;
++			};
++
++			/* sfp4 */
++			sfp04_gpio00_loss {
++        		reg-map = <0x08 (1 << 4)>; /* reg mask */
++        		gpio-num = <12>;
++			};
++			sfp04_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 4)>; /* reg mask */
++        		gpio-num = <13>;
++			};
++			sfp04_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 4)>; /* reg mask */
++        		gpio-num = <14>;
++			};
++
++			/* sfp5 */
++			sfp05_gpio00_loss {
++        		reg-map = <0x08 (1 << 5)>; /* reg mask */
++        		gpio-num = <15>;
++			};
++			sfp05_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 5)>; /* reg mask */
++        		gpio-num = <16>;
++			};
++			sfp05_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 5)>; /* reg mask */
++        		gpio-num = <17>;
++			};
++
++			/* sfp6 */
++			sfp06_gpio00_loss {
++        		reg-map = <0x08 (1 << 6)>; /* reg mask */
++        		gpio-num = <18>;
++			};
++			sfp06_gpio01_pres {
++        		reg-map = <0x02 (1 << 6)>; /* reg mask */
++        		gpio-num = <19>;
++			};
++			sfp06_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 6)>; /* reg mask */
++        		gpio-num = <20>;
++			};
++
++			/* sfp7 */
++			sfp07_gpio00_sfp_loss {
++        		reg-map = <0x08 (1 << 7)>; /* reg mask */
++        		gpio-num = <21>;
++			};
++			sfp07_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 7)>; /* reg mask */
++        		gpio-num = <22>;
++			};
++			sfp07_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 7)>; /* reg mask */
++        		gpio-num = <23>;
++			};
++
++			/* sfp8 */
++			sfp08_gpio00_loss {
++        		reg-map = <0x09 (1 << 0)>; /* reg mask */
++        		gpio-num = <24>;
++			};
++			sfp08_gpio01_pres {
++        		reg-map = <0x03 (1 << 0)>; /* reg mask */
++        		gpio-num = <25>;
++			};
++			sfp08_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 0)>; /* reg mask */
++        		gpio-num = <26>;
++			};
++
++			/* sfp9 */
++			sfp09_gpio00_loss {
++        		reg-map = <0x09 (1 << 1)>; /* reg mask */
++        		gpio-num = <27>;
++			};
++			sfp09_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 1)>; /* reg mask */
++        		gpio-num = <28>;
++			};
++			sfp09_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 1)>; /* reg mask */
++        		gpio-num = <29>;
++			};
++
++			/* sfp10 */
++			sfp10_gpio00_loss {
++        		reg-map = <0x09 (1 << 2)>; /* reg mask */
++        		gpio-num = <30>;
++			};
++			sfp10_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 2)>; /* reg mask */
++        		gpio-num = <31>;
++			};
++			sfp10_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 2)>; /* reg mask */
++        		gpio-num = <32>;
++			};
++
++			/* sfp11 */
++			sfp11_gpio00_loss {
++        		reg-map = <0x09 (1 << 3)>; /* reg mask */
++        		gpio-num = <33>;
++			};
++			sfp11_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 3)>; /* reg mask */
++        		gpio-num = <34>;
++			};
++			sfp11_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 3)>; /* reg mask */
++        		gpio-num = <35>;
++			};
++
++			/* sfp12 */
++			sfp12_gpio00_loss {
++        		reg-map = <0x09 (1 << 4)>; /* reg mask */
++        		gpio-num = <36>;
++			};
++			sfp12_gpio01_pres {
++        		reg-map = <0x03 (1 << 4)>; /* reg mask */
++        		gpio-num = <37>;
++			};
++			sfp12_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 4)>; /* reg mask */
++        		gpio-num = <38>;
++			};
++
++			/* sfp13 */
++			sfp13_gpio00_loss {
++        		reg-map = <0x09 (1 << 5)>; /* reg mask */
++        		gpio-num = <39>;
++			};
++			sfp13_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 5)>; /* reg mask */
++        		gpio-num = <40>;
++			};
++			sfp13_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 5)>; /* reg mask */
++        		gpio-num = <41>;
++			};
++
++			/* sfp14 */
++			sfp14_gpio00_loss {
++        		reg-map = <0x09 (1 << 6)>; /* reg mask */
++        		gpio-num = <42>;
++			};
++			sfp14_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 6)>; /* reg mask */
++        		gpio-num = <43>;
++			};
++			sfp14_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 6)>; /* reg mask */
++        		gpio-num = <44>;
++			};
++
++			/* sfp15 */
++			sfp15_gpio00_loss {
++        		reg-map = <0x09 (1 << 7)>; /* reg mask */
++        		gpio-num = <45>;
++			};
++			sfp15_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 7)>; /* reg mask */
++        		gpio-num = <46>;
++			};
++			sfp15_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 7)>; /* reg mask */
++        		gpio-num = <47>;
++			};
++
++			/* sfp16 */
++			sfp16_gpio00_loss {
++        		reg-map = <0x0a (1 << 0)>; /* reg mask */
++        		gpio-num = <48>;
++			};
++			sfp16_gpio01_pres {
++        		reg-map = <0x04 (1 << 0)>; /* reg mask */
++        		gpio-num = <49>;
++			};
++			sfp16_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 0)>; /* reg mask */
++        		gpio-num = <50>;
++			};
++
++			/* sfp17 */
++			sfp17_gpio00_loss {
++        		reg-map = <0x0a (1 << 1)>; /* reg mask */
++        		gpio-num = <51>;
++			};
++			sfp17_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 1)>; /* reg mask */
++        		gpio-num = <52>;
++			};
++			sfp17_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 1)>; /* reg mask */
++        		gpio-num = <53>;
++			};
++
++			/* sfp18 */
++			sfp18_gpio00_loss {
++        		reg-map = <0x0a (1 << 2)>; /* reg mask */
++        		gpio-num = <54>;
++			};
++			sfp18_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 2)>; /* reg mask */
++        		gpio-num = <55>;
++			};
++			sfp18_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 2)>; /* reg mask */
++        		gpio-num = <56>;
++			};
++
++			/* sfp19 */
++			sfp19_gpio00_loss {
++        		reg-map = <0x0a (1 << 3)>; /* reg mask */
++        		gpio-num = <57>;
++			};
++			sfp19_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 3)>; /* reg mask */
++        		gpio-num = <58>;
++			};
++			sfp19_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 3)>; /* reg mask */
++        		gpio-num = <59>;
++			};
++
++			/* sfp20 */
++			sfp20_gpio00_loss {
++        		reg-map = <0x0a (1 << 4)>; /* reg mask */
++        		gpio-num = <60>;
++			};
++			sfp20_gpio01_pres {
++        		reg-map = <0x04 (1 << 4)>; /* reg mask */
++        		gpio-num = <61>;
++			};
++			sfp20_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 4)>; /* reg mask */
++        		gpio-num = <62>;
++			};
++
++			/* sfp21 */
++			sfp21_gpio00_loss {
++        		reg-map = <0x0a (1 << 5)>; /* reg mask */
++        		gpio-num = <63>;
++			};
++			sfp21_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 5)>; /* reg mask */
++        		gpio-num = <64>;
++			};
++			sfp21_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 5)>; /* reg mask */
++        		gpio-num = <65>;
++			};
++
++			/* sfp22 */
++			sfp22_gpio00_loss {
++        		reg-map = <0x0a (1 << 6)>; /* reg mask */
++        		gpio-num = <66>;
++			};
++			sfp22_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 6)>; /* reg mask */
++        		gpio-num = <67>;
++			};
++			sfp22_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 6)>; /* reg mask */
++        		gpio-num = <68>;
++			};
++
++			/* sfp23 */
++			sfp23_gpio00_loss {
++        		reg-map = <0x0a (1 << 7)>; /* reg mask */
++        		gpio-num = <69>;
++			};
++			sfp23_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 7)>; /* reg mask */
++        		gpio-num = <70>;
++			};
++			sfp23_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 7)>; /* reg mask */
++        		gpio-num = <71>;
++			};
++
++		/* sfp24 */
++			sfp24_gpio00_loss {
++        		reg-map = <0x0b (1 << 0)>; /* reg mask */
++        		gpio-num = <72>;
++			};
++			sfp24_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 0)>; /* reg mask */
++        		gpio-num = <73>;
++			};
++			sfp24_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 0)>; /* reg mask */
++        		gpio-num = <74>;
++			};
++
++			/* sfp25 */
++			sfp25_gpio00_loss {
++        		reg-map = <0x0b (1 << 1)>; /* reg mask */
++        		gpio-num = <75>;
++			};
++			sfp25_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 1)>; /* reg mask */
++        		gpio-num = <76>;
++			};
++			sfp25_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 1)>; /* reg mask */
++        		gpio-num = <77>;
++			};
++
++			/* sfp26 */
++			sfp26_gpio00_loss {
++        		reg-map = <0x0b (1 << 2)>; /* reg mask */
++        		gpio-num = <78>;
++			};
++			sfp26_gpio01_pres {
++        		reg-map = <0x05 (1 << 2)>; /* reg mask */
++        		gpio-num = <79>;
++			};
++			sfp26_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 2)>; /* reg mask */
++        		gpio-num = <80>;
++			};
++
++			/* sfp27 */
++			sfp27_gpio00_sfp_loss {
++        		reg-map = <0x0b (1 << 3)>; /* reg mask */
++        		gpio-num = <81>;
++			};
++			sfp27_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 3)>; /* reg mask */
++        		gpio-num = <82>;
++			};
++			sfp27_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 3)>; /* reg mask */
++        		gpio-num = <83>;
++			};
++
++			/* sfp28 */
++			sfp28_gpio00_loss {
++        		reg-map = <0x0b (1 << 4)>; /* reg mask */
++        		gpio-num = <84>;
++			};
++			sfp28_gpio01_pres {
++        		reg-map = <0x05 (1 << 4)>; /* reg mask */
++        		gpio-num = <85>;
++			};
++			sfp28_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 4)>; /* reg mask */
++        		gpio-num = <86>;
++			};
++
++			/* sfp29 */
++			sfp29_gpio00_loss {
++        		reg-map = <0x0b (1 << 5)>; /* reg mask */
++        		gpio-num = <87>;
++			};
++			sfp29_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 5)>; /* reg mask */
++        		gpio-num = <88>;
++			};
++			sfp29_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 5)>; /* reg mask */
++        		gpio-num = <89>;
++			};
++
++			/* sfp30 */
++			sfp30_gpio00_loss {
++        		reg-map = <0x0b (1 << 6)>; /* reg mask */
++        		gpio-num = <90>;
++			};
++			sfp30_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 6)>; /* reg mask */
++        		gpio-num = <91>;
++			};
++			sfp30_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 6)>; /* reg mask */
++        		gpio-num = <92>;
++			};
++
++			/* sfp31 */
++			sfp31_gpio00_loss {
++        		reg-map = <0x0b (1 << 7)>; /* reg mask */
++        		gpio-num = <93>;
++			};
++			sfp31_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 7)>; /* reg mask */
++        		gpio-num = <94>;
++			};
++			sfp31_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 7)>; /* reg mask */
++        		gpio-num = <95>;
++			};
++
++			/* sfp32 */
++			sfp32_gpio00_loss {
++        		reg-map = <0x0c (1 << 0)>; /* reg mask */
++        		gpio-num = <96>;
++			};
++			sfp32_gpio01_pres {
++        		reg-map = <0x06 (1 << 0)>; /* reg mask */
++        		gpio-num = <97>;
++			};
++			sfp32_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 0)>; /* reg mask */
++        		gpio-num = <98>;
++			};
++
++			/* sfp33 */
++			sfp33_gpio00_loss {
++        		reg-map = <0x0c (1 << 1)>; /* reg mask */
++        		gpio-num = <99>;
++			};
++			sfp33_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 1)>; /* reg mask */
++        		gpio-num = <100>;
++			};
++			sfp33_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 1)>; /* reg mask */
++        		gpio-num = <101>;
++			};
++
++			/* sfp34 */
++			sfp34_gpio00_loss {
++        		reg-map = <0x0c (1 << 2)>; /* reg mask */
++        		gpio-num = <102>;
++			};
++			sfp34_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 2)>; /* reg mask */
++        		gpio-num = <103>;
++			};
++			sfp34_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 2)>; /* reg mask */
++        		gpio-num = <104>;
++			};
++
++			/* sfp35 */
++			sfp35_gpio00_loss {
++        		reg-map = <0x0c (1 << 3)>; /* reg mask */
++        		gpio-num = <105>;
++			};
++			sfp35_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 3)>; /* reg mask */
++        		gpio-num = <106>;
++			};
++			sfp35_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 3)>; /* reg mask */
++        		gpio-num = <107>;
++			};
++
++			/* sfp36 */
++			sfp36_gpio00_loss {
++        		reg-map = <0x0c (1 << 4)>; /* reg mask */
++        		gpio-num = <108>;
++			};
++			sfp36_gpio01_pres {
++        		reg-map = <0x06 (1 << 4)>; /* reg mask */
++        		gpio-num = <109>;
++			};
++			sfp36_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 4)>; /* reg mask */
++        		gpio-num = <110>;
++			};
++
++			/* sfp37 */
++			sfp37_gpio00_loss {
++        		reg-map = <0x0c (1 << 5)>; /* reg mask */
++        		gpio-num = <111>;
++			};
++			sfp37_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 5)>; /* reg mask */
++        		gpio-num = <112>;
++			};
++			sfp37_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 5)>; /* reg mask */
++        		gpio-num = <113>;
++			};
++
++			/* sfp38 */
++			sfp38_gpio00_loss {
++        		reg-map = <0x0c (1 << 6)>; /* reg mask */
++        		gpio-num = <114>;
++			};
++			sfp38_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 6)>; /* reg mask */
++        		gpio-num = <115>;
++			};
++			sfp38_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 6)>; /* reg mask */
++        		gpio-num = <116>;
++			};
++
++			/* sfp39 */
++			sfp39_gpio00_loss {
++        		reg-map = <0x0c (1 << 7)>; /* reg mask */
++        		gpio-num = <117>;
++			};
++			sfp39_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 7)>; /* reg mask */
++        		gpio-num = <118>;
++			};
++			sfp39_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 7)>; /* reg mask */
++        		gpio-num = <119>;
++			};
++
++			/* sfp40 */
++			sfp40_gpio00_loss {
++        		reg-map = <0x0d (1 << 0)>; /* reg mask */
++        		gpio-num = <120>;
++			};
++			sfp40_gpio01_pres {
++        		reg-map = <0x07 (1 << 0)>; /* reg mask */
++        		gpio-num = <121>;
++			};
++			sfp40_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 0)>; /* reg mask */
++        		gpio-num = <122>;
++			};
++
++			/* sfp41 */
++			sfp41_gpio00_loss {
++        		reg-map = <0x0d (1 << 1)>; /* reg mask */
++        		gpio-num = <123>;
++			};
++			sfp41_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 1)>; /* reg mask */
++        		gpio-num = <124>;
++			};
++			sfp41_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 1)>; /* reg mask */
++        		gpio-num = <125>;
++			};
++
++			/* sfp42 */
++			sfp42_gpio00_loss {
++        		reg-map = <0x0d (1 << 2)>; /* reg mask */
++        		gpio-num = <126>;
++			};
++			sfp42_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 2)>; /* reg mask */
++        		gpio-num = <127>;
++			};
++			sfp42_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 2)>; /* reg mask */
++        		gpio-num = <128>;
++			};
++
++			/* sfp43 */
++			sfp43_gpio00_loss {
++        		reg-map = <0x0d (1 << 3)>; /* reg mask */
++        		gpio-num = <129>;
++			};
++			sfp43_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 3)>; /* reg mask */
++        		gpio-num = <130>;
++			};
++			sfp43_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 3)>; /* reg mask */
++        		gpio-num = <131>;
++			};
++
++			/* sfp44 */
++			sfp44_gpio00_loss {
++        		reg-map = <0x0d (1 << 4)>; /* reg mask */
++        		gpio-num = <132>;
++			};
++			sfp44_gpio01_pres {
++        		reg-map = <0x07 (1 << 4)>; /* reg mask */
++        		gpio-num = <133>;
++			};
++			sfp44_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 4)>; /* reg mask */
++        		gpio-num = <134>;
++			};
++
++			/* sfp45 */
++			sfp45_gpio00_loss {
++        		reg-map = <0x0d (1 << 5)>; /* reg mask */
++        		gpio-num = <135>;
++			};
++			sfp45_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 5)>; /* reg mask */
++        		gpio-num = <136>;
++			};
++			sfp45_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 5)>; /* reg mask */
++        		gpio-num = <137>;
++			};
++
++			/* sfp46 */
++			sfp46_gpio00_loss {
++        		reg-map = <0x0d (1 << 6)>; /* reg mask */
++        		gpio-num = <138>;
++			};
++			sfp46_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 6)>; /* reg mask */
++        		gpio-num = <139>;
++			};
++			sfp46_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 6)>; /* reg mask */
++        		gpio-num = <140>;
++			};
++
++			/* sfp47 */
++			sfp47_gpio00_loss {
++        		reg-map = <0x0d (1 << 7)>; /* reg mask */
++        		gpio-num = <141>;
++			};
++			sfp47_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 7)>; /* reg mask */
++        		gpio-num = <142>;
++			};
++			sfp47_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 7)>; /* reg mask */
++        		gpio-num = <143>;
++			};
++    	};
++	};
++};
++
++&cp0_i2c0 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++    	compatible = "nxp,pca9548";
++    	reg = <0x70>;
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	i2c-mux-idle-disconnect;
++
++    	cp0_i2c3: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			status = "okay";
++			clock-frequency = <100000>;
++
++			eeprom_at24: at24@54 {
++        		compatible = "atmel,24c02";
++        		reg = <0x54>;
++			};
++    	};
++    	cp0_i2c4: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c5: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c6: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c7: i2c@4 {
++			reg = <4>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c8: i2c@5 {
++			reg = <5>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c9: i2c@6 {
++			reg = <6>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c10: i2c@7 {
++			reg = <7>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++	};
++};
++
++&cp0_i2c1 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++			compatible = "nxp,pca9548";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			i2c-mux-idle-disconnect;
++
++			cp0_i2c11: i2c@0 {
++        		reg = <0>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++        		i2cmux@71 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x71>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c1_sfp0: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp1: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp2: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp3: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp4: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp5: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp6: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp7: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c12: i2c@1 {
++        		reg = <1>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@72 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x72>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c2_sfp8: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp9: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp10: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp11: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp12: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp13: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp14: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp15: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c13: i2c@2 {
++        		reg = <2>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@73 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x73>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c3_sfp16: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp17: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp18: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp19: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp20: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp21: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp22: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp23: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c14: i2c@3 {
++        		reg = <3>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@74 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x74>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c4_sfp24: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp25: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp26: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp27: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp28: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp29: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp30: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp31: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c15: i2c@4 {
++        		reg = <4>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@75 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x75>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c5_sfp32: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp33: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp34: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp35: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp36: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp37: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp38: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp39: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c16: i2c@5 {
++        		reg = <5>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@76 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x76>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c6_sfp40: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp41: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp42: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp43: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp44: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp45: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp46: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp47: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c17: i2c@6 {
++        		reg = <6>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++        	};
++        	cp0_i2c18: i2c@7 {
++        		reg = <7>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++        	};
++    };
 +};
 +
 +&i2c0 {
 +	status = "okay";
 +	clock-frequency = <100000>;
 +};
-+
 +
 +&spi0 {
 +	status = "okay";
@@ -113,8 +1820,9 @@
 +};
 +
 +&cp0_pcie0 {
-+	ranges = <0x81000000 0x0 0xf9020000 0x0 0xf9020000 0x0 0x10000
-+		  0x82000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x30000000>;
++	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
++		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x2000000
++		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
 +	status = "okay";
 +	phys = <&cp0_comphy0 0>;
 +};
@@ -126,16 +1834,6 @@
 +
 +&cp0_pcie2 {
 +	status = "disabled";
-+};
-+
-+&cp0_i2c0 {
-+	status = "okay";
-+	clock-frequency = <100000>;
-+};
-+
-+&cp0_i2c1 {
-+	status = "okay";
-+	clock-frequency = <100000>;
 +};
 +
 +&cp0_sata0 {
@@ -176,7 +1874,7 @@
 +};
 +
 +&cp0_eth0 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy-mode = "sgmii";*/
 +	phy-mode = "2500base-x";
@@ -190,7 +1888,7 @@
 +};
 +
 +&cp0_eth1 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy = <&phy0>;*/
 +	phy-mode = "sgmii";
@@ -213,3 +1911,6 @@
 +&cp0_crypto {
 +	status = "okay";
 +};
+-- 
+2.17.1
+

--- a/packages/base/any/kernels/5.10-lts/patches/0011-wnc-qsa72-aom-a-48p.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0011-wnc-qsa72-aom-a-48p.patch
@@ -1,6 +1,23 @@
+From 49f1f89df5afe392eb2f475b09811bb9093a295d Mon Sep 17 00:00:00 2001
+From: Clement Chu <Clement.Chu@wnc.com.tw>
+Date: Mon, 3 May 2021 11:22:19 +0800
+Subject: [PATCH] Add QSA72_AOM_A_48P device tree
+
+1. Add prestera driver related description for support ethtool.
+Include driver, onie_eeprom and pcie mapping information.
+2. Add gpio-i2c driver and SFP cage interface description.
+3. Disable eth0 and eth1 interface to avoid the security issues.
+---
+ .../boot/dts/marvell/wnc-qsa72-aom-a-48p.dts  | 435 ++++++++++++++++++
+ 1 file changed, 435 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
+
+diff --git a/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts b/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
+new file mode 100644
+index 0000000..b7dfa9d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,435 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (C) 2016 Marvell Technology Group Ltd.
@@ -24,12 +41,12 @@
 +	aliases {
 +                serial0 = &uart0;
 +                serial1 = &cp0_uart1;
-+		ethernet0 = &cp0_eth0;
-+		ethernet1 = &cp0_eth1;
-+		ethernet2 = &cp0_eth2;
-+		i2c0 = &cp0_i2c0;
-+		i2c1 = &cp0_i2c1;
-+		i2c2 = &i2c0;
++                ethernet0 = &cp0_eth0;
++                ethernet1 = &cp0_eth1;
++                ethernet2 = &cp0_eth2;
++                i2c0 = &i2c0;
++                i2c1 = &cp0_i2c1;
++                i2c2 = &cp0_i2c0;
 +	};
 +
 +	cp0_utmi: utmi@580000 {
@@ -46,6 +63,238 @@
 +			status = "disabled";
 +		};
 +    };
++
++    switch-cpu {
++		compatible = "marvell,prestera-switch-rxtx-sdma";
++		status = "okay";
++	};
++
++	onie_eeprom: onie-eeprom {
++		compatible = "onie-nvmem-cells";
++		status = "okay";
++
++		nvmem = <&eeprom_at24>;
++	};
++
++	prestera {
++		compatible = "marvell,prestera";
++		status = "okay";
++
++		base-mac-provider = <&onie_eeprom>;
++		ports {
++			port49 {
++        		prestera,port-num = <49>;
++        		sfp = <&sfp49>;
++			};
++			port50 {
++        		prestera,port-num = <50>;
++        		sfp = <&sfp50>;
++			};
++			port51 {
++        		prestera,port-num = <51>;
++        		sfp = <&sfp51>;
++			};
++			port52 {
++        		prestera,port-num = <52>;
++        		sfp = <&sfp52>;
++			};
++		};
++	};
++
++	sfp49: sfp-49 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp0>;
++
++    	los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
++	};
++	sfp50: sfp-50 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp1>;
++
++    	los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
++	};
++	sfp51: sfp-51 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp2>;
++
++    	los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
++	};
++	sfp52: sfp-52 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp3>;
++
++    	los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
++	};
++
++	gpio_i2c: gpio-i2c {
++    	compatible = "qsa72_48p_gpio_i2c";
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	gpio-controller;
++    	#gpio-cells = <2>;
++
++		gpio-map {
++			/* sfp0 */
++			sfp00_gpio00_loss {
++        		reg-map = <0x0 (1 << 2)>;
++        		gpio-num = <0>;
++			};
++			sfp00_gpio01_pres {
++        		reg-map = <0x0 (1 << 1)>; /* reg mask */
++        		gpio-num = <1>;
++			};
++			sfp00_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 0)>; /* reg mask */
++        		gpio-num = <2>;
++			};
++
++			/* sfp1 */
++			sfp01_gpio00_sfp_loss {
++        		reg-map = <0x0 (1 << 5)>; /* reg mask */
++        		gpio-num = <3>;
++			};
++			sfp01_gpio01_sfp_pres {
++        		reg-map = <0x0 (1 << 4)>; /* reg mask */
++        		gpio-num = <4>;
++			};
++			sfp01_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 3)>; /* reg mask */
++        		gpio-num = <5>;
++			};
++
++			/* sfp2 */
++			sfp02_gpio00_loss {
++        		reg-map = <0x1 (1 << 0)>; /* reg mask */
++        		gpio-num = <6>;
++			};
++			sfp02_gpio01_pres {
++        		reg-map = <0x0 (1 << 7)>; /* reg mask */
++        		gpio-num = <7>;
++			};
++			sfp02_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 6)>; /* reg mask */
++        		gpio-num = <8>;
++			};
++
++			/* sfp3 */
++			sfp03_gpio00_loss {
++        		reg-map = <0x1 (1 << 3)>; /* reg mask */
++        		gpio-num = <9>;
++			};
++			sfp03_gpio01_sfp_pres {
++        		reg-map = <0x1 (1 << 2)>; /* reg mask */
++        		gpio-num = <10>;
++			};
++			sfp03_gpio02_tx_dis {
++        		reg-map = <0x3 (1 << 1)>; /* reg mask */
++        		gpio-num = <11>;
++			};
++		};
++	};
++};
++
++&cp0_i2c0 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++    	compatible = "nxp,pca9548";
++    	reg = <0x70>;
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	i2c-mux-idle-disconnect;
++
++    	cp0_i2c3: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			status = "okay";
++			clock-frequency = <100000>;
++
++			eeprom_at24: at24@54 {
++        		compatible = "atmel,24c02";
++        		reg = <0x54>;
++			};
++    	};
++    	cp0_i2c4: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c5: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c6: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c7: i2c@4 {
++			reg = <4>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c8: i2c@5 {
++			reg = <5>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c9: i2c@6 {
++			reg = <6>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c10: i2c@7 {
++			reg = <7>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++	};
++};
++
++&cp0_i2c1 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++		compatible = "nxp,pca9548";
++		reg = <0x70>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		i2c-mux-idle-disconnect;
++
++		i2c1_sfp0: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp1: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp2: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp3: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++	};
 +};
 +
 +&i2c0 {
@@ -78,8 +327,8 @@
 +&cp0_spi0 {
 +           pinctrl-names = "default";
 +           reg = <0x700600 0x50>;          /* control */
-+	   status = "okay";
-+	   spi-flash@0 {
++           status = "okay";
++           spi-flash@0 {
 +                     #address-cells = <0x1>;
 +                     #size-cells = <0x1>;
 +                     compatible = "jedec,spi-nor";
@@ -113,10 +362,11 @@
 +};
 +
 +&cp0_pcie0 {
-+	ranges = <0x81000000 0x0 0xf9020000 0x0 0xf9020000 0x0 0x10000
-+		  0x82000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x30000000>;
-+	status = "okay";
++	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
++		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x2000000
++		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
 +	phys = <&cp0_comphy0 0>;
++	status = "okay";
 +};
 +
 +&cp0_pcie1 {
@@ -126,16 +376,6 @@
 +
 +&cp0_pcie2 {
 +	status = "disabled";
-+};
-+
-+&cp0_i2c0 {
-+	status = "okay";
-+	clock-frequency = <100000>;
-+};
-+
-+&cp0_i2c1 {
-+	status = "okay";
-+	clock-frequency = <100000>;
 +};
 +
 +&cp0_sata0 {
@@ -176,7 +416,7 @@
 +};
 +
 +&cp0_eth0 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy-mode = "sgmii";*/
 +	phy-mode = "2500base-x";
@@ -190,7 +430,7 @@
 +};
 +
 +&cp0_eth1 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy = <&phy0>;*/
 +	phy-mode = "sgmii";
@@ -213,3 +453,6 @@
 +&cp0_crypto {
 +	status = "okay";
 +};
+-- 
+2.17.1
+

--- a/packages/base/any/kernels/5.6-lts/patches/0010-wnc-qsd61-aom-a-48.patch
+++ b/packages/base/any/kernels/5.6-lts/patches/0010-wnc-qsd61-aom-a-48.patch
@@ -1,6 +1,23 @@
+From d48213123a4743a6727d76785a7300874c348e62 Mon Sep 17 00:00:00 2001
+From: Clement Chu <Clement.Chu@wnc.com.tw>
+Date: Mon, 3 May 2021 11:24:26 +0800
+Subject: [PATCH] Add QSD61_AOM_A_48 device tree
+
+1. Add prestera driver related description for support ethtool.
+Include driver, onie_eeprom and pcie mapping information.
+2. Add gpio-i2c driver and SFP cage interface (port 1~48) description.
+3. Disable eth0 and eth1 interface to avoid the security issues.
+---
+ .../boot/dts/marvell/wnc-qsd61-aom-a-48.dts   | 1893 +++++++++++++++++
+ 1 file changed, 1893 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
+
+diff --git a/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts b/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
+new file mode 100644
+index 0000000..bd256f2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/marvell/wnc-qsd61-aom-a-48.dts
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,1893 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (C) 2016 Marvell Technology Group Ltd.
@@ -27,9 +44,9 @@
 +		ethernet0 = &cp0_eth0;
 +		ethernet1 = &cp0_eth1;
 +		ethernet2 = &cp0_eth2;
-+		i2c0 = &cp0_i2c0;
++		i2c0 = &i2c0;
 +		i2c1 = &cp0_i2c1;
-+		i2c2 = &i2c0;
++		i2c2 = &cp0_i2c0;
 +	};
 +
 +	cp0_utmi: utmi@580000 {
@@ -46,13 +63,1703 @@
 +			status = "disabled";
 +		};
 +    };
++
++	switch-cpu {
++		compatible = "marvell,prestera-switch-rxtx-sdma";
++		status = "okay";
++	};
++
++	onie_eeprom: onie-eeprom {
++		compatible = "onie-nvmem-cells";
++		status = "okay";
++
++		nvmem = <&eeprom_at24>;
++	};
++
++	prestera {
++		compatible = "marvell,prestera";
++		status = "okay";
++
++		base-mac-provider = <&onie_eeprom>;
++		ports {
++			port1 {
++        		prestera,port-num = <1>;
++        		sfp = <&sfp1>;
++			};
++			port2 {
++        		prestera,port-num = <2>;
++        		sfp = <&sfp2>;
++			};
++			port3 {
++        		prestera,port-num = <3>;
++        		sfp = <&sfp3>;
++			};
++			port4 {
++        		prestera,port-num = <4>;
++        		sfp = <&sfp4>;
++			};
++			port5 {
++        		prestera,port-num = <5>;
++        		sfp = <&sfp5>;
++			};
++			port6 {
++        		prestera,port-num = <6>;
++        		sfp = <&sfp6>;
++			};
++			port7 {
++        		prestera,port-num = <7>;
++        		sfp = <&sfp7>;
++			};
++			port8 {
++        		prestera,port-num = <8>;
++        		sfp = <&sfp8>;
++			};
++			port9 {
++        		prestera,port-num = <9>;
++        		sfp = <&sfp9>;
++			};
++			port10 {
++        		prestera,port-num = <10>;
++        		sfp = <&sfp10>;
++			};
++			port11 {
++        		prestera,port-num = <11>;
++        		sfp = <&sfp11>;
++			};
++			port12 {
++        		prestera,port-num = <12>;
++        		sfp = <&sfp12>;
++			};
++			port13 {
++        		prestera,port-num = <13>;
++        		sfp = <&sfp13>;
++			};
++			port14 {
++        		prestera,port-num = <14>;
++        		sfp = <&sfp14>;
++			};
++			port15 {
++        		prestera,port-num = <15>;
++        		sfp = <&sfp15>;
++			};
++			port16 {
++        		prestera,port-num = <16>;
++        		sfp = <&sfp16>;
++			};
++			port17 {
++        		prestera,port-num = <17>;
++        		sfp = <&sfp17>;
++			};
++			port18 {
++        		prestera,port-num = <18>;
++        		sfp = <&sfp18>;
++			};
++			port19 {
++        		prestera,port-num = <19>;
++        		sfp = <&sfp19>;
++			};
++			port20 {
++        		prestera,port-num = <20>;
++        		sfp = <&sfp20>;
++			};
++			port21 {
++        		prestera,port-num = <21>;
++        		sfp = <&sfp21>;
++			};
++			port22 {
++        		prestera,port-num = <22>;
++        		sfp = <&sfp22>;
++			};
++			port23 {
++        		prestera,port-num = <23>;
++        		sfp = <&sfp23>;
++			};
++			port24 {
++        		prestera,port-num = <24>;
++        		sfp = <&sfp24>;
++			};
++			port25 {
++        		prestera,port-num = <25>;
++        		sfp = <&sfp25>;
++			};
++			port26 {
++        		prestera,port-num = <26>;
++        		sfp = <&sfp26>;
++			};
++			port27 {
++        		prestera,port-num = <27>;
++        		sfp = <&sfp27>;
++			};
++			port28 {
++        		prestera,port-num = <28>;
++        		sfp = <&sfp28>;
++			};
++			port29 {
++        		prestera,port-num = <29>;
++        		sfp = <&sfp29>;
++			};
++			port30 {
++        		prestera,port-num = <30>;
++        		sfp = <&sfp30>;
++			};
++			port31 {
++        		prestera,port-num = <31>;
++        		sfp = <&sfp31>;
++			};
++			port32 {
++        		prestera,port-num = <32>;
++        		sfp = <&sfp32>;
++			};
++			port33 {
++        		prestera,port-num = <33>;
++        		sfp = <&sfp33>;
++			};
++			port34 {
++        		prestera,port-num = <34>;
++        		sfp = <&sfp34>;
++			};
++			port35 {
++        		prestera,port-num = <35>;
++        		sfp = <&sfp35>;
++			};
++			port36 {
++        		prestera,port-num = <36>;
++        		sfp = <&sfp36>;
++			};
++			port37 {
++        		prestera,port-num = <37>;
++        		sfp = <&sfp37>;
++			};
++			port38 {
++        		prestera,port-num = <38>;
++        		sfp = <&sfp38>;
++			};
++			port39 {
++        		prestera,port-num = <39>;
++        		sfp = <&sfp39>;
++			};
++			port40 {
++        		prestera,port-num = <40>;
++        		sfp = <&sfp40>;
++			};
++			port41 {
++        		prestera,port-num = <41>;
++        		sfp = <&sfp41>;
++			};
++			port42 {
++        		prestera,port-num = <42>;
++        		sfp = <&sfp42>;
++			};
++			port43 {
++        		prestera,port-num = <43>;
++        		sfp = <&sfp43>;
++			};
++			port44 {
++        		prestera,port-num = <44>;
++        		sfp = <&sfp44>;
++			};
++			port45 {
++        		prestera,port-num = <45>;
++        		sfp = <&sfp45>;
++			};
++			port46 {
++        		prestera,port-num = <46>;
++        		sfp = <&sfp46>;
++			};
++			port47 {
++        		prestera,port-num = <47>;
++        		sfp = <&sfp47>;
++			};
++			port48 {
++        		prestera,port-num = <48>;
++        		sfp = <&sfp48>;
++			};
++    	};
++	};
++
++	sfp1: sfp-1 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp0>;
++
++    	los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
++	};
++	sfp2: sfp-2 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp1>;
++
++    	los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
++	};
++	sfp3: sfp-3 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp2>;
++
++    	los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
++	};
++	sfp4: sfp-4 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp3>;
++
++    	los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
++	};
++	sfp5: sfp-5 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp4>;
++
++    	los-gpio = <&gpio_i2c 12 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 13 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 14 GPIO_ACTIVE_HIGH>;
++	};
++	sfp6: sfp-6 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp5>;
++
++    	los-gpio = <&gpio_i2c 15 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 16 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 17 GPIO_ACTIVE_HIGH>;
++	};
++	sfp7: sfp-7 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp6>;
++
++    	los-gpio = <&gpio_i2c 18 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 19 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 20 GPIO_ACTIVE_HIGH>;
++	};
++	sfp8: sfp-8 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp7>;
++
++    	los-gpio = <&gpio_i2c 21 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 22 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 23 GPIO_ACTIVE_HIGH>;
++	};
++	sfp9: sfp-9 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp8>;
++
++    	los-gpio = <&gpio_i2c 24 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 25 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 26 GPIO_ACTIVE_HIGH>;
++	};
++	sfp10: sfp-10 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp9>;
++
++    	los-gpio = <&gpio_i2c 27 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 28 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 29 GPIO_ACTIVE_HIGH>;
++	};
++	sfp11: sfp-11 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp10>;
++
++    	los-gpio = <&gpio_i2c 30 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 31 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 32 GPIO_ACTIVE_HIGH>;
++	};
++	sfp12: sfp-12 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp11>;
++
++    	los-gpio = <&gpio_i2c 33 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 34 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 35 GPIO_ACTIVE_HIGH>;
++	};
++	sfp13: sfp-13 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp12>;
++
++    	los-gpio = <&gpio_i2c 36 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 37 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 38 GPIO_ACTIVE_HIGH>;
++	};
++	sfp14: sfp-14 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp13>;
++
++    	los-gpio = <&gpio_i2c 39 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 40 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 41 GPIO_ACTIVE_HIGH>;
++	};
++	sfp15: sfp-15 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp14>;
++
++    	los-gpio = <&gpio_i2c 42 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 43 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 44 GPIO_ACTIVE_HIGH>;
++	};
++	sfp16: sfp-16 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c2_sfp15>;
++
++    	los-gpio = <&gpio_i2c 45 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 46 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 47 GPIO_ACTIVE_HIGH>;
++	};
++	sfp17: sfp-17 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp16>;
++
++    	los-gpio = <&gpio_i2c 48 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 49 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 50 GPIO_ACTIVE_HIGH>;
++	};
++	sfp18: sfp-18 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp17>;
++
++    	los-gpio = <&gpio_i2c 51 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 52 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 53 GPIO_ACTIVE_HIGH>;
++	};
++	sfp19: sfp-19 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp18>;
++
++    	los-gpio = <&gpio_i2c 54 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 55 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 56 GPIO_ACTIVE_HIGH>;
++	};
++	sfp20: sfp-20 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp19>;
++
++    	los-gpio = <&gpio_i2c 57 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 58 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 59 GPIO_ACTIVE_HIGH>;
++	};
++	sfp21: sfp-21 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp20>;
++
++    	los-gpio = <&gpio_i2c 60 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 61 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 62 GPIO_ACTIVE_HIGH>;
++	};
++	sfp22: sfp-22 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp21>;
++
++    	los-gpio = <&gpio_i2c 63 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 64 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 65 GPIO_ACTIVE_HIGH>;
++	};
++	sfp23: sfp-23 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp22>;
++
++    	los-gpio = <&gpio_i2c 66 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 67 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 68 GPIO_ACTIVE_HIGH>;
++	};
++	sfp24: sfp-24 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c3_sfp23>;
++
++    	los-gpio = <&gpio_i2c 69 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 70 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 71 GPIO_ACTIVE_HIGH>;
++	};
++	sfp25: sfp-25 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp24>;
++
++    	los-gpio = <&gpio_i2c 72 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 73 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 74 GPIO_ACTIVE_HIGH>;
++	};
++	sfp26: sfp-26 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp25>;
++
++    	los-gpio = <&gpio_i2c 75 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 76 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 77 GPIO_ACTIVE_HIGH>;
++	};
++	sfp27: sfp-27 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp26>;
++
++    	los-gpio = <&gpio_i2c 78 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 79 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 80 GPIO_ACTIVE_HIGH>;
++	};
++	sfp28: sfp-28 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp27>;
++
++    	los-gpio = <&gpio_i2c 81 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 82 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 83 GPIO_ACTIVE_HIGH>;
++	};
++	sfp29: sfp-29 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp28>;
++
++    	los-gpio = <&gpio_i2c 84 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 85 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 86 GPIO_ACTIVE_HIGH>;
++	};
++	sfp30: sfp-30 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp29>;
++
++    	los-gpio = <&gpio_i2c 87 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 88 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 89 GPIO_ACTIVE_HIGH>;
++	};
++	sfp31: sfp-31 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp30>;
++
++    	los-gpio = <&gpio_i2c 90 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 91 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 92 GPIO_ACTIVE_HIGH>;
++	};
++	sfp32: sfp-32 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c4_sfp31>;
++
++    	los-gpio = <&gpio_i2c 93 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 94 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 95 GPIO_ACTIVE_HIGH>;
++	};
++	sfp33: sfp-33 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp32>;
++
++    	los-gpio = <&gpio_i2c 96 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 97 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 98 GPIO_ACTIVE_HIGH>;
++	};
++	sfp34: sfp-34 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp33>;
++
++    	los-gpio = <&gpio_i2c 99 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 100 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 101 GPIO_ACTIVE_HIGH>;
++	};
++	sfp35: sfp-35 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp34>;
++
++    	los-gpio = <&gpio_i2c 102 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 103 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 104 GPIO_ACTIVE_HIGH>;
++	};
++	sfp36: sfp-36 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp35>;
++
++    	los-gpio = <&gpio_i2c 105 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 106 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 107 GPIO_ACTIVE_HIGH>;
++	};
++	sfp37: sfp-37 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp36>;
++
++    	los-gpio = <&gpio_i2c 108 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 109 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 110 GPIO_ACTIVE_HIGH>;
++	};
++	sfp38: sfp-38 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp37>;
++
++    	los-gpio = <&gpio_i2c 111 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 112 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 113 GPIO_ACTIVE_HIGH>;
++	};
++	sfp39: sfp-39 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp38>;
++
++    	los-gpio = <&gpio_i2c 114 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 115 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 116 GPIO_ACTIVE_HIGH>;
++	};
++	sfp40: sfp-40 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c5_sfp39>;
++
++    	los-gpio = <&gpio_i2c 117 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 118 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 119 GPIO_ACTIVE_HIGH>;
++	};
++	sfp41: sfp-41 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp40>;
++
++    	los-gpio = <&gpio_i2c 120 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 121 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 122 GPIO_ACTIVE_HIGH>;
++	};
++	sfp42: sfp-42 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp41>;
++
++    	los-gpio = <&gpio_i2c 123 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 124 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 125 GPIO_ACTIVE_HIGH>;
++	};
++	sfp43: sfp-43 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp42>;
++
++    	los-gpio = <&gpio_i2c 126 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 127 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 128 GPIO_ACTIVE_HIGH>;
++	};
++	sfp44: sfp-44 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp43>;
++
++    	los-gpio = <&gpio_i2c 129 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 130 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 131 GPIO_ACTIVE_HIGH>;
++	};
++	sfp45: sfp-45 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp44>;
++
++    	los-gpio = <&gpio_i2c 132 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 133 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 134 GPIO_ACTIVE_HIGH>;
++	};
++	sfp46: sfp-46 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp45>;
++
++    	los-gpio = <&gpio_i2c 135 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 136 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 137 GPIO_ACTIVE_HIGH>;
++	};
++	sfp47: sfp-47 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp46>;
++
++    	los-gpio = <&gpio_i2c 138 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 139 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 140 GPIO_ACTIVE_HIGH>;
++	};
++	sfp48: sfp-48 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c6_sfp47>;
++
++    	los-gpio = <&gpio_i2c 141 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 142 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 143 GPIO_ACTIVE_HIGH>;
++	};
++
++	gpio_i2c: gpio-i2c {
++    	compatible = "qsd61_48_gpio_i2c";
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	gpio-controller;
++    	#gpio-cells = <2>;
++    	/* reg = <0x40>; */  /* CPLD/MUX I2C address */
++
++    	gpio-map {
++			/* sfp0 */
++			sfp00_gpio00_loss {
++        		reg-map = <0x08 (1 << 0)>; /* 0xA6=register in the CPLD, (1 << 0)=Selected bit */
++        		gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
++			};
++			sfp00_gpio01_pres {
++        		reg-map = <0x02 (1 << 0)>; /* reg mask */
++        		gpio-num = <1>;
++			};
++			sfp00_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 0)>; /* reg mask */
++        		gpio-num = <2>;
++			};
++
++			/* sfp1 */
++			sfp01_gpio00_sfp_loss {
++        		reg-map = <0x08 (1 << 1)>; /* reg mask */
++        		gpio-num = <3>;
++			};
++			sfp01_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 1)>; /* reg mask */
++        		gpio-num = <4>;
++			};
++			sfp01_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 1)>; /* reg mask */
++        		gpio-num = <5>;
++			};
++
++			/* sfp2 */
++			sfp02_gpio00_loss {
++        		reg-map = <0x08 (1 << 2)>; /* reg mask */
++        		gpio-num = <6>;
++			};
++			sfp02_gpio01_pres {
++        		reg-map = <0x02 (1 << 2)>; /* reg mask */
++        		gpio-num = <7>;
++			};
++			sfp02_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 2)>; /* reg mask */
++        		gpio-num = <8>;
++			};
++
++			/* sfp3 */
++			sfp03_gpio00_loss {
++        		reg-map = <0x08 (1 << 3)>; /* reg mask */
++        		gpio-num = <9>;
++			};
++			sfp03_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 3)>; /* reg mask */
++        		gpio-num = <10>;
++			};
++			sfp03_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 3)>; /* reg mask */
++        		gpio-num = <11>;
++			};
++
++			/* sfp4 */
++			sfp04_gpio00_loss {
++        		reg-map = <0x08 (1 << 4)>; /* reg mask */
++        		gpio-num = <12>;
++			};
++			sfp04_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 4)>; /* reg mask */
++        		gpio-num = <13>;
++			};
++			sfp04_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 4)>; /* reg mask */
++        		gpio-num = <14>;
++			};
++
++			/* sfp5 */
++			sfp05_gpio00_loss {
++        		reg-map = <0x08 (1 << 5)>; /* reg mask */
++        		gpio-num = <15>;
++			};
++			sfp05_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 5)>; /* reg mask */
++        		gpio-num = <16>;
++			};
++			sfp05_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 5)>; /* reg mask */
++        		gpio-num = <17>;
++			};
++
++			/* sfp6 */
++			sfp06_gpio00_loss {
++        		reg-map = <0x08 (1 << 6)>; /* reg mask */
++        		gpio-num = <18>;
++			};
++			sfp06_gpio01_pres {
++        		reg-map = <0x02 (1 << 6)>; /* reg mask */
++        		gpio-num = <19>;
++			};
++			sfp06_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 6)>; /* reg mask */
++        		gpio-num = <20>;
++			};
++
++			/* sfp7 */
++			sfp07_gpio00_sfp_loss {
++        		reg-map = <0x08 (1 << 7)>; /* reg mask */
++        		gpio-num = <21>;
++			};
++			sfp07_gpio01_sfp_pres {
++        		reg-map = <0x02 (1 << 7)>; /* reg mask */
++        		gpio-num = <22>;
++			};
++			sfp07_gpio02_tx_dis {
++        		reg-map = <0x14 (1 << 7)>; /* reg mask */
++        		gpio-num = <23>;
++			};
++
++			/* sfp8 */
++			sfp08_gpio00_loss {
++        		reg-map = <0x09 (1 << 0)>; /* reg mask */
++        		gpio-num = <24>;
++			};
++			sfp08_gpio01_pres {
++        		reg-map = <0x03 (1 << 0)>; /* reg mask */
++        		gpio-num = <25>;
++			};
++			sfp08_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 0)>; /* reg mask */
++        		gpio-num = <26>;
++			};
++
++			/* sfp9 */
++			sfp09_gpio00_loss {
++        		reg-map = <0x09 (1 << 1)>; /* reg mask */
++        		gpio-num = <27>;
++			};
++			sfp09_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 1)>; /* reg mask */
++        		gpio-num = <28>;
++			};
++			sfp09_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 1)>; /* reg mask */
++        		gpio-num = <29>;
++			};
++
++			/* sfp10 */
++			sfp10_gpio00_loss {
++        		reg-map = <0x09 (1 << 2)>; /* reg mask */
++        		gpio-num = <30>;
++			};
++			sfp10_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 2)>; /* reg mask */
++        		gpio-num = <31>;
++			};
++			sfp10_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 2)>; /* reg mask */
++        		gpio-num = <32>;
++			};
++
++			/* sfp11 */
++			sfp11_gpio00_loss {
++        		reg-map = <0x09 (1 << 3)>; /* reg mask */
++        		gpio-num = <33>;
++			};
++			sfp11_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 3)>; /* reg mask */
++        		gpio-num = <34>;
++			};
++			sfp11_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 3)>; /* reg mask */
++        		gpio-num = <35>;
++			};
++
++			/* sfp12 */
++			sfp12_gpio00_loss {
++        		reg-map = <0x09 (1 << 4)>; /* reg mask */
++        		gpio-num = <36>;
++			};
++			sfp12_gpio01_pres {
++        		reg-map = <0x03 (1 << 4)>; /* reg mask */
++        		gpio-num = <37>;
++			};
++			sfp12_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 4)>; /* reg mask */
++        		gpio-num = <38>;
++			};
++
++			/* sfp13 */
++			sfp13_gpio00_loss {
++        		reg-map = <0x09 (1 << 5)>; /* reg mask */
++        		gpio-num = <39>;
++			};
++			sfp13_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 5)>; /* reg mask */
++        		gpio-num = <40>;
++			};
++			sfp13_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 5)>; /* reg mask */
++        		gpio-num = <41>;
++			};
++
++			/* sfp14 */
++			sfp14_gpio00_loss {
++        		reg-map = <0x09 (1 << 6)>; /* reg mask */
++        		gpio-num = <42>;
++			};
++			sfp14_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 6)>; /* reg mask */
++        		gpio-num = <43>;
++			};
++			sfp14_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 6)>; /* reg mask */
++        		gpio-num = <44>;
++			};
++
++			/* sfp15 */
++			sfp15_gpio00_loss {
++        		reg-map = <0x09 (1 << 7)>; /* reg mask */
++        		gpio-num = <45>;
++			};
++			sfp15_gpio01_sfp_pres {
++        		reg-map = <0x03 (1 << 7)>; /* reg mask */
++        		gpio-num = <46>;
++			};
++			sfp15_gpio02_tx_dis {
++        		reg-map = <0x15 (1 << 7)>; /* reg mask */
++        		gpio-num = <47>;
++			};
++
++			/* sfp16 */
++			sfp16_gpio00_loss {
++        		reg-map = <0x0a (1 << 0)>; /* reg mask */
++        		gpio-num = <48>;
++			};
++			sfp16_gpio01_pres {
++        		reg-map = <0x04 (1 << 0)>; /* reg mask */
++        		gpio-num = <49>;
++			};
++			sfp16_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 0)>; /* reg mask */
++        		gpio-num = <50>;
++			};
++
++			/* sfp17 */
++			sfp17_gpio00_loss {
++        		reg-map = <0x0a (1 << 1)>; /* reg mask */
++        		gpio-num = <51>;
++			};
++			sfp17_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 1)>; /* reg mask */
++        		gpio-num = <52>;
++			};
++			sfp17_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 1)>; /* reg mask */
++        		gpio-num = <53>;
++			};
++
++			/* sfp18 */
++			sfp18_gpio00_loss {
++        		reg-map = <0x0a (1 << 2)>; /* reg mask */
++        		gpio-num = <54>;
++			};
++			sfp18_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 2)>; /* reg mask */
++        		gpio-num = <55>;
++			};
++			sfp18_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 2)>; /* reg mask */
++        		gpio-num = <56>;
++			};
++
++			/* sfp19 */
++			sfp19_gpio00_loss {
++        		reg-map = <0x0a (1 << 3)>; /* reg mask */
++        		gpio-num = <57>;
++			};
++			sfp19_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 3)>; /* reg mask */
++        		gpio-num = <58>;
++			};
++			sfp19_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 3)>; /* reg mask */
++        		gpio-num = <59>;
++			};
++
++			/* sfp20 */
++			sfp20_gpio00_loss {
++        		reg-map = <0x0a (1 << 4)>; /* reg mask */
++        		gpio-num = <60>;
++			};
++			sfp20_gpio01_pres {
++        		reg-map = <0x04 (1 << 4)>; /* reg mask */
++        		gpio-num = <61>;
++			};
++			sfp20_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 4)>; /* reg mask */
++        		gpio-num = <62>;
++			};
++
++			/* sfp21 */
++			sfp21_gpio00_loss {
++        		reg-map = <0x0a (1 << 5)>; /* reg mask */
++        		gpio-num = <63>;
++			};
++			sfp21_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 5)>; /* reg mask */
++        		gpio-num = <64>;
++			};
++			sfp21_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 5)>; /* reg mask */
++        		gpio-num = <65>;
++			};
++
++			/* sfp22 */
++			sfp22_gpio00_loss {
++        		reg-map = <0x0a (1 << 6)>; /* reg mask */
++        		gpio-num = <66>;
++			};
++			sfp22_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 6)>; /* reg mask */
++        		gpio-num = <67>;
++			};
++			sfp22_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 6)>; /* reg mask */
++        		gpio-num = <68>;
++			};
++
++			/* sfp23 */
++			sfp23_gpio00_loss {
++        		reg-map = <0x0a (1 << 7)>; /* reg mask */
++        		gpio-num = <69>;
++			};
++			sfp23_gpio01_sfp_pres {
++        		reg-map = <0x04 (1 << 7)>; /* reg mask */
++        		gpio-num = <70>;
++			};
++			sfp23_gpio02_tx_dis {
++        		reg-map = <0x16 (1 << 7)>; /* reg mask */
++        		gpio-num = <71>;
++			};
++
++		/* sfp24 */
++			sfp24_gpio00_loss {
++        		reg-map = <0x0b (1 << 0)>; /* reg mask */
++        		gpio-num = <72>;
++			};
++			sfp24_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 0)>; /* reg mask */
++        		gpio-num = <73>;
++			};
++			sfp24_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 0)>; /* reg mask */
++        		gpio-num = <74>;
++			};
++
++			/* sfp25 */
++			sfp25_gpio00_loss {
++        		reg-map = <0x0b (1 << 1)>; /* reg mask */
++        		gpio-num = <75>;
++			};
++			sfp25_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 1)>; /* reg mask */
++        		gpio-num = <76>;
++			};
++			sfp25_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 1)>; /* reg mask */
++        		gpio-num = <77>;
++			};
++
++			/* sfp26 */
++			sfp26_gpio00_loss {
++        		reg-map = <0x0b (1 << 2)>; /* reg mask */
++        		gpio-num = <78>;
++			};
++			sfp26_gpio01_pres {
++        		reg-map = <0x05 (1 << 2)>; /* reg mask */
++        		gpio-num = <79>;
++			};
++			sfp26_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 2)>; /* reg mask */
++        		gpio-num = <80>;
++			};
++
++			/* sfp27 */
++			sfp27_gpio00_sfp_loss {
++        		reg-map = <0x0b (1 << 3)>; /* reg mask */
++        		gpio-num = <81>;
++			};
++			sfp27_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 3)>; /* reg mask */
++        		gpio-num = <82>;
++			};
++			sfp27_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 3)>; /* reg mask */
++        		gpio-num = <83>;
++			};
++
++			/* sfp28 */
++			sfp28_gpio00_loss {
++        		reg-map = <0x0b (1 << 4)>; /* reg mask */
++        		gpio-num = <84>;
++			};
++			sfp28_gpio01_pres {
++        		reg-map = <0x05 (1 << 4)>; /* reg mask */
++        		gpio-num = <85>;
++			};
++			sfp28_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 4)>; /* reg mask */
++        		gpio-num = <86>;
++			};
++
++			/* sfp29 */
++			sfp29_gpio00_loss {
++        		reg-map = <0x0b (1 << 5)>; /* reg mask */
++        		gpio-num = <87>;
++			};
++			sfp29_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 5)>; /* reg mask */
++        		gpio-num = <88>;
++			};
++			sfp29_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 5)>; /* reg mask */
++        		gpio-num = <89>;
++			};
++
++			/* sfp30 */
++			sfp30_gpio00_loss {
++        		reg-map = <0x0b (1 << 6)>; /* reg mask */
++        		gpio-num = <90>;
++			};
++			sfp30_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 6)>; /* reg mask */
++        		gpio-num = <91>;
++			};
++			sfp30_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 6)>; /* reg mask */
++        		gpio-num = <92>;
++			};
++
++			/* sfp31 */
++			sfp31_gpio00_loss {
++        		reg-map = <0x0b (1 << 7)>; /* reg mask */
++        		gpio-num = <93>;
++			};
++			sfp31_gpio01_sfp_pres {
++        		reg-map = <0x05 (1 << 7)>; /* reg mask */
++        		gpio-num = <94>;
++			};
++			sfp31_gpio02_tx_dis {
++        		reg-map = <0x17 (1 << 7)>; /* reg mask */
++        		gpio-num = <95>;
++			};
++
++			/* sfp32 */
++			sfp32_gpio00_loss {
++        		reg-map = <0x0c (1 << 0)>; /* reg mask */
++        		gpio-num = <96>;
++			};
++			sfp32_gpio01_pres {
++        		reg-map = <0x06 (1 << 0)>; /* reg mask */
++        		gpio-num = <97>;
++			};
++			sfp32_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 0)>; /* reg mask */
++        		gpio-num = <98>;
++			};
++
++			/* sfp33 */
++			sfp33_gpio00_loss {
++        		reg-map = <0x0c (1 << 1)>; /* reg mask */
++        		gpio-num = <99>;
++			};
++			sfp33_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 1)>; /* reg mask */
++        		gpio-num = <100>;
++			};
++			sfp33_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 1)>; /* reg mask */
++        		gpio-num = <101>;
++			};
++
++			/* sfp34 */
++			sfp34_gpio00_loss {
++        		reg-map = <0x0c (1 << 2)>; /* reg mask */
++        		gpio-num = <102>;
++			};
++			sfp34_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 2)>; /* reg mask */
++        		gpio-num = <103>;
++			};
++			sfp34_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 2)>; /* reg mask */
++        		gpio-num = <104>;
++			};
++
++			/* sfp35 */
++			sfp35_gpio00_loss {
++        		reg-map = <0x0c (1 << 3)>; /* reg mask */
++        		gpio-num = <105>;
++			};
++			sfp35_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 3)>; /* reg mask */
++        		gpio-num = <106>;
++			};
++			sfp35_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 3)>; /* reg mask */
++        		gpio-num = <107>;
++			};
++
++			/* sfp36 */
++			sfp36_gpio00_loss {
++        		reg-map = <0x0c (1 << 4)>; /* reg mask */
++        		gpio-num = <108>;
++			};
++			sfp36_gpio01_pres {
++        		reg-map = <0x06 (1 << 4)>; /* reg mask */
++        		gpio-num = <109>;
++			};
++			sfp36_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 4)>; /* reg mask */
++        		gpio-num = <110>;
++			};
++
++			/* sfp37 */
++			sfp37_gpio00_loss {
++        		reg-map = <0x0c (1 << 5)>; /* reg mask */
++        		gpio-num = <111>;
++			};
++			sfp37_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 5)>; /* reg mask */
++        		gpio-num = <112>;
++			};
++			sfp37_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 5)>; /* reg mask */
++        		gpio-num = <113>;
++			};
++
++			/* sfp38 */
++			sfp38_gpio00_loss {
++        		reg-map = <0x0c (1 << 6)>; /* reg mask */
++        		gpio-num = <114>;
++			};
++			sfp38_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 6)>; /* reg mask */
++        		gpio-num = <115>;
++			};
++			sfp38_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 6)>; /* reg mask */
++        		gpio-num = <116>;
++			};
++
++			/* sfp39 */
++			sfp39_gpio00_loss {
++        		reg-map = <0x0c (1 << 7)>; /* reg mask */
++        		gpio-num = <117>;
++			};
++			sfp39_gpio01_sfp_pres {
++        		reg-map = <0x06 (1 << 7)>; /* reg mask */
++        		gpio-num = <118>;
++			};
++			sfp39_gpio02_tx_dis {
++        		reg-map = <0x18 (1 << 7)>; /* reg mask */
++        		gpio-num = <119>;
++			};
++
++			/* sfp40 */
++			sfp40_gpio00_loss {
++        		reg-map = <0x0d (1 << 0)>; /* reg mask */
++        		gpio-num = <120>;
++			};
++			sfp40_gpio01_pres {
++        		reg-map = <0x07 (1 << 0)>; /* reg mask */
++        		gpio-num = <121>;
++			};
++			sfp40_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 0)>; /* reg mask */
++        		gpio-num = <122>;
++			};
++
++			/* sfp41 */
++			sfp41_gpio00_loss {
++        		reg-map = <0x0d (1 << 1)>; /* reg mask */
++        		gpio-num = <123>;
++			};
++			sfp41_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 1)>; /* reg mask */
++        		gpio-num = <124>;
++			};
++			sfp41_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 1)>; /* reg mask */
++        		gpio-num = <125>;
++			};
++
++			/* sfp42 */
++			sfp42_gpio00_loss {
++        		reg-map = <0x0d (1 << 2)>; /* reg mask */
++        		gpio-num = <126>;
++			};
++			sfp42_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 2)>; /* reg mask */
++        		gpio-num = <127>;
++			};
++			sfp42_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 2)>; /* reg mask */
++        		gpio-num = <128>;
++			};
++
++			/* sfp43 */
++			sfp43_gpio00_loss {
++        		reg-map = <0x0d (1 << 3)>; /* reg mask */
++        		gpio-num = <129>;
++			};
++			sfp43_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 3)>; /* reg mask */
++        		gpio-num = <130>;
++			};
++			sfp43_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 3)>; /* reg mask */
++        		gpio-num = <131>;
++			};
++
++			/* sfp44 */
++			sfp44_gpio00_loss {
++        		reg-map = <0x0d (1 << 4)>; /* reg mask */
++        		gpio-num = <132>;
++			};
++			sfp44_gpio01_pres {
++        		reg-map = <0x07 (1 << 4)>; /* reg mask */
++        		gpio-num = <133>;
++			};
++			sfp44_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 4)>; /* reg mask */
++        		gpio-num = <134>;
++			};
++
++			/* sfp45 */
++			sfp45_gpio00_loss {
++        		reg-map = <0x0d (1 << 5)>; /* reg mask */
++        		gpio-num = <135>;
++			};
++			sfp45_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 5)>; /* reg mask */
++        		gpio-num = <136>;
++			};
++			sfp45_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 5)>; /* reg mask */
++        		gpio-num = <137>;
++			};
++
++			/* sfp46 */
++			sfp46_gpio00_loss {
++        		reg-map = <0x0d (1 << 6)>; /* reg mask */
++        		gpio-num = <138>;
++			};
++			sfp46_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 6)>; /* reg mask */
++        		gpio-num = <139>;
++			};
++			sfp46_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 6)>; /* reg mask */
++        		gpio-num = <140>;
++			};
++
++			/* sfp47 */
++			sfp47_gpio00_loss {
++        		reg-map = <0x0d (1 << 7)>; /* reg mask */
++        		gpio-num = <141>;
++			};
++			sfp47_gpio01_sfp_pres {
++        		reg-map = <0x07 (1 << 7)>; /* reg mask */
++        		gpio-num = <142>;
++			};
++			sfp47_gpio02_tx_dis {
++        		reg-map = <0x19 (1 << 7)>; /* reg mask */
++        		gpio-num = <143>;
++			};
++    	};
++	};
++};
++
++&cp0_i2c0 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++    	compatible = "nxp,pca9548";
++    	reg = <0x70>;
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	i2c-mux-idle-disconnect;
++
++    	cp0_i2c3: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			status = "okay";
++			clock-frequency = <100000>;
++
++			eeprom_at24: at24@54 {
++        		compatible = "atmel,24c02";
++        		reg = <0x54>;
++			};
++    	};
++    	cp0_i2c4: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c5: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c6: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c7: i2c@4 {
++			reg = <4>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c8: i2c@5 {
++			reg = <5>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c9: i2c@6 {
++			reg = <6>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c10: i2c@7 {
++			reg = <7>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++	};
++};
++
++&cp0_i2c1 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++			compatible = "nxp,pca9548";
++			reg = <0x70>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			i2c-mux-idle-disconnect;
++
++			cp0_i2c11: i2c@0 {
++        		reg = <0>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++        		i2cmux@71 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x71>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c1_sfp0: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp1: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp2: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp3: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp4: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp5: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp6: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c1_sfp7: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c12: i2c@1 {
++        		reg = <1>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@72 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x72>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c2_sfp8: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp9: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp10: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp11: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp12: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp13: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp14: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c2_sfp15: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c13: i2c@2 {
++        		reg = <2>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@73 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x73>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c3_sfp16: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp17: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp18: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp19: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp20: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp21: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp22: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c3_sfp23: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c14: i2c@3 {
++        		reg = <3>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@74 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x74>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c4_sfp24: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp25: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp26: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp27: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp28: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp29: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp30: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c4_sfp31: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c15: i2c@4 {
++        		reg = <4>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@75 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x75>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c5_sfp32: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp33: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp34: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp35: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp36: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp37: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp38: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c5_sfp39: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c16: i2c@5 {
++        		reg = <5>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++
++				i2cmux@76 {
++        			compatible = "nxp,pca9548";
++        			reg = <0x76>;
++        			#address-cells = <1>;
++        			#size-cells = <0>;
++        			i2c-mux-idle-disconnect;
++
++        			i2c6_sfp40: i2c@0 {
++        				reg = <0>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp41: i2c@1 {
++        				reg = <1>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp42: i2c@2 {
++        				reg = <2>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp43: i2c@3 {
++        				reg = <3>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp44: i2c@4 {
++        				reg = <4>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp45: i2c@5 {
++        				reg = <5>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp46: i2c@6 {
++        				reg = <6>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        			i2c6_sfp47: i2c@7 {
++        				reg = <7>;
++        				#address-cells = <1>;
++        				#size-cells = <0>;
++        			};
++        		};
++        	};
++        	cp0_i2c17: i2c@6 {
++        		reg = <6>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++        	};
++        	cp0_i2c18: i2c@7 {
++        		reg = <7>;
++        		#address-cells = <1>;
++        		#size-cells = <0>;
++        	};
++    };
 +};
 +
 +&i2c0 {
 +	status = "okay";
 +	clock-frequency = <100000>;
 +};
-+
 +
 +&spi0 {
 +	status = "okay";
@@ -113,8 +1820,9 @@
 +};
 +
 +&cp0_pcie0 {
-+	ranges = <0x81000000 0x0 0xf9020000 0x0 0xf9020000 0x0 0x10000
-+		  0x82000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x30000000>;
++	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
++		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x2000000
++		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
 +	status = "okay";
 +	phys = <&cp0_comphy0 0>;
 +};
@@ -126,16 +1834,6 @@
 +
 +&cp0_pcie2 {
 +	status = "disabled";
-+};
-+
-+&cp0_i2c0 {
-+	status = "okay";
-+	clock-frequency = <100000>;
-+};
-+
-+&cp0_i2c1 {
-+	status = "okay";
-+	clock-frequency = <100000>;
 +};
 +
 +&cp0_sata0 {
@@ -176,7 +1874,7 @@
 +};
 +
 +&cp0_eth0 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy-mode = "sgmii";*/
 +	phy-mode = "2500base-x";
@@ -190,7 +1888,7 @@
 +};
 +
 +&cp0_eth1 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy = <&phy0>;*/
 +	phy-mode = "sgmii";
@@ -213,3 +1911,6 @@
 +&cp0_crypto {
 +	status = "okay";
 +};
+-- 
+2.17.1
+

--- a/packages/base/any/kernels/5.6-lts/patches/0011-wnc-qsa72-aom-a-48p.patch
+++ b/packages/base/any/kernels/5.6-lts/patches/0011-wnc-qsa72-aom-a-48p.patch
@@ -1,6 +1,23 @@
+From 49f1f89df5afe392eb2f475b09811bb9093a295d Mon Sep 17 00:00:00 2001
+From: Clement Chu <Clement.Chu@wnc.com.tw>
+Date: Mon, 3 May 2021 11:22:19 +0800
+Subject: [PATCH] Add QSA72_AOM_A_48P device tree
+
+1. Add prestera driver related description for support ethtool.
+Include driver, onie_eeprom and pcie mapping information.
+2. Add gpio-i2c driver and SFP cage interface description.
+3. Disable eth0 and eth1 interface to avoid the security issues.
+---
+ .../boot/dts/marvell/wnc-qsa72-aom-a-48p.dts  | 435 ++++++++++++++++++
+ 1 file changed, 435 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
+
+diff --git a/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts b/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
+new file mode 100644
+index 0000000..b7dfa9d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/marvell/wnc-qsa72-aom-a-48p.dts
-@@ -0,0 +1,212 @@
+@@ -0,0 +1,435 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (C) 2016 Marvell Technology Group Ltd.
@@ -24,12 +41,12 @@
 +	aliases {
 +                serial0 = &uart0;
 +                serial1 = &cp0_uart1;
-+		ethernet0 = &cp0_eth0;
-+		ethernet1 = &cp0_eth1;
-+		ethernet2 = &cp0_eth2;
-+		i2c0 = &cp0_i2c0;
-+		i2c1 = &cp0_i2c1;
-+		i2c2 = &i2c0;
++                ethernet0 = &cp0_eth0;
++                ethernet1 = &cp0_eth1;
++                ethernet2 = &cp0_eth2;
++                i2c0 = &i2c0;
++                i2c1 = &cp0_i2c1;
++                i2c2 = &cp0_i2c0;
 +	};
 +
 +	cp0_utmi: utmi@580000 {
@@ -46,6 +63,238 @@
 +			status = "disabled";
 +		};
 +    };
++
++    switch-cpu {
++		compatible = "marvell,prestera-switch-rxtx-sdma";
++		status = "okay";
++	};
++
++	onie_eeprom: onie-eeprom {
++		compatible = "onie-nvmem-cells";
++		status = "okay";
++
++		nvmem = <&eeprom_at24>;
++	};
++
++	prestera {
++		compatible = "marvell,prestera";
++		status = "okay";
++
++		base-mac-provider = <&onie_eeprom>;
++		ports {
++			port49 {
++        		prestera,port-num = <49>;
++        		sfp = <&sfp49>;
++			};
++			port50 {
++        		prestera,port-num = <50>;
++        		sfp = <&sfp50>;
++			};
++			port51 {
++        		prestera,port-num = <51>;
++        		sfp = <&sfp51>;
++			};
++			port52 {
++        		prestera,port-num = <52>;
++        		sfp = <&sfp52>;
++			};
++		};
++	};
++
++	sfp49: sfp-49 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp0>;
++
++    	los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
++	};
++	sfp50: sfp-50 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp1>;
++
++    	los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
++	};
++	sfp51: sfp-51 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp2>;
++
++    	los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
++	};
++	sfp52: sfp-52 {
++    	compatible = "sff,sfp";
++    	i2c-bus = <&i2c1_sfp3>;
++
++    	los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
++    	mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
++    	tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
++	};
++
++	gpio_i2c: gpio-i2c {
++    	compatible = "qsa72_48p_gpio_i2c";
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	gpio-controller;
++    	#gpio-cells = <2>;
++
++		gpio-map {
++			/* sfp0 */
++			sfp00_gpio00_loss {
++        		reg-map = <0x0 (1 << 2)>;
++        		gpio-num = <0>;
++			};
++			sfp00_gpio01_pres {
++        		reg-map = <0x0 (1 << 1)>; /* reg mask */
++        		gpio-num = <1>;
++			};
++			sfp00_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 0)>; /* reg mask */
++        		gpio-num = <2>;
++			};
++
++			/* sfp1 */
++			sfp01_gpio00_sfp_loss {
++        		reg-map = <0x0 (1 << 5)>; /* reg mask */
++        		gpio-num = <3>;
++			};
++			sfp01_gpio01_sfp_pres {
++        		reg-map = <0x0 (1 << 4)>; /* reg mask */
++        		gpio-num = <4>;
++			};
++			sfp01_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 3)>; /* reg mask */
++        		gpio-num = <5>;
++			};
++
++			/* sfp2 */
++			sfp02_gpio00_loss {
++        		reg-map = <0x1 (1 << 0)>; /* reg mask */
++        		gpio-num = <6>;
++			};
++			sfp02_gpio01_pres {
++        		reg-map = <0x0 (1 << 7)>; /* reg mask */
++        		gpio-num = <7>;
++			};
++			sfp02_gpio02_tx_dis {
++        		reg-map = <0x2 (1 << 6)>; /* reg mask */
++        		gpio-num = <8>;
++			};
++
++			/* sfp3 */
++			sfp03_gpio00_loss {
++        		reg-map = <0x1 (1 << 3)>; /* reg mask */
++        		gpio-num = <9>;
++			};
++			sfp03_gpio01_sfp_pres {
++        		reg-map = <0x1 (1 << 2)>; /* reg mask */
++        		gpio-num = <10>;
++			};
++			sfp03_gpio02_tx_dis {
++        		reg-map = <0x3 (1 << 1)>; /* reg mask */
++        		gpio-num = <11>;
++			};
++		};
++	};
++};
++
++&cp0_i2c0 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++    	compatible = "nxp,pca9548";
++    	reg = <0x70>;
++    	#address-cells = <1>;
++    	#size-cells = <0>;
++    	i2c-mux-idle-disconnect;
++
++    	cp0_i2c3: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			status = "okay";
++			clock-frequency = <100000>;
++
++			eeprom_at24: at24@54 {
++        		compatible = "atmel,24c02";
++        		reg = <0x54>;
++			};
++    	};
++    	cp0_i2c4: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c5: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c6: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c7: i2c@4 {
++			reg = <4>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c8: i2c@5 {
++			reg = <5>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c9: i2c@6 {
++			reg = <6>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++    	cp0_i2c10: i2c@7 {
++			reg = <7>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++    	};
++	};
++};
++
++&cp0_i2c1 {
++	status = "okay";
++	clock-frequency = <100000>;
++
++	i2cmux@70 {
++		compatible = "nxp,pca9548";
++		reg = <0x70>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		i2c-mux-idle-disconnect;
++
++		i2c1_sfp0: i2c@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp1: i2c@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp2: i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++		i2c1_sfp3: i2c@3 {
++			reg = <3>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++	};
 +};
 +
 +&i2c0 {
@@ -78,8 +327,8 @@
 +&cp0_spi0 {
 +           pinctrl-names = "default";
 +           reg = <0x700600 0x50>;          /* control */
-+	   status = "okay";
-+	   spi-flash@0 {
++           status = "okay";
++           spi-flash@0 {
 +                     #address-cells = <0x1>;
 +                     #size-cells = <0x1>;
 +                     compatible = "jedec,spi-nor";
@@ -113,10 +362,11 @@
 +};
 +
 +&cp0_pcie0 {
-+	ranges = <0x81000000 0x0 0xf9020000 0x0 0xf9020000 0x0 0x10000
-+		  0x82000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x30000000>;
-+	status = "okay";
++	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
++		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x2000000
++		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
 +	phys = <&cp0_comphy0 0>;
++	status = "okay";
 +};
 +
 +&cp0_pcie1 {
@@ -126,16 +376,6 @@
 +
 +&cp0_pcie2 {
 +	status = "disabled";
-+};
-+
-+&cp0_i2c0 {
-+	status = "okay";
-+	clock-frequency = <100000>;
-+};
-+
-+&cp0_i2c1 {
-+	status = "okay";
-+	clock-frequency = <100000>;
 +};
 +
 +&cp0_sata0 {
@@ -176,7 +416,7 @@
 +};
 +
 +&cp0_eth0 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy-mode = "sgmii";*/
 +	phy-mode = "2500base-x";
@@ -190,7 +430,7 @@
 +};
 +
 +&cp0_eth1 {
-+	status = "okay";
++	status = "disabled";
 +	/* Network PHY */
 +	/*phy = <&phy0>;*/
 +	phy-mode = "sgmii";
@@ -213,3 +453,6 @@
 +&cp0_crypto {
 +	status = "okay";
 +};
+-- 
+2.17.1
+

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/PKG.yml
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml ARCH=arm64 VENDOR=wnc BASENAME=arm64-wnc-qsa72-aom-a-48p KERNELS="onl-kernel-5.6-lts-arm64-all:arm64"
+!include $ONL_TEMPLATES/platform-modules.yml ARCH=arm64 VENDOR=wnc BASENAME=arm64-wnc-qsa72-aom-a-48p KERNELS="onl-kernel-5.10-lts-arm64-all:arm64"

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/Makefile
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/Makefile
@@ -1,5 +1,5 @@
 # Settings used by ONL
-KERNELS := onl-kernel-5.6-lts-arm64-all:arm64
+KERNELS := onl-kernel-5.10-lts-arm64-all:arm64
 KMODULES := src
 VENDOR := wnc
 BASENAME := arm64-wnc-qsa72-aom-a-48p

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/Makefile
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/Makefile
@@ -1,2 +1,4 @@
 obj-m += qsa72-aom-a-48p-sys_cpld.o
+obj-m += qsa72-aom-a-48p-sfp_plus_cpld.o
+obj-m += qsa72-aom-a-48p-gpio_i2c.o
 obj-m += optoe.o

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-gpio_i2c.c
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-gpio_i2c.c
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+/*
+ * Copyright (c) 2019-2020 Marvell International Ltd. All rights reserved.
+ *
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/gpio/driver.h>
+#include <linux/init.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/i2c.h>
+#include <linux/delay.h>
+
+#define GPIO_I2C_NGPIOS		144
+
+#define GPIO_I2C_RETRY_COUNT		10
+#define GPIO_I2C_RETRY_INTERVAL	60      /* ms */
+
+extern int qsa72_sfp_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int qsa72_sfp_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+
+struct gpio_i2c_reg {
+	struct list_head head;
+	u32 gpio_num;
+	u32 reg_addr;
+	u32 reg_mask;
+};
+
+struct gpio_i2c_chip {
+	struct gpio_chip gpio_chip;
+	struct device *dev;
+	struct device_attribute bin;
+
+	struct list_head gpio_list;
+};
+
+static int gpio_i2c_read(struct gpio_i2c_chip *chip, u8 reg)
+{
+        int status = 0, retry = GPIO_I2C_RETRY_COUNT;
+
+        while (retry) {
+                status = qsa72_sfp_cpld_read(0x74, reg);
+                if (unlikely(status < 0)) {
+                        msleep(GPIO_I2C_RETRY_INTERVAL);
+                        retry--;
+                        continue;
+                }
+                break;
+        }
+
+        return status;
+}
+
+static int gpio_i2c_write(struct gpio_i2c_chip *chip, u8 reg, u8 value)
+{
+        int status = 0, retry = GPIO_I2C_RETRY_COUNT;
+
+        while (retry) {
+                status = qsa72_sfp_cpld_write(0x74, reg, value);
+                if (unlikely(status < 0)) {
+                        msleep(GPIO_I2C_RETRY_INTERVAL);
+                        retry--;
+                        continue;
+                }
+                break;
+        }
+
+        return status;
+}
+
+static struct gpio_i2c_reg *gpio_i2c_reg_by_num(struct gpio_i2c_chip *chip,
+						unsigned int offs)
+{
+	struct gpio_i2c_reg *gpio_reg;
+
+	list_for_each_entry(gpio_reg, &chip->gpio_list, head) {
+		if (gpio_reg->gpio_num == offs)
+			return gpio_reg;
+	}
+
+	return NULL;
+}
+
+static int gpio_i2c_get_value(struct gpio_chip *gc, unsigned int offs)
+{
+	struct gpio_i2c_chip *chip = gpiochip_get_data(gc);
+	struct gpio_i2c_reg *gpio_reg;
+	int val;
+
+	gpio_reg = gpio_i2c_reg_by_num(chip, offs);
+	if (!gpio_reg) {
+		dev_err(chip->dev, "invalid gpio offset (0x%x)\n", offs);
+		return -EINVAL;
+	}
+
+	val = gpio_i2c_read(chip, gpio_reg->reg_addr);
+	val &= gpio_reg->reg_mask;
+
+	return val;
+}
+
+static void gpio_i2c_set_value(struct gpio_chip *gc, unsigned int offs, int set)
+{
+	struct gpio_i2c_chip *chip = gpiochip_get_data(gc);
+	struct gpio_i2c_reg *gpio_reg;
+	unsigned int val;
+
+	gpio_reg = gpio_i2c_reg_by_num(chip, offs);
+	if (!gpio_reg) {
+		dev_err(chip->dev, "invalid gpio offset (0x%x)\n", offs);
+		return;
+	}
+
+	val = gpio_i2c_read(chip, gpio_reg->reg_addr);
+
+	val &= ~gpio_reg->reg_mask;
+	if (set)
+		val |= gpio_reg->reg_mask;
+
+	gpio_i2c_write(chip, gpio_reg->reg_addr, val);
+}
+
+static int gpio_i2c_reg_parse(struct gpio_i2c_chip *chip, struct device_node *np)
+{
+	struct gpio_i2c_reg *gpio_reg;
+	struct device *dev = chip->dev;
+	u32 gpio_reg_map[2];
+	u32 gpio_num;
+	int err;
+
+	err = of_property_read_u32_array(np, "reg-map", gpio_reg_map,
+					 ARRAY_SIZE(gpio_reg_map));
+
+	if (err) {
+		dev_err(dev, "error while parsing 'reg-map' property\n");
+		return err;
+	}
+
+	err = of_property_read_u32(np, "gpio-num", &gpio_num);
+	if (err) {
+		dev_err(dev, "error while parsing 'gpio-num' property\n");
+		return err;
+	}
+
+	gpio_reg = devm_kmalloc(dev, sizeof(*gpio_reg), GFP_KERNEL);
+	if (!gpio_reg)
+		return err;
+
+	gpio_reg->reg_addr = gpio_reg_map[0];
+	gpio_reg->reg_mask = gpio_reg_map[1];
+	gpio_reg->gpio_num = gpio_num;
+
+	list_add(&gpio_reg->head, &chip->gpio_list);
+
+	return 0;
+}
+
+static int gpio_i2c_map_parse(struct gpio_i2c_chip *chip,
+			      struct device_node *gpio_map_np)
+{
+	struct device_node *node;
+
+	for_each_child_of_node(gpio_map_np, node) {
+		int err;
+
+		err = gpio_i2c_reg_parse(chip, node);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static int gpio_i2c_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	struct device_node *gpio_map_np;
+	struct gpio_i2c_chip *chip;
+	int err;
+
+	if (!np)
+		return -EINVAL;
+
+	chip = devm_kzalloc(dev, sizeof(*chip), GFP_KERNEL);
+	if (!chip)
+		return -ENOMEM;
+
+	INIT_LIST_HEAD(&chip->gpio_list);
+	chip->dev = dev;
+
+	gpio_map_np = of_find_node_by_name(np, "gpio-map");
+	if (gpio_map_np) {
+		err = gpio_i2c_map_parse(chip, gpio_map_np);
+		if (err)
+			return err;
+	}
+
+	printk("%s:  gpio_i2c probe.\n", __FUNCTION__);
+	chip->gpio_chip.parent = dev;
+
+	dev_set_drvdata(dev, chip);
+
+	chip->gpio_chip.label = dev_name(dev);
+	chip->gpio_chip.get = gpio_i2c_get_value;
+	chip->gpio_chip.set = gpio_i2c_set_value;
+	chip->gpio_chip.base = -1;
+
+	chip->gpio_chip.ngpio = GPIO_I2C_NGPIOS;
+
+	chip->gpio_chip.owner = THIS_MODULE;
+	chip->gpio_chip.can_sleep = true;
+
+	return devm_gpiochip_add_data(dev, &chip->gpio_chip, chip);
+}
+
+static int gpio_i2c_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static const struct of_device_id gpio_i2c_id[] = {
+	{ .compatible = "qsa72_48p_gpio_i2c" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, gpio_i2c_id);
+
+static struct platform_driver gpio_i2c_driver = {
+	.driver = {
+		.name = "qsa72_48p_gpio_i2c",
+		.owner = THIS_MODULE,
+		.of_match_table = gpio_i2c_id,
+	},
+	.probe = gpio_i2c_probe,
+	.remove = gpio_i2c_remove,
+};
+
+module_platform_driver(gpio_i2c_driver);
+
+MODULE_AUTHOR("Kily Chen <Kily.Chen@wnc.com.tw");
+MODULE_LICENSE("Dual BSD/GPL");
+MODULE_DESCRIPTION("GPIO to I2C driver");

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld.c
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld.c
@@ -1,0 +1,401 @@
+#include <linux/module.h>
+#include <linux/i2c.h>
+#include <linux/delay.h>
+
+#include "qsa72-aom-a-48p-sfp_plus_cpld_reg.h"
+#include "qsa72-aom-a-48p-sfp_plus_cpld_sysfs.h"
+
+static int debug_flag = 0;
+
+static LIST_HEAD(cpld_client_list);
+static struct mutex list_lock;
+
+struct cpld_client_node {
+    struct i2c_client *client;
+    struct list_head   list;
+};
+
+struct system_cpld_data {
+    struct mutex lock;
+    struct i2c_client *client;
+    struct device_attribute bin;
+};
+struct system_cpld_data *system_cpld;
+
+static const struct i2c_device_id system_cpld_ids[] = {
+    { "qsa72_48p_sfp_cpld2", 0 },
+    { /* END OF LIST */ }
+};
+MODULE_DEVICE_TABLE(i2c, system_cpld_ids);
+
+static int system_cpld_raw_read(struct device *dev, struct device_attribute *attr, char *buf,
+    int reg_offset, int reg_width, int fld_shift, int fld_width, int fld_mask, char *reg_name)
+{
+    unsigned int reg_val = 0, fld_val;
+    static int debug_flag;
+    struct system_cpld_data *data = dev_get_drvdata(dev);
+    struct i2c_client *client = data->client;
+    int err;
+
+    if(reg_width != 8)
+    {
+        printk("%s: Register table width setting failed.\n", reg_name);
+        return -EINVAL;
+    }
+
+    mutex_lock(&data->lock);
+
+    if((err = i2c_smbus_read_byte_data(client, (u8)reg_offset)) < 0)
+    {
+        /* CPLD read error condition */;
+        mutex_unlock(&data->lock);
+        printk("%s: i2c read failed, error code = %d.\n", reg_name, err);
+        return err;
+    }
+    reg_val = err;
+
+    if(debug_flag)
+    {
+        printk("%s: reg_offset = %d, width = %d, cur value = 0x%x.\n", reg_name, reg_offset, reg_width, reg_val);
+    }
+
+    mutex_unlock(&data->lock);
+
+    if(fld_width == reg_width)
+    {
+        fld_val = reg_val & fld_mask;
+    }
+    else
+    {
+        fld_val = (reg_val >> fld_shift) & fld_mask;
+    }
+
+    return sprintf(buf, "0x%x\n", fld_val);
+}
+
+static int system_cpld_raw_write(struct device *dev, struct device_attribute *attr, const char *buf, size_t count,
+    int reg_offset, int reg_width, int fld_shift, int fld_width, int fld_mask, char *reg_name)
+{
+    int ret_code;
+    unsigned int reg_val, fld_val;
+    unsigned long val;
+    static int debug_flag;
+    struct system_cpld_data *data = dev_get_drvdata(dev);
+    struct i2c_client *client = data->client;
+
+    if(reg_width != 8)
+    {
+        printk("%s: Register table width setting failed.\n", reg_name);
+        return -EINVAL;
+    }
+
+    /* Parse buf and store to fld_val */
+    if((ret_code = kstrtoul(buf, 16, &val)))
+    {
+        printk("%s: Conversion value = %s failed, errno = %d.\n", reg_name, buf, ret_code);
+        return ret_code;
+    }
+    fld_val = (unsigned int)val;
+
+    mutex_lock(&data->lock);
+
+    if((ret_code = i2c_smbus_read_byte_data(client, (u8)reg_offset)) < 0)
+    {
+        /* Handle CPLD read error condition */;
+        mutex_unlock(&data->lock);
+        printk("%s: i2c read failed, error code = %d.\n",  reg_name, ret_code);
+        return ret_code;
+    }
+    reg_val = ret_code;
+
+    if(debug_flag)
+    {
+        printk("%s: offset = %d, width = %d, cur value = 0x%x.\n", reg_name, reg_offset, reg_width, reg_val);
+    }
+
+    if(fld_width == reg_width)
+    {
+        reg_val = fld_val & fld_mask;
+    }
+    else
+    {
+        reg_val = (reg_val & ~(fld_mask << fld_shift)) |
+                    ((fld_val & (fld_mask)) << fld_shift);
+    }
+
+    if((ret_code = i2c_smbus_write_byte_data(client, (u8)reg_offset, (u8)reg_val)) != 0)
+    {
+        /* Handle CPLD write error condition */;
+        mutex_unlock(&data->lock);
+        printk("%s: i2c write failed, error code = %d.\n",  reg_name, ret_code);
+        return ret_code;
+    }
+    else if(debug_flag)
+    {
+        printk("%s: offset = %d, width = %d, new value = 0x%x.\n", reg_name, reg_offset, reg_width, reg_val);
+    }
+
+    mutex_unlock(&data->lock);
+
+    return count;
+}
+
+/*-------------------- Special file for debug ---------------------- */
+static ssize_t system_cpld_debug_read(struct device *dev, struct device_attribute *attr,
+             char *buf)
+{
+    return sprintf(buf, "%d\n", debug_flag);
+}
+
+static ssize_t system_cpld_debug_write(struct device *dev, struct device_attribute *attr,
+            const char *buf, size_t count)
+{
+    int temp;
+    int error;
+
+    error = kstrtoint(buf, 10, &temp);
+    if(error)
+    {
+        printk(KERN_INFO "%s: Conversion value = %s failed.\n", __FUNCTION__, buf);
+        return count;
+    }
+    debug_flag = temp;
+
+    if(debug_flag)
+        printk("%s, debug_flag = %d\n", __FUNCTION__, debug_flag);
+
+    return count;
+}
+SYSFS_MISC_RW_ATTR_DEF(debug, system_cpld_debug_read, system_cpld_debug_write)
+
+/* ---------------- Define misc group ---------------------------- */
+static struct attribute *misc_attributes[] = {
+
+	SYSFS_ATTR_PTR(in_1                   ),
+	SYSFS_ATTR_PTR(in_2                   ),
+	SYSFS_ATTR_PTR(out_1                  ),
+	SYSFS_ATTR_PTR(out_2                  ),
+	SYSFS_ATTR_PTR(inv_1                  ),
+	SYSFS_ATTR_PTR(inv_2                  ),
+	SYSFS_ATTR_PTR(dir_1                  ),
+	SYSFS_ATTR_PTR(dir_2                  ),
+	SYSFS_ATTR_PTR(p49_mod_abs            ),
+	SYSFS_ATTR_PTR(p50_mod_abs            ),
+	SYSFS_ATTR_PTR(p51_mod_abs            ),
+	SYSFS_ATTR_PTR(p52_mod_abs            ),
+	SYSFS_ATTR_PTR(p49_rx_los             ),
+	SYSFS_ATTR_PTR(p50_rx_los             ),
+	SYSFS_ATTR_PTR(p51_rx_los             ),
+	SYSFS_ATTR_PTR(p52_rx_los             ),
+	//SYSFS_ATTR_PTR(p49_tx_fault           ),
+	//SYSFS_ATTR_PTR(p50_tx_fault           ),
+	//SYSFS_ATTR_PTR(p51_tx_fault           ),
+	//SYSFS_ATTR_PTR(p52_tx_fault           ),
+	SYSFS_ATTR_PTR(p49_tx_disable         ),
+	SYSFS_ATTR_PTR(p50_tx_disable         ),
+	SYSFS_ATTR_PTR(p51_tx_disable         ),
+	SYSFS_ATTR_PTR(p52_tx_disable         ),
+
+    NULL
+};
+
+static const struct attribute_group system_cpld_group_misc = {
+    .attrs = misc_attributes,
+};
+
+#define I2C_RW_RETRY_COUNT               10
+#define I2C_RW_RETRY_INTERVAL            60 /* ms */
+
+static void qsa72_sfp_cpld_add_client(struct i2c_client *client)
+{
+    struct cpld_client_node *node = kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
+
+    if (!node) {
+        dev_dbg(&client->dev, "Can't allocate cpld_client_node (0x%x)\n", client->addr);
+        return;
+    }
+
+    node->client = client;
+
+    mutex_lock(&list_lock);
+    list_add(&node->list, &cpld_client_list);
+    mutex_unlock(&list_lock);
+}
+
+static void qsa72_sfp_cpld_remove_client(struct i2c_client *client)
+{
+    struct list_head    *list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int found = 0;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client == client) {
+            found = 1;
+            break;
+        }
+    }
+
+    if (found) {
+        list_del(list_node);
+        kfree(cpld_node);
+    }
+
+    mutex_unlock(&list_lock);
+}
+
+static int qsa72_sfp_cpld_read_internal(struct i2c_client *client, u8 reg)
+{
+    int status = 0, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_read_byte_data(client, reg);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    return status;
+}
+
+static int qsa72_sfp_cpld_write_internal(struct i2c_client *client, u8 reg, u8 value)
+{
+    int status = 0, retry = I2C_RW_RETRY_COUNT;
+
+    while (retry) {
+        status = i2c_smbus_write_byte_data(client, reg, value);
+        if (unlikely(status < 0)) {
+            msleep(I2C_RW_RETRY_INTERVAL);
+            retry--;
+            continue;
+        }
+
+        break;
+    }
+
+    return status;
+}
+
+int qsa72_sfp_cpld_read(unsigned short cpld_addr, u8 reg)
+{
+    struct list_head   *list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int ret = -EPERM;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client->addr == cpld_addr) {
+            ret = qsa72_sfp_cpld_read_internal(cpld_node->client, reg);
+            break;
+        }
+    }
+
+    mutex_unlock(&list_lock);
+
+    return ret;
+}
+EXPORT_SYMBOL(qsa72_sfp_cpld_read);
+
+int qsa72_sfp_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
+{
+    struct list_head   *list_node = NULL;
+    struct cpld_client_node *cpld_node = NULL;
+    int ret = -EIO;
+
+    mutex_lock(&list_lock);
+
+    list_for_each(list_node, &cpld_client_list)
+    {
+        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+        if (cpld_node->client->addr == cpld_addr) {
+            ret = qsa72_sfp_cpld_write_internal(cpld_node->client, reg, value);
+            break;
+        }
+    }
+
+    mutex_unlock(&list_lock);
+
+    return ret;
+}
+EXPORT_SYMBOL(qsa72_sfp_cpld_write);
+
+static int system_cpld_probe(struct i2c_client *client, const struct i2c_device_id *id)
+{
+    int err;
+
+    /* allocate memory to system_cpld */
+    system_cpld = devm_kzalloc(&client->dev, sizeof(struct system_cpld_data), GFP_KERNEL);
+
+    if(!system_cpld)
+        return -ENOMEM;
+
+    mutex_init(&system_cpld->lock);
+
+    err = sysfs_create_group(&client->dev.kobj, &system_cpld_group_misc);
+    if(err)
+    {
+        printk("%s: Error create misc group.\n", __FUNCTION__);
+    }
+
+    system_cpld->client = client;
+    i2c_set_clientdata(client, system_cpld);
+
+    printk(KERN_INFO "%s: 10g SFP plus CPLD2 created.\n", __FUNCTION__);
+
+    qsa72_sfp_cpld_add_client(client);
+
+    return 0;
+}
+
+static int system_cpld_remove(struct i2c_client *client)
+{
+    sysfs_remove_group(&client->dev.kobj, &system_cpld_group_misc);
+
+    qsa72_sfp_cpld_remove_client(client);
+
+    printk(KERN_INFO "%s: 10g SFP plus CPLD2 removed.\n", __FUNCTION__);
+    return 0;
+}
+
+static struct i2c_driver system_cpld_driver = {
+    .driver = {
+        .name = "qsa72_48p_sfp_cpld2",
+        .owner = THIS_MODULE,
+    },
+    .probe = system_cpld_probe,
+    .remove = system_cpld_remove,
+    .id_table = system_cpld_ids,
+};
+
+static int __init system_cpld_init(void)
+{
+    printk(KERN_INFO "%s: init.\n", __FUNCTION__);
+	mutex_init(&list_lock);
+    return i2c_add_driver(&system_cpld_driver);
+}
+module_init(system_cpld_init);
+
+static void __exit system_cpld_exit(void)
+{
+    printk(KERN_INFO "%s: exit.\n", __FUNCTION__);
+    i2c_del_driver(&system_cpld_driver);
+}
+module_exit(system_cpld_exit);
+
+MODULE_DESCRIPTION("Driver for 48p SFP plus CPLD2");
+MODULE_AUTHOR("Kily Chen <Kily.Chen@wnc.com.tw>");
+MODULE_LICENSE("GPL");
+

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld_reg.h
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld_reg.h
@@ -1,0 +1,80 @@
+#ifndef __qsa72_aom_a_48p_sfp_plus_cpld_reg_H__
+#define __qsa72_aom_a_48p_sfp_plus_cpld_reg_H__
+
+
+static int system_cpld_raw_read(struct device *dev, struct device_attribute *attr, char *buf,
+    int reg_offset, int reg_width, int fld_shift, int fld_width, int fld_mask, char *reg_name);
+static int system_cpld_raw_write(struct device *dev, struct device_attribute *attr, const char *buf, size_t count,
+    int reg_offset, int reg_width, int fld_shift, int fld_width, int fld_mask, char *reg_name);
+
+/* Generic CPLD read function */
+#define FLD_RAW_RD_FUNC(_reg, _fld, _wdh) static ssize_t \
+system_cpld_##_fld##_raw_read(struct device *dev, struct device_attribute *attr, char *buf) { \
+    return system_cpld_raw_read(dev, attr, buf, _reg##_offset, _reg##_width, _fld##_shift, _fld##_width, _fld##_mask, #_reg); \
+}
+
+/* Generic CPLD write function */
+#define FLD_RAW_WR_FUNC(_reg, _fld, _wdh) static ssize_t \
+system_cpld_##_fld##_raw_write(struct device *dev, struct device_attribute *attr, const char *buf, size_t count) { \
+    return system_cpld_raw_write(dev, attr, buf, count, _reg##_offset, _reg##_width, _fld##_shift, _fld##_width, _fld##_mask, #_reg); \
+}
+
+/* CPLD register definition macros */
+#define REG_DEF(_reg, _off, _wdh) \
+static unsigned int _reg##_offset = (unsigned int)(_off); \
+static unsigned int _reg##_width = (unsigned int)(_wdh);
+
+/* CPLD register field definition macros, with generic read/write function */
+#define FLD_RAW_RO_DEF(_reg, _fld, _sft, _wdh) \
+static unsigned int _fld##_shift = (unsigned int)(_sft); \
+static unsigned int _fld##_width = (unsigned int)(_wdh); \
+static unsigned int _fld##_mask = ((((unsigned int)1) << (_wdh)) - 1); \
+FLD_RAW_RD_FUNC(_reg, _fld, _wdh)
+
+#define FLD_RAW_RW_DEF(_reg, _fld, _sft, _wdh) \
+static unsigned int _fld##_shift = (unsigned int)(_sft); \
+static unsigned int _fld##_width = (unsigned int)(_wdh); \
+static unsigned int _fld##_mask = ((((unsigned int)1) << (_wdh)) - 1); \
+FLD_RAW_RD_FUNC(_reg, _fld, _wdh) FLD_RAW_WR_FUNC(_reg, _fld, _wdh)
+
+
+/* Declare system CPLD registers */
+/*           register name                          offset  width */
+/*           --------------------------------      -------  ----- */
+REG_DEF(     in_1_reg   ,                             0x00,   8)
+REG_DEF(     in_2_reg   ,                             0x01,   8)
+REG_DEF(     out_1_reg  ,                             0x02,   8)
+REG_DEF(     out_2_reg  ,                             0x03,   8)
+REG_DEF(     inv_1_reg  ,                             0x04,   8)
+REG_DEF(     inv_2_reg  ,                             0x05,   8)
+REG_DEF(     dir_1_reg  ,                             0x06,   8)
+REG_DEF(     dir_2_reg  ,                             0x07,   8)
+//REG_DEF(     debug_reg  ,                             0xFF,   8)
+
+/* Declare system CPLD register's fields */
+/*                      register name               field name                  shift  width */
+/*                      ----------------------      ----------------            ------ ----- */
+FLD_RAW_RW_DEF(         in_1_reg,                   in_1,                       0,      8)
+FLD_RAW_RW_DEF(         in_2_reg,                   in_2,                       0,      8)
+FLD_RAW_RW_DEF(         out_1_reg,                  out_1,                      0,      8)
+FLD_RAW_RW_DEF(         out_2_reg,                  out_2,                      0,      8)
+FLD_RAW_RW_DEF(         inv_1_reg,                  inv_1,                      0,      8)
+FLD_RAW_RW_DEF(         inv_2_reg,                  inv_2,                      0,      8)
+FLD_RAW_RW_DEF(         dir_1_reg,                  dir_1,                      0,      8)
+FLD_RAW_RW_DEF(         dir_2_reg,                  dir_2,                      0,      8)
+//FLD_RAW_RW_DEF(         debug_reg,                  debug,                      0,      8)
+FLD_RAW_RO_DEF(         in_1_reg,                   p49_mod_abs,                1,      1)
+FLD_RAW_RO_DEF(         in_1_reg,                   p50_mod_abs,                4,      1)
+FLD_RAW_RO_DEF(         in_1_reg,                   p51_mod_abs,                7,      1)
+FLD_RAW_RO_DEF(         in_2_reg,                   p52_mod_abs,                2,      1)
+FLD_RAW_RO_DEF(         in_1_reg,                   p49_rx_los,                 2,      1)
+FLD_RAW_RO_DEF(         in_1_reg,                   p50_rx_los,                 5,      1)
+FLD_RAW_RO_DEF(         in_2_reg,                   p51_rx_los,                 0,      1)
+FLD_RAW_RO_DEF(         in_2_reg,                   p52_rx_los,                 3,      1)
+FLD_RAW_RW_DEF(         out_1_reg,                  p49_tx_disable,             0,      1)
+FLD_RAW_RW_DEF(         out_1_reg,                  p50_tx_disable,             3,      1)
+FLD_RAW_RW_DEF(         out_1_reg,                  p51_tx_disable,             4,      1)
+FLD_RAW_RW_DEF(         out_2_reg,                  p52_tx_disable,             1,      1)
+
+
+#endif /* __qsa72_aom_a_48p_sfp_plus_cpld_reg_H__ */

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld_sysfs.h
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/modules/builds/src/qsa72-aom-a-48p-sfp_plus_cpld_sysfs.h
@@ -1,0 +1,51 @@
+#ifndef __qsa72_aom_a_48p_sfp_plus_cpld_sysfs_H__
+#define __qsa72_aom_a_48p_sfp_plus_cpld_sysfs_H__
+
+/* Generic CPLD sysfs file definition macros */
+#define SYSFS_RAW_RO_ATTR_DEF(field)  \
+struct device_attribute field  \
+    = __ATTR(field, S_IRUGO, system_cpld_##field##_raw_read, NULL);
+
+#define SYSFS_RAW_RW_ATTR_DEF(field)  \
+struct device_attribute field  \
+    = __ATTR(field, S_IRUGO | S_IWUSR, system_cpld_##field##_raw_read, system_cpld_##field##_raw_write);
+
+#define SYSFS_MISC_RO_ATTR_DEF(field, _read)  \
+struct device_attribute field  \
+    = __ATTR(field, S_IRUGO, _read, NULL);
+
+#define SYSFS_MISC_RW_ATTR_DEF(field, _read, _write)  \
+struct device_attribute field  \
+    = __ATTR(field, S_IRUGO | S_IWUSR, _read, _write);
+
+#define SYSFS_ATTR_PTR(field) &field.attr
+
+SYSFS_RAW_RW_ATTR_DEF(in_1                  )
+SYSFS_RAW_RW_ATTR_DEF(in_2                  )
+SYSFS_RAW_RW_ATTR_DEF(out_1                 )
+SYSFS_RAW_RW_ATTR_DEF(out_2                 )
+SYSFS_RAW_RW_ATTR_DEF(inv_1                 )
+SYSFS_RAW_RW_ATTR_DEF(inv_2                 )
+SYSFS_RAW_RW_ATTR_DEF(dir_1                 )
+SYSFS_RAW_RW_ATTR_DEF(dir_2                 )
+//SYSFS_RAW_RW_ATTR_DEF(debug                 )
+SYSFS_RAW_RO_ATTR_DEF(p49_mod_abs                )
+SYSFS_RAW_RO_ATTR_DEF(p50_mod_abs                )
+SYSFS_RAW_RO_ATTR_DEF(p51_mod_abs                )
+SYSFS_RAW_RO_ATTR_DEF(p52_mod_abs                )
+SYSFS_RAW_RO_ATTR_DEF(p49_rx_los                 )
+SYSFS_RAW_RO_ATTR_DEF(p50_rx_los                 )
+SYSFS_RAW_RO_ATTR_DEF(p51_rx_los                 )
+SYSFS_RAW_RO_ATTR_DEF(p52_rx_los                 )
+//SYSFS_RAW_RO_ATTR_DEF(p49_tx_fault               )
+//SYSFS_RAW_RO_ATTR_DEF(p50_tx_fault               )
+//SYSFS_RAW_RO_ATTR_DEF(p51_tx_fault               )
+//SYSFS_RAW_RO_ATTR_DEF(p52_tx_fault               )
+SYSFS_RAW_RW_ATTR_DEF(p49_tx_disable             )
+SYSFS_RAW_RW_ATTR_DEF(p50_tx_disable             )
+SYSFS_RAW_RW_ATTR_DEF(p51_tx_disable             )
+SYSFS_RAW_RW_ATTR_DEF(p52_tx_disable             )
+
+
+#endif /*__qsa72_aom_a_48p_sfp_plus_cpld_sysfs_H__*/
+

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/fani.c
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/fani.c
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include "platform_lib.h"
 
-#define PREFIX_PATH_ON_MAIN_BOARD   "/sys/bus/i2c/devices/2-0077/"
+#define PREFIX_PATH_ON_MAIN_BOARD   "/sys/bus/i2c/devices/0-0077/"
 
 #define MAX_FAN_SPEED     17600
 #define FAN_MIN_PERCENTAGE 50

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/ledi.c
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/ledi.c
@@ -33,7 +33,7 @@
 #include "platform_lib.h"
 
 #define sfp_led_path "/sys/class/gpio/gpio%d/value"
-#define prefix_path "/sys/bus/i2c/devices/2-0077/"
+#define prefix_path "/sys/bus/i2c/devices/0-0077/"
 #define filename    "brightness"
 #define NUM_OF_SFP_PORT 4
 

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/sysi.c
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/onlp/builds/arm64_qsa72-aom-a-48p/module/src/sysi.c
@@ -59,11 +59,11 @@ static int manage_fans_status = MANAGE_FANS_STA_INIT;
 
 static char arr_cpldcap_name[NUM_OF_CPLD][64] =
 {
-   "2-0077/cpld1_rev_cap",
+   "0-0077/cpld1_rev_cap",
 };
 static char arr_cpldsub_name[NUM_OF_CPLD][64] =
 {
-   "2-0077/cpld1_rev_sub",
+   "0-0077/cpld1_rev_sub",
 };
 
 const char*

--- a/packages/platforms/wnc/arm64/qsa72-aom-a-48p/platform-config/r0/src/lib/arm64-wnc-qsa72-aom-a-48p-r0.yml
+++ b/packages/platforms/wnc/arm64/qsa72-aom-a-48p/platform-config/r0/src/lib/arm64-wnc-qsa72-aom-a-48p-r0.yml
@@ -9,10 +9,10 @@
 arm64-wnc-qsa72-aom-a-48p-r0:
   flat_image_tree:
     kernel:
-      <<: *arm64-kernel-5-6
+      <<: *arm64-kernel-5-10
     dtb:
       =: wnc-qsa72-aom-a-48p.dtb
-      <<: *arm64-kernel-5-6-package
+      <<: *arm64-kernel-5-10-package
     itb:
       <<: *arm64-itb
 
@@ -51,5 +51,5 @@ arm64-wnc-qsa72-aom-a-48p-r0:
   network:
     interfaces:
       ma1:
-        name: eth2
+        name: eth0
 

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/PKG.yml
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml ARCH=arm64 VENDOR=wnc BASENAME=arm64-wnc-qsd61-aom-a-48 KERNELS="onl-kernel-5.6-lts-arm64-all:arm64"
+!include $ONL_TEMPLATES/platform-modules.yml ARCH=arm64 VENDOR=wnc BASENAME=arm64-wnc-qsd61-aom-a-48 KERNELS="onl-kernel-5.10-lts-arm64-all:arm64"

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/Makefile
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/Makefile
@@ -1,5 +1,5 @@
 # Settings used by ONL
-KERNELS := onl-kernel-5.6-lts-arm64-all:arm64
+KERNELS := onl-kernel-5.10-lts-arm64-all:arm64
 KMODULES := src
 VENDOR := wnc
 BASENAME := arm64-wnc-qsd61-aom-a-48

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/Makefile
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/Makefile
@@ -1,3 +1,4 @@
 obj-m += qsd61-aom-a-48-sfp_plus_cpld.o
 obj-m += qsd61-aom-a-48-sys_cpld.o
+obj-m += qsd61-aom-a-48-gpio_i2c.o
 obj-m += optoe.o

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/qsd61-aom-a-48-gpio_i2c.c
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/qsd61-aom-a-48-gpio_i2c.c
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
+/*
+ * Copyright (c) 2019-2020 Marvell International Ltd. All rights reserved.
+ *
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/gpio/driver.h>
+#include <linux/init.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_device.h>
+#include <linux/i2c.h>
+#include <linux/delay.h>
+
+#define GPIO_I2C_NGPIOS		144
+
+#define GPIO_I2C_RETRY_COUNT		10
+#define GPIO_I2C_RETRY_INTERVAL	60      /* ms */
+
+extern int qsd61_sfp_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int qsd61_sfp_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+
+struct gpio_i2c_reg {
+	struct list_head head;
+	u32 gpio_num;
+	u32 reg_addr;
+	u32 reg_mask;
+};
+
+struct gpio_i2c_chip {
+	struct gpio_chip gpio_chip;
+	struct device *dev;
+
+	struct list_head gpio_list;
+};
+
+static int gpio_i2c_read(struct gpio_i2c_chip *chip, u8 reg)
+{
+	int status = 0, retry = GPIO_I2C_RETRY_COUNT;
+
+	while (retry) {
+		status = qsd61_sfp_cpld_read(0x76, reg);
+		if (unlikely(status < 0)) {
+			msleep(GPIO_I2C_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+		break;
+	}
+
+	return status;
+}
+
+static int gpio_i2c_write(struct gpio_i2c_chip *chip, u8 reg, u8 value)
+{
+	int status = 0, retry = GPIO_I2C_RETRY_COUNT;
+
+	while (retry) {
+		status = qsd61_sfp_cpld_write(0x76, reg, value);
+		if (unlikely(status < 0)) {
+			msleep(GPIO_I2C_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+		break;
+	}
+
+	return status;
+}
+
+static struct gpio_i2c_reg *gpio_i2c_reg_by_num(struct gpio_i2c_chip *chip,
+						unsigned int offs)
+{
+	struct gpio_i2c_reg *gpio_reg;
+
+	list_for_each_entry(gpio_reg, &chip->gpio_list, head) {
+		if (gpio_reg->gpio_num == offs)
+			return gpio_reg;
+	}
+
+	return NULL;
+}
+
+static int gpio_i2c_get_value(struct gpio_chip *gc, unsigned int offs)
+{
+	struct gpio_i2c_chip *chip = gpiochip_get_data(gc);
+	struct gpio_i2c_reg *gpio_reg;
+	int val;
+
+	gpio_reg = gpio_i2c_reg_by_num(chip, offs);
+	if (!gpio_reg) {
+		dev_err(chip->dev, "invalid gpio offset (0x%x)\n", offs);
+		return -EINVAL;
+	}
+
+	val = gpio_i2c_read(chip, gpio_reg->reg_addr);
+	val &= gpio_reg->reg_mask;
+
+	return val;
+}
+
+static void gpio_i2c_set_value(struct gpio_chip *gc, unsigned int offs, int set)
+{
+	struct gpio_i2c_chip *chip = gpiochip_get_data(gc);
+	struct gpio_i2c_reg *gpio_reg;
+	unsigned int val;
+
+	gpio_reg = gpio_i2c_reg_by_num(chip, offs);
+	if (!gpio_reg) {
+		dev_err(chip->dev, "invalid gpio offset (0x%x)\n", offs);
+		return;
+	}
+
+	val = gpio_i2c_read(chip, gpio_reg->reg_addr);
+
+	val &= ~gpio_reg->reg_mask;
+	if (set)
+		val |= gpio_reg->reg_mask;
+
+	gpio_i2c_write(chip, gpio_reg->reg_addr, val);
+}
+
+static int gpio_i2c_reg_parse(struct gpio_i2c_chip *chip, struct device_node *np)
+{
+	struct gpio_i2c_reg *gpio_reg;
+	struct device *dev = chip->dev;
+	u32 gpio_reg_map[2];
+	u32 gpio_num;
+	int err;
+
+	err = of_property_read_u32_array(np, "reg-map", gpio_reg_map,
+					 ARRAY_SIZE(gpio_reg_map));
+
+	if (err) {
+		dev_err(dev, "error while parsing 'reg-map' property\n");
+		return err;
+	}
+
+	err = of_property_read_u32(np, "gpio-num", &gpio_num);
+	if (err) {
+		dev_err(dev, "error while parsing 'gpio-num' property\n");
+		return err;
+	}
+
+	gpio_reg = devm_kmalloc(dev, sizeof(*gpio_reg), GFP_KERNEL);
+	if (!gpio_reg)
+		return err;
+
+	gpio_reg->reg_addr = gpio_reg_map[0];
+	gpio_reg->reg_mask = gpio_reg_map[1];
+	gpio_reg->gpio_num = gpio_num;
+
+	list_add(&gpio_reg->head, &chip->gpio_list);
+
+	return 0;
+}
+
+static int gpio_i2c_map_parse(struct gpio_i2c_chip *chip,
+			      struct device_node *gpio_map_np)
+{
+	struct device_node *node;
+
+	for_each_child_of_node(gpio_map_np, node) {
+		int err;
+
+		err = gpio_i2c_reg_parse(chip, node);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+static int gpio_i2c_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *np = dev->of_node;
+	struct device_node *gpio_map_np;
+	struct gpio_i2c_chip *chip;
+	int err;
+
+	if (!np)
+		return -EINVAL;
+
+	chip = devm_kzalloc(dev, sizeof(*chip), GFP_KERNEL);
+	if (!chip)
+		return -ENOMEM;
+
+	INIT_LIST_HEAD(&chip->gpio_list);
+	chip->dev = dev;
+
+	gpio_map_np = of_find_node_by_name(np, "gpio-map");
+	if (gpio_map_np) {
+		err = gpio_i2c_map_parse(chip, gpio_map_np);
+		if (err)
+			return err;
+	}
+
+	chip->gpio_chip.parent = dev;
+
+	dev_set_drvdata(dev, chip);
+
+	chip->gpio_chip.label = dev_name(dev);
+	chip->gpio_chip.get = gpio_i2c_get_value;
+	chip->gpio_chip.set = gpio_i2c_set_value;
+	chip->gpio_chip.base = -1;
+
+	chip->gpio_chip.ngpio = GPIO_I2C_NGPIOS;
+
+	chip->gpio_chip.owner = THIS_MODULE;
+	chip->gpio_chip.can_sleep = true;
+
+	return devm_gpiochip_add_data(dev, &chip->gpio_chip, chip);
+}
+
+static int gpio_i2c_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+
+static const struct of_device_id gpio_i2c_id[] = {
+	{ .compatible = "qsd61_48_gpio_i2c" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, gpio_i2c_id);
+
+static struct platform_driver gpio_i2c_driver = {
+	.driver = {
+		.name = "qsd61_48_gpio_i2c",
+		.owner = THIS_MODULE,
+		.of_match_table = gpio_i2c_id,
+	},
+	.probe = gpio_i2c_probe,
+	.remove = gpio_i2c_remove,
+};
+
+module_platform_driver(gpio_i2c_driver);
+
+
+MODULE_AUTHOR("Clement Chu <Clement.Chu@wnc.com.tw");
+MODULE_LICENSE("Dual BSD/GPL");
+MODULE_DESCRIPTION("GPIO to I2C driver");

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/qsd61-aom-a-48-sfp_plus_cpld_reg.h
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/modules/builds/src/qsd61-aom-a-48-sfp_plus_cpld_reg.h
@@ -380,6 +380,4 @@ FLD_RAW_RW_DEF(         module_absence_f_proc_reg,  p41_mod_abs_proc,           
 FLD_RAW_RO_DEF(         cpld_version_reg,           cpld2_rev_cap,              6,      2)
 FLD_RAW_RO_DEF(         cpld_version_reg,           cpld2_rev_sub,              0,      6)
 
-
-
 #endif /* __qsd61_aom_a_48_sfp_plus_cpld_reg_H__ */

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/fani.c
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/fani.c
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include "platform_lib.h"
 
-#define PREFIX_PATH_ON_MAIN_BOARD   "/sys/bus/i2c/devices/2-0077/"
+#define PREFIX_PATH_ON_MAIN_BOARD   "/sys/bus/i2c/devices/0-0077/"
 
 #define MAX_FAN_SPEED     17600
 #define FAN_MIN_PERCENTAGE 50

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/ledi.c
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/ledi.c
@@ -32,7 +32,7 @@
 
 #include "platform_lib.h"
 
-#define prefix_path "/sys/bus/i2c/devices/2-0077/"
+#define prefix_path "/sys/bus/i2c/devices/0-0077/"
 #define filename    "brightness"
 
 #define SYSFS_NODE_PATH_MAX_LEN  128

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/sfpi.c
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/sfpi.c
@@ -39,19 +39,19 @@
 
 #define NUM_OF_SFP_PORT 48
 
-#define MODULE_PRESENT_FORMAT        "/sys/bus/i2c/devices/2-0076/p%.02d_mod_abs"
-#define MODULE_RXLOS_FORMAT          "/sys/bus/i2c/devices/2-0076/p%.02d_rx_los"
+#define MODULE_PRESENT_FORMAT        "/sys/bus/i2c/devices/0-0076/p%.02d_mod_abs"
+#define MODULE_RXLOS_FORMAT          "/sys/bus/i2c/devices/0-0076/p%.02d_rx_los"
 #define PORT_EEPROM_FORMAT           "/sys/bus/i2c/devices/%d-0050/eeprom"
 #define PORT_GPIO_RXLOS_OFFSET   1
 
 int port_mapping_i2c_busl_table[NUM_OF_SFP_PORT] =
 {
-    19, 20, 21, 22, 23, 24, 25, 26,
-	27, 28, 29, 30, 31, 32, 33, 34,
-	35, 36, 37, 38, 39, 40, 41, 42,
-	43, 44, 45, 46, 47, 48, 49, 50,
-	51, 52, 53, 54, 55, 56, 57, 58,
-	59, 60, 61, 62, 63, 64, 65, 66
+    12, 13, 14, 15, 16, 17, 18, 19,
+	21, 22, 23, 24, 25, 26, 27, 28,
+	30, 31, 32, 33, 34, 35, 36, 37,
+	39, 40, 41, 42, 43, 44, 45, 46,
+	48, 49, 50, 51, 52, 53, 54, 55,
+	57, 58, 59, 60, 61, 62, 63, 64
 };
 
 /************************************************************

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/sysi.c
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/onlp/builds/arm64_qsd61-aom-a-48/module/src/sysi.c
@@ -59,13 +59,13 @@ static int manage_fans_status = MANAGE_FANS_STA_INIT;
 
 static char arr_cpldcap_name[NUM_OF_CPLD][64] =
 {
-   "2-0077/cpld1_rev_cap",
-   "2-0076/cpld2_rev_cap"
+   "0-0077/cpld1_rev_cap",
+   "0-0076/cpld2_rev_cap"
 };
 static char arr_cpldsub_name[NUM_OF_CPLD][64] =
 {
-   "2-0077/cpld1_rev_sub",
-   "2-0076/cpld2_rev_sub"
+   "0-0077/cpld1_rev_sub",
+   "0-0076/cpld2_rev_sub"
 };
 
 const char*

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/platform-config/r0/src/lib/arm64-wnc-qsd61-aom-a-48-r0.yml
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/platform-config/r0/src/lib/arm64-wnc-qsd61-aom-a-48-r0.yml
@@ -9,10 +9,10 @@
 arm64-wnc-qsd61-aom-a-48-r0:
   flat_image_tree:
     kernel:
-      <<: *arm64-kernel-5-6
+      <<: *arm64-kernel-5-10
     dtb:
       =: wnc-qsd61-aom-a-48.dtb
-      <<: *arm64-kernel-5-6-package
+      <<: *arm64-kernel-5-10-package
     itb:
       <<: *arm64-itb
 
@@ -50,5 +50,5 @@ arm64-wnc-qsd61-aom-a-48-r0:
   network:
     interfaces:
       ma1:
-        name: eth2
+        name: eth0
 

--- a/packages/platforms/wnc/arm64/qsd61-aom-a-48/platform-config/r0/src/python/arm64_wnc_qsd61_aom_a_48_r0/__init__.py
+++ b/packages/platforms/wnc/arm64/qsd61-aom-a-48/platform-config/r0/src/python/arm64_wnc_qsd61_aom_a_48_r0/__init__.py
@@ -13,34 +13,21 @@ class OnlPlatform_arm64_wnc_qsd61_aom_a_48_r0(OnlPlatformWNC,
 
         self.insmod("qsd61-aom-a-48-sys_cpld")
         self.insmod("qsd61-aom-a-48-sfp_plus_cpld")
+        self.insmod("qsd61-aom-a-48-gpio_i2c")
         self.insmod("optoe")
 
         self.new_i2c_devices([
-                ('pca9548', 0x70, 0),
-                ('pca9548', 0x70, 1),
-                ('24c02', 0x54, 3),
                 ('lm75', 0x48, 6),
                 ('lm75', 0x49, 7),
                 ('lm75', 0x4A, 8),
-                ('pca9548', 0x71, 11),
-                ('pca9548', 0x72, 12),
-                ('pca9548', 0x73, 13),
-                ('pca9548', 0x74, 14),
-                ('pca9548', 0x75, 15),
-                ('pca9548', 0x76, 16),
                 ])
 
-        port_num = [19, 20, 21, 22, 23, 24, 25, 26, \
-                27, 28, 29, 30, 31, 32, 33, 34,\
-                35, 36, 37, 38, 39, 40, 41, 42,\
-                43, 44, 45, 46, 47, 48, 49, 50,\
-                51, 52, 53, 54, 55, 56, 57, 58,\
-                59, 60, 61, 62, 63, 64, 65, 66]
-
-        for port in port_num:
-            self.new_i2c_devices([
-                ('optoe2', 0x50, port),
-                ])
+        port_num = [12, 13, 14, 15, 16, 17, 18, 19, \
+                21, 22, 23, 24, 25, 26, 27, 28,\
+                30, 31, 32, 33, 34, 35, 36, 37,\
+                39, 40, 41, 42, 43, 44, 45, 46,\
+                48, 49, 50, 51, 52, 53, 54, 55,\
+                57, 58, 59, 60, 61, 62, 63, 64]
 
         #CP_MPP 6 CPLD1 interrupt
         subprocess.call('echo 38 > /sys/class/gpio/export', shell=True)
@@ -80,8 +67,21 @@ class OnlPlatform_arm64_wnc_qsd61_aom_a_48_r0(OnlPlatformWNC,
 
 
         self.new_i2c_devices([
-                        ('qsd61_48_sys_cpld1', 0x77, 2),
-                        ('qsd61_48_sfp_cpld2', 0x76, 2),
+                        ('qsd61_48_sys_cpld1', 0x77, 0),
+                        ('qsd61_48_sfp_cpld2', 0x76, 0),
                         ])
+
+        # Insert Marvell prestera modules by only probing prestera_pci module
+        self.modprobe('prestera_pci')
+
+        # set up systemctl rules
+        for swp in range(1, 49):
+           cmd = "systemctl enable switchdev-online@swp%d" % swp
+        subprocess.check_call(cmd, shell=True)
+
+        for port in port_num:
+            self.new_i2c_devices([
+                ('optoe2', 0x50, port),
+                ])
 
         return True


### PR DESCRIPTION
Upgrade kernel version to 5.10 on QSD61_AOM_A_48 and QSA72_AOM_A_48P platform to support Prestera Switchdev v2.8.0 driver.
WNC platform uses the Prestera Switchdev v2.8.0 driver, and each port interface can be accessed through ethtool.

Test logs as below:
[dentOS_wnc_qsa72_aom_a_48p_support_ethtool_0429_2021.txt](https://github.com/dentproject/dentOS/files/6396970/dentOS_wnc_qsa72_aom_a_48p_support_ethtool_0429_2021.txt)
[dentOS_wnc_qsd61_aom_a_48_support_ethtool_0429_2021.txt](https://github.com/dentproject/dentOS/files/6396971/dentOS_wnc_qsd61_aom_a_48_support_ethtool_0429_2021.txt)

Signed-off-by: Clement Chu <Clement.Chu@wnc.com.tw>