### PR TITLE
Marvell-1G support 2500_BaseT, Kernel 5.10.4

### DIFF
--- a/packages/base/any/kernels/5.10-lts/patches/0024-kernel-5-10-4-comphy-support-2500-BaseT.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0024-kernel-5-10-4-comphy-support-2500-BaseT.patch
@@ -1,0 +1,103 @@
+diff --git a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+index cea886c5b..f53251c62 100644
+--- a/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
++++ b/drivers/net/ethernet/marvell/mvpp2/mvpp2_main.c
+@@ -1300,6 +1300,7 @@ static int mvpp22_gop_init(struct mvpp2_port *port)
+ 	case PHY_INTERFACE_MODE_SGMII:
+ 	case PHY_INTERFACE_MODE_1000BASEX:
+ 	case PHY_INTERFACE_MODE_2500BASEX:
++	case PHY_INTERFACE_MODE_2500BASET:
+ 		mvpp22_gop_init_sgmii(port);
+ 		break;
+ 	case PHY_INTERFACE_MODE_10GBASER:
+@@ -1338,7 +1339,8 @@ static void mvpp22_gop_unmask_irq(struct mvpp2_port *port)
+ 
+ 	if (phy_interface_mode_is_rgmii(port->phy_interface) ||
+ 	    phy_interface_mode_is_8023z(port->phy_interface) ||
+-	    port->phy_interface == PHY_INTERFACE_MODE_SGMII) {
++	    port->phy_interface == PHY_INTERFACE_MODE_SGMII ||
++		port->phy_interface == PHY_INTERFACE_MODE_2500BASET) {
+ 		/* Enable the GMAC link status irq for this port */
+ 		val = readl(port->base + MVPP22_GMAC_INT_SUM_MASK);
+ 		val |= MVPP22_GMAC_INT_SUM_MASK_LINK_STAT;
+@@ -1369,7 +1371,8 @@ static void mvpp22_gop_mask_irq(struct mvpp2_port *port)
+ 
+ 	if (phy_interface_mode_is_rgmii(port->phy_interface) ||
+ 	    phy_interface_mode_is_8023z(port->phy_interface) ||
+-	    port->phy_interface == PHY_INTERFACE_MODE_SGMII) {
++	    port->phy_interface == PHY_INTERFACE_MODE_SGMII ||
++		port->phy_interface == PHY_INTERFACE_MODE_2500BASET) {
+ 		val = readl(port->base + MVPP22_GMAC_INT_SUM_MASK);
+ 		val &= ~MVPP22_GMAC_INT_SUM_MASK_LINK_STAT;
+ 		writel(val, port->base + MVPP22_GMAC_INT_SUM_MASK);
+@@ -3082,7 +3085,8 @@ static void mvpp2_isr_handle_gmac_internal(struct mvpp2_port *port)
+ 
+ 	if (phy_interface_mode_is_rgmii(port->phy_interface) ||
+ 	    phy_interface_mode_is_8023z(port->phy_interface) ||
+-	    port->phy_interface == PHY_INTERFACE_MODE_SGMII) {
++	    port->phy_interface == PHY_INTERFACE_MODE_SGMII ||
++		port->phy_interface == PHY_INTERFACE_MODE_2500BASET) {
+ 		val = readl(port->base + MVPP22_GMAC_INT_STAT);
+ 		if (val & MVPP22_GMAC_INT_STAT_LINK) {
+ 			val = readl(port->base + MVPP2_GMAC_STATUS0);
+@@ -5742,6 +5746,7 @@ static void mvpp2_gmac_pcs_get_state(struct phylink_pcs *pcs,
+ 		state->speed = SPEED_1000;
+ 		break;
+ 	case PHY_INTERFACE_MODE_2500BASEX:
++	case PHY_INTERFACE_MODE_2500BASET:
+ 		state->speed = SPEED_2500;
+ 		break;
+ 	default:
+@@ -5907,6 +5912,9 @@ static void mvpp2_phylink_validate(struct phylink_config *config,
+ 			phylink_set(mask, 2500baseX_Full);
+ 		}
+ 		break;
++	case PHY_INTERFACE_MODE_2500BASET:
++		phylink_set(mask, 2500baseT_Full);
++		break;
+ 	default:
+ 		goto empty_set;
+ 	}
+@@ -5963,7 +5971,8 @@ static void mvpp2_gmac_config(struct mvpp2_port *port, unsigned int mode,
+ 		ctrl4 |= MVPP22_CTRL4_SYNC_BYPASS_DIS |
+ 			 MVPP22_CTRL4_DP_CLK_SEL |
+ 			 MVPP22_CTRL4_QSGMII_BYPASS_ACTIVE;
+-	} else if (state->interface == PHY_INTERFACE_MODE_SGMII) {
++	} else if (state->interface == PHY_INTERFACE_MODE_SGMII ||
++		   state->interface == PHY_INTERFACE_MODE_2500BASET) {
+ 		ctrl2 |= MVPP2_GMAC_PCS_ENABLE_MASK | MVPP2_GMAC_INBAND_AN_MASK;
+ 		ctrl4 &= ~MVPP22_CTRL4_EXT_PIN_GMII_SEL;
+ 		ctrl4 |= MVPP22_CTRL4_SYNC_BYPASS_DIS |
+@@ -5984,7 +5993,8 @@ static void mvpp2_gmac_config(struct mvpp2_port *port, unsigned int mode,
+ 	} else if (state->interface == PHY_INTERFACE_MODE_SGMII) {
+ 		/* SGMII in-band mode receives the speed and duplex from
+ 		 * the PHY. Flow control information is not received. */
+-	} else if (phy_interface_mode_is_8023z(state->interface)) {
++	} else if (phy_interface_mode_is_8023z(state->interface) ||
++		   state->interface == PHY_INTERFACE_MODE_2500BASET) {
+ 		/* 1000BaseX and 2500BaseX ports cannot negotiate speed nor can
+ 		 * they negotiate duplex: they are always operating with a fixed
+ 		 * speed of 1000/2500Mbps in full duplex, so force 1000/2500
+diff --git a/include/linux/phy.h b/include/linux/phy.h
+old mode 100644
+new mode 100755
+index 56563e5e0..84dc637e4
+--- a/include/linux/phy.h
++++ b/include/linux/phy.h
+@@ -137,6 +137,7 @@ typedef enum {
+ 	PHY_INTERFACE_MODE_TRGMII,
+ 	PHY_INTERFACE_MODE_1000BASEX,
+ 	PHY_INTERFACE_MODE_2500BASEX,
++	PHY_INTERFACE_MODE_2500BASET,
+ 	PHY_INTERFACE_MODE_RXAUI,
+ 	PHY_INTERFACE_MODE_XAUI,
+ 	/* 10GBASE-R, XFI, SFI - single lane 10G Serdes */
+@@ -207,6 +208,8 @@ static inline const char *phy_modes(phy_interface_t interface)
+ 		return "1000base-x";
+ 	case PHY_INTERFACE_MODE_2500BASEX:
+ 		return "2500base-x";
++	case PHY_INTERFACE_MODE_2500BASET:
++		return "2500base-t";
+ 	case PHY_INTERFACE_MODE_RXAUI:
+ 		return "rxaui";
+ 	case PHY_INTERFACE_MODE_XAUI:

--- a/packages/base/any/kernels/5.10-lts/patches/0025-kernel-5-10-4-marvell10G-support-2500-BaseT.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0025-kernel-5-10-4-marvell10G-support-2500-BaseT.patch
@@ -1,0 +1,58 @@
+From b7dc1d4800a9d2445cb53426839541363398d20a Mon Sep 17 00:00:00 2001
+From: paulchen040968 <paul.chen@wtmec.com>
+Date: Tue, 25 May 2021 23:12:06 +0800
+Subject: [PATCH 4/4] kernel 5.10.4 marvell10G support 2500_BaseT
+
+
+diff --git a/drivers/net/phy/marvell10g.c b/drivers/net/phy/marvell10g.c
+old mode 100644
+new mode 100755
+index 1901ba2..7c6112c
+--- a/drivers/net/phy/marvell10g.c
++++ b/drivers/net/phy/marvell10g.c
+@@ -263,10 +263,10 @@ static int mv3310_power_up(struct phy_device *phydev)
+ 	ret = phy_clear_bits_mmd(phydev, MDIO_MMD_VEND2, MV_V2_PORT_CTRL,
+ 				 MV_V2_PORT_CTRL_PWRDOWN);
+ 
+-	if (phydev->drv->phy_id != MARVELL_PHY_ID_88X3310 ||
++	/*if (phydev->drv->phy_id != MARVELL_PHY_ID_88X3310 ||
+ 	    priv->firmware_ver < 0x00030000)
+ 		return ret;
+-
++	*/
+ 	return phy_set_bits_mmd(phydev, MDIO_MMD_VEND2, MV_V2_PORT_CTRL,
+ 				MV_V2_PORT_CTRL_SWRST);
+ }
+@@ -462,9 +462,10 @@ static int mv3310_config_init(struct phy_device *phydev)
+ 	/* Check that the PHY interface type is compatible */
+ 	if (phydev->interface != PHY_INTERFACE_MODE_SGMII &&
+ 	    phydev->interface != PHY_INTERFACE_MODE_2500BASEX &&
++		phydev->interface != PHY_INTERFACE_MODE_2500BASET &&
+ 	    phydev->interface != PHY_INTERFACE_MODE_XAUI &&
+ 	    phydev->interface != PHY_INTERFACE_MODE_RXAUI &&
+-	    phydev->interface != PHY_INTERFACE_MODE_10GBASER)
++	    phydev->interface != PHY_INTERFACE_MODE_10GKR)
+ 		return -ENODEV;
+ 
+ 	phydev->mdix_ctrl = ETH_TP_MDI_AUTO;
+@@ -598,7 +599,7 @@ static void mv3310_update_interface(struct phy_device *phydev)
+ 	}
+ 
+ 	if ((phydev->interface == PHY_INTERFACE_MODE_SGMII ||
+-	     phydev->interface == PHY_INTERFACE_MODE_2500BASEX ||
++	     phydev->interface == PHY_INTERFACE_MODE_2500BASET ||
+ 	     phydev->interface == PHY_INTERFACE_MODE_10GBASER) &&
+ 	    phydev->link) {
+ 		/* The PHY automatically switches its serdes interface (and
+@@ -612,7 +613,7 @@ static void mv3310_update_interface(struct phy_device *phydev)
+ 			phydev->interface = PHY_INTERFACE_MODE_10GBASER;
+ 			break;
+ 		case SPEED_2500:
+-			phydev->interface = PHY_INTERFACE_MODE_2500BASEX;
++			phydev->interface = PHY_INTERFACE_MODE_2500BASET;
+ 			break;
+ 		case SPEED_1000:
+ 		case SPEED_100:
+-- 
+2.7.4
+

--- a/packages/base/any/kernels/5.10-lts/patches/series.arm64
+++ b/packages/base/any/kernels/5.10-lts/patches/series.arm64
@@ -16,3 +16,5 @@
 0020-accton-as5114.patch
 0021-tn48m-add-sfp-eeprom-support-to-ethtool.patch
 0022-delta-tn48m-dn-series-dts.patch
+0023-kernel-5-10-4-comphy-support-2500-BaseT.patch
+0024-kernel-5-10-4-marvell10G-support-2500-BaseT.patch


### PR DESCRIPTION
Introduced by Simon Miao, Staff FAE, Processors and Security in Marvell
Confirmed on Marvell A7K DB platform.

Signed-off-by: Mickey Rachamim <mickeyr@marvell.com>