### PR TITLE
[as4564-26p] Add thermal policy (auto fan controller)

### DIFF
--- a/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/Makefile
+++ b/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/Makefile
@@ -1,4 +1,6 @@
 obj-m += arm64-accton-as4564-26p-cpld.o
 obj-m += arm64-accton-as4564-26p-gpio-i2c.o
 obj-m += arm64-accton-as4564-26p-psu.o
+obj-m += arm64-accton-as4564-26p-fan.o
+obj-m += arm64-accton-as4564-26p-thermal.o
 obj-m += optoe.o

--- a/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/arm64-accton-as4564-26p-fan.c
+++ b/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/arm64-accton-as4564-26p-fan.c
@@ -1,0 +1,527 @@
+/*
+ * A hwmon driver for the Accton as9926 24d fan
+ *
+ * Copyright (C) 2016 Accton Technology Corporation.
+ * Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/dmi.h>
+#include <linux/platform_device.h>
+#include <linux/delay.h>
+
+#define DRVNAME "as4564_fan"
+
+#define BOARD_INFO_REG_OFFSET 0x00
+#define FAN_STATUS_I2C_ADDR 0x40
+#define MAX_FAN_SPEED_RPM 10670
+#define FAN_DUTY_CYCLE_REG_MASK 0xFF
+#define FAN_MAX_DUTY_CYCLE 100
+#define FAN_REG_VAL_TO_SPEED_RPM_STEP 100
+
+static struct as4564_fan_data *as4564_fan_update_device(struct device *dev);
+static ssize_t fan_show_value(struct device *dev, struct device_attribute *da,
+		char *buf);
+static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t count);
+static ssize_t show_wtd(struct device *dev, struct device_attribute *da,
+		char *buf);
+static ssize_t set_wtd(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t count);
+static int _reset_wtd(void);
+static ssize_t reset_wtd(struct device *dev, struct device_attribute *da,
+		const char *buf, size_t count);
+extern int as4564_26p_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int as4564_26p_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+
+static struct as4564_fan_data *data = NULL;
+
+/* fan related data, the index should match sysfs_fan_attributes
+ */
+static const u8 fan_reg[] = {
+	0x70,	   /* fan1 PWM */
+	0x71,	   /* fan2 PWM */
+	0x80,	   /* fan 1 tach speed */
+	0x81,	   /* fan 2 tach speed */
+	0x62,	  /* fan tech speed setting */
+};
+
+/* fan data */
+struct as4564_fan_data {
+	struct platform_device *pdev;
+	struct device *hwmon_dev;
+	struct mutex update_lock;
+	char valid; /* != 0 if registers are valid */
+	unsigned long last_updated; /* In jiffies */
+	u8 reg_val[ARRAY_SIZE(fan_reg)]; /* Register value */
+};
+
+enum fan_id {
+	FAN1_ID,
+	FAN2_ID
+};
+
+enum sysfs_fan_attributes {
+	FAN1_PWM,
+	FAN2_PWM,
+	FAN1_SPEED_RPM,
+	FAN2_SPEED_RPM,
+	FAN_TECH_SETTING,
+	FAN1_FAULT,
+	FAN2_FAULT,
+	FAN_MAX_RPM,
+	WTD_CLOCK,
+	WTD_COUNTER,
+	WTD_ENABLE,
+	WTD_RESET
+};
+
+/* sysfs attributes for hwmon
+ */
+static SENSOR_DEVICE_ATTR(fan_max_rpm, S_IRUGO, fan_show_value, NULL,
+			FAN_MAX_RPM);
+
+/* Fan watchdog */
+static SENSOR_DEVICE_ATTR(wtd_clock, S_IRUGO | S_IWUSR, show_wtd, set_wtd,
+			WTD_CLOCK);
+static SENSOR_DEVICE_ATTR(wtd_counter, S_IRUGO | S_IWUSR, show_wtd, set_wtd,
+			WTD_COUNTER);
+static SENSOR_DEVICE_ATTR(wtd_enable, S_IRUGO | S_IWUSR, show_wtd, set_wtd,
+			WTD_ENABLE);
+static SENSOR_DEVICE_ATTR(wtd_reset, S_IWUSR, NULL, reset_wtd, WTD_RESET);
+
+static struct attribute *fan_attributes_common[] = {
+	&sensor_dev_attr_fan_max_rpm.dev_attr.attr,
+	&sensor_dev_attr_wtd_clock.dev_attr.attr,
+	&sensor_dev_attr_wtd_counter.dev_attr.attr,
+	&sensor_dev_attr_wtd_enable.dev_attr.attr,
+	&sensor_dev_attr_wtd_reset.dev_attr.attr,
+	NULL
+};
+
+#define FAN_ATTRS_COMMON() { .attrs = fan_attributes_common }
+
+#define FAN_ATTRS(fid) \
+static SENSOR_DEVICE_ATTR(fan##fid##_pwm, \
+	S_IWUSR | S_IRUGO, fan_show_value, set_duty_cycle, \
+	FAN##fid##_PWM); \
+static SENSOR_DEVICE_ATTR(fan##fid##_input, S_IRUGO, fan_show_value, \
+	NULL, FAN##fid##_SPEED_RPM); \
+static SENSOR_DEVICE_ATTR(fan##fid##_fault, S_IRUGO, fan_show_value, \
+	NULL, FAN##fid##_FAULT); \
+static struct attribute *fan_attributes##fid[] = { \
+	&sensor_dev_attr_fan##fid##_pwm.dev_attr.attr, \
+	&sensor_dev_attr_fan##fid##_input.dev_attr.attr, \
+	&sensor_dev_attr_fan##fid##_fault.dev_attr.attr, \
+	NULL \
+}
+
+FAN_ATTRS(1);
+FAN_ATTRS(2);
+
+#define FAN_ATTR_GROUP(fid)  { .attrs = fan_attributes##fid }
+
+static struct attribute_group fan_group[] = {
+	FAN_ATTRS_COMMON(),
+	FAN_ATTR_GROUP(1),
+	FAN_ATTR_GROUP(2),
+};
+
+static int as4564_fan_read_value(u8 reg)
+{
+	return as4564_26p_cpld_read(FAN_STATUS_I2C_ADDR, reg);
+}
+
+static int as4564_fan_write_value(u8 reg, u8 value)
+{
+	return as4564_26p_cpld_write(FAN_STATUS_I2C_ADDR, reg, value);
+}
+
+/* fan utility functions
+ */
+static u32 reg_val_to_duty_cycle(u8 reg_val)
+{
+	reg_val &= FAN_DUTY_CYCLE_REG_MASK;
+	return ((((u32)reg_val * 10000 / 255) + 50) / 100);
+}
+
+static u8 duty_cycle_to_reg_val(u8 duty_cycle)
+{
+	return (duty_cycle * 255 / 100);
+}
+
+static u32 reg_val_to_speed_rpm(u8 reg_val, u8 tech_reg_val)
+{
+	u32 timer[] = { 1048, 2097, 4194, 8389 };
+	u8 counter = (tech_reg_val & 0x3F);
+	u8 clock   = (tech_reg_val >> 6) & 0x3;
+
+	return (reg_val * 3000000) / (timer[clock] * counter);
+}
+
+static u8 is_fan_fault(struct as4564_fan_data *data, enum fan_id id)
+{
+	return !reg_val_to_speed_rpm(data->reg_val[FAN1_SPEED_RPM + id],
+					data->reg_val[FAN_TECH_SETTING]);
+}
+
+static ssize_t set_duty_cycle(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+	int error, value;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+
+	error = kstrtoint(buf, 10, &value);
+	if (error)
+		return error;
+
+	if (value < 10)
+		value = 10;
+	else if (value > 100)
+		value = 100;
+
+	/* Disable the watchdog timer
+	 */
+	error = _reset_wtd();
+	if (unlikely(error < 0)) {
+		dev_dbg(dev, "Unable to reset the watchdog timer\n");
+		return error;
+	}
+
+	as4564_fan_write_value(fan_reg[attr->index - FAN1_PWM],
+				duty_cycle_to_reg_val(value));
+	data->valid = 0;
+
+	return count;
+}
+
+static ssize_t fan_show_value(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct as4564_fan_data *data = as4564_fan_update_device(dev);
+	ssize_t ret = 0;
+
+	if (data->valid) {
+		switch (attr->index) {
+		case FAN1_PWM:
+		case FAN2_PWM:
+			ret = sprintf(buf, "%u\n",
+			reg_val_to_duty_cycle(data->reg_val[attr->index]));
+			break;
+		case FAN1_SPEED_RPM:
+		case FAN2_SPEED_RPM:
+			ret = sprintf(buf, "%u\n",
+				reg_val_to_speed_rpm(data->reg_val[attr->index],
+					data->reg_val[FAN_TECH_SETTING]));
+			break;
+		case FAN1_FAULT:
+		case FAN2_FAULT:
+			ret = sprintf(buf, "%d\n",
+				is_fan_fault(data, attr->index - FAN1_FAULT));
+			break;
+		case FAN_MAX_RPM:
+			ret = sprintf(buf, "%d\n", MAX_FAN_SPEED_RPM);
+			break;
+		default:
+			break;
+		}
+	}
+
+	return ret;
+}
+
+static ssize_t show_wtd(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	int status = 0;
+	u8 reg = 0, mask = 0;
+
+	switch (attr->index) {
+	case WTD_ENABLE:
+		reg  = 0x60;
+		mask = 0x01;
+		break;
+	case WTD_CLOCK:
+		reg  = 0x61;
+		mask = 0xC0;
+		break;
+	case WTD_COUNTER:
+		reg  = 0x61;
+		mask = 0x3F;
+		break;
+	default:
+		return 0;
+	}
+
+	mutex_lock(&data->update_lock);
+	status = as4564_fan_read_value(reg);
+	if (unlikely(status < 0))
+		goto exit;
+	mutex_unlock(&data->update_lock);
+
+	while (!(mask & 0x1)) {
+		status >>= 1;
+		mask >>= 1;
+	}
+
+	return sprintf(buf, "%d\n", (status & mask));
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
+}
+
+#define VALIDATE_WTD_VAL_RETURN(value, mask) \
+	do { \
+		if (value & ~mask) \
+			return -EINVAL; \
+	} while (0)
+
+static ssize_t set_wtd(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	long value;
+	int status;
+	u8 reg = 0, mask = 0;
+
+	status = kstrtol(buf, 10, &value);
+	if (status)
+		return status;
+
+	switch (attr->index) {
+	case WTD_ENABLE:
+		reg  = 0x60;
+		mask = 0x01;
+		value &= mask;
+		VALIDATE_WTD_VAL_RETURN(value, mask);
+		break;
+	case WTD_CLOCK:
+		reg  = 0x61;
+		mask = 0xC0;
+		value <<= 6;
+		VALIDATE_WTD_VAL_RETURN(value, mask);
+		break;
+	case WTD_COUNTER:
+		reg  = 0x61;
+		mask = 0x3F;
+		value &= mask;
+		VALIDATE_WTD_VAL_RETURN(value, mask);
+		break;
+	default:
+		return 0;
+	}
+
+	/* Read current status */
+	mutex_lock(&data->update_lock);
+
+	status = as4564_fan_read_value(reg);
+	if (unlikely(status < 0))
+		goto exit;
+
+	/* Update wtd status */
+	status = (value & mask) | (status & ~mask);
+	status = as4564_fan_write_value(reg, status);
+	if (unlikely(status < 0))
+		goto exit;
+
+	mutex_unlock(&data->update_lock);
+	return count;
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return status;
+}
+
+static int _reset_wtd(void)
+{
+	int status;
+
+	/* Set value as 0->1 to reset wtd */
+	status = as4564_fan_write_value(0x60, 0);
+	if (unlikely(status < 0))
+		return status;
+
+	msleep(50);
+	status = as4564_fan_write_value(0x60, 1);
+	if (unlikely(status < 0))
+		return status;
+
+	return status;
+}
+
+static ssize_t reset_wtd(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+	long value;
+	int status;
+
+	status = kstrtol(buf, 10, &value);
+	if (status)
+		return status;
+
+	if (!value)
+		return count;
+
+	/* Read current status */
+	mutex_lock(&data->update_lock);
+
+	status = _reset_wtd();
+	if (unlikely(status < 0)) {
+		dev_dbg(dev, "Unable to reset the watchdog timer\n");
+		return status;
+	}
+
+	mutex_unlock(&data->update_lock);
+	return count;
+}
+
+static struct as4564_fan_data *as4564_fan_update_device(struct device *dev)
+{
+	mutex_lock(&data->update_lock);
+
+	if (time_after(jiffies, data->last_updated + HZ + HZ / 2) ||
+		!data->valid) {
+		int i;
+
+		dev_dbg(dev, "Starting as4564_fan update\n");
+		data->valid = 0;
+
+		/* Update fan data
+		 */
+		for (i = 0; i < ARRAY_SIZE(data->reg_val); i++) {
+			int status = as4564_fan_read_value(fan_reg[i]);
+
+			if (status < 0) {
+				data->valid = 0;
+				mutex_unlock(&data->update_lock);
+				dev_dbg(dev, "reg %d, err %d\n",
+						fan_reg[i], status);
+				return data;
+			}
+			else {
+				data->reg_val[i] = status;
+			}
+		}
+
+		data->last_updated = jiffies;
+		data->valid = 1;
+	}
+
+	mutex_unlock(&data->update_lock);
+
+	return data;
+}
+
+static int as4564_fan_probe(struct platform_device *pdev)
+{
+	int status = -1;
+	int i = 0;
+
+	/* Register sysfs hooks */
+	for (i = 0; i < ARRAY_SIZE(fan_group); i++) {
+		/* Register sysfs hooks */
+		status = sysfs_create_group(&pdev->dev.kobj, &fan_group[i]);
+		if (status) {
+			goto exit;
+		}
+	}
+
+	dev_info(&pdev->dev, "device created\n");
+
+	return 0;
+
+exit:
+	for (--i; i >= 0; i--) {
+		sysfs_remove_group(&pdev->dev.kobj, &fan_group[i]);
+	}
+	return status;
+}
+
+static int as4564_fan_remove(struct platform_device *pdev)
+{
+	int i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(fan_group); i++) {
+		sysfs_remove_group(&pdev->dev.kobj, &fan_group[i]);
+	}
+
+	return 0;
+}
+
+static struct platform_driver as4564_fan_driver = {
+	.probe	  = as4564_fan_probe,
+	.remove	 = as4564_fan_remove,
+	.driver	 = {
+		.name   = DRVNAME,
+		.owner  = THIS_MODULE,
+	},
+};
+
+static int __init as4564_fan_init(void)
+{
+	int ret;
+
+	data = kzalloc(sizeof(struct as4564_fan_data), GFP_KERNEL);
+	if (!data) {
+		ret = -ENOMEM;
+		goto alloc_err;
+	}
+
+	mutex_init(&data->update_lock);
+
+	ret = platform_driver_register(&as4564_fan_driver);
+	if (ret < 0)
+		goto dri_reg_err;
+
+	data->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+	if (IS_ERR(data->pdev)) {
+		ret = PTR_ERR(data->pdev);
+		goto dev_reg_err;
+	}
+
+	return 0;
+
+dev_reg_err:
+	platform_driver_unregister(&as4564_fan_driver);
+dri_reg_err:
+	kfree(data);
+alloc_err:
+	return ret;
+}
+
+static void __exit as4564_fan_exit(void)
+{
+	platform_device_unregister(data->pdev);
+	platform_driver_unregister(&as4564_fan_driver);
+	kfree(data);
+}
+
+module_init(as4564_fan_init);
+module_exit(as4564_fan_exit);
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("as4564_fan driver");
+MODULE_LICENSE("GPL");

--- a/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/arm64-accton-as4564-26p-thermal.c
+++ b/packages/platforms/accton/arm64/as4564-26p/modules/builds/src/arm64-accton-as4564-26p-thermal.c
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C)  Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on:
+ *	pca954x.c from Kumar Gala <galak@kernel.crashing.org>
+ * Copyright (C) 2006
+ *
+ * Based on:
+ *	pca954x.c from Ken Harrenstien
+ * Copyright (C) 2004 Google, Inc. (Ken Harrenstien)
+ *
+ * Based on:
+ *	i2c-virtual_cb.c from Brian Kuschak <bkuschak@yahoo.com>
+ * and
+ *	pca9540.c from Jean Delvare <khali@linux-fr.org>.
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2. This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/slab.h>
+#include <linux/device.h>
+#include <linux/version.h>
+#include <linux/stat.h>
+#include <linux/sysfs.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/platform_device.h>
+#include <linux/io.h>
+
+#define DRVNAME "as4564_thermal"
+#define A7K_TEMP_ADDRESS 0xF06F808C
+
+static ssize_t show_temp(struct device *dev, struct device_attribute *attr,
+	char *buf);
+static int as4564_26p_thermal_probe(struct platform_device *pdev);
+static int as4564_26p_thermal_remove(struct platform_device *pdev);
+
+enum temp_data_index {
+	TEMP_INPUT
+};
+
+struct as4564_26p_thermal_data {
+	struct platform_device *pdev;
+	struct mutex update_lock;
+	unsigned long last_updated;	/* In jiffies */
+	u32 __iomem *hw_addr;
+	unsigned int reg_value;
+};
+
+struct as4564_26p_thermal_data *data = NULL;
+
+static struct platform_driver as4564_26p_thermal_driver = {
+	.probe = as4564_26p_thermal_probe,
+	.remove = as4564_26p_thermal_remove,
+	.driver = {
+		.name = DRVNAME,
+		.owner = THIS_MODULE,
+	},
+};
+
+enum as4564_26p_thermal_sysfs_attrs {
+	TEMP1_INPUT
+};
+
+#define DECLARE_THERMAL_SENSOR_DEVICE_ATTR(index) \
+	static SENSOR_DEVICE_ATTR(temp##index##_input, S_IRUGO, show_temp, \
+					NULL, TEMP##index##_INPUT)
+
+#define DECLARE_THERMAL_ATTR(index) \
+	&sensor_dev_attr_temp##index##_input.dev_attr.attr
+
+DECLARE_THERMAL_SENSOR_DEVICE_ATTR(1);
+
+static struct attribute *as4564_26p_thermal_attributes[] = {
+	DECLARE_THERMAL_ATTR(1),
+	NULL
+};
+
+static const struct attribute_group as4564_26p_thermal_group = {
+	.attrs = as4564_26p_thermal_attributes,
+};
+
+static int twos_complement_to_int(u16 data, u8 valid_bit, int mask)
+{
+    u16  valid_data  = data & mask;
+    bool is_negative = valid_data >> (valid_bit - 1);
+
+    return is_negative ? (-(((~valid_data) & mask) + 1)) : valid_data;
+}
+
+static int regval_to_temp(u32 reg_val)
+{
+	int value = twos_complement_to_int(reg_val, 10, 0x3FF);
+	return (value * 423 + 150000);
+}
+
+static ssize_t show_temp(struct device *dev, struct device_attribute *da,
+							char *buf)
+{
+	int status = 0;
+
+	mutex_lock(&data->update_lock);
+
+	if (time_after(jiffies, data->last_updated + HZ * 5)) {
+		data->reg_value = ioread32(data->hw_addr);
+		data->last_updated = jiffies;
+	}
+
+	/* Get temperature in degree celsius */
+	status = regval_to_temp(data->reg_value);
+
+	mutex_unlock(&data->update_lock);
+	return sprintf(buf, "%d\n", status);
+}
+
+static int as4564_26p_thermal_probe(struct platform_device *pdev)
+{
+	int status = -1;
+
+	data->hw_addr = ioremap(A7K_TEMP_ADDRESS, 32);
+	if (data->hw_addr == NULL) {
+		status = -ENOMEM;
+		goto exit;
+	}
+
+	/* Register sysfs hooks */
+	status = sysfs_create_group(&pdev->dev.kobj, &as4564_26p_thermal_group);
+	if (status)
+		goto exit_io;
+
+	dev_info(&pdev->dev, "device created\n");
+
+	return 0;
+
+exit_io:
+	iounmap(data->hw_addr);
+exit:
+	return status;
+}
+
+static int as4564_26p_thermal_remove(struct platform_device *pdev)
+{
+	sysfs_remove_group(&pdev->dev.kobj, &as4564_26p_thermal_group);
+	iounmap(data->hw_addr);
+	return 0;
+}
+
+static int __init as4564_26p_thermal_init(void)
+{
+	int ret;
+
+	data = kzalloc(sizeof(struct as4564_26p_thermal_data), GFP_KERNEL);
+	if (!data) {
+		ret = -ENOMEM;
+		goto alloc_err;
+	}
+
+	mutex_init(&data->update_lock);
+
+	ret = platform_driver_register(&as4564_26p_thermal_driver);
+	if (ret < 0)
+		goto dri_reg_err;
+
+	data->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+	if (IS_ERR(data->pdev)) {
+		ret = PTR_ERR(data->pdev);
+		goto dev_reg_err;
+	}
+
+	return 0;
+
+dev_reg_err:
+	platform_driver_unregister(&as4564_26p_thermal_driver);
+dri_reg_err:
+	kfree(data);
+alloc_err:
+	return ret;
+}
+
+static void __exit as4564_26p_thermal_exit(void)
+{
+	platform_device_unregister(data->pdev);
+	platform_driver_unregister(&as4564_26p_thermal_driver);
+	kfree(data);
+}
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("as4564_thermal driver");
+MODULE_LICENSE("GPL");
+
+module_init(as4564_26p_thermal_init);
+module_exit(as4564_26p_thermal_exit);

--- a/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/fani.c
+++ b/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/fani.c
@@ -1,0 +1,194 @@
+/************************************************************
+ * <bsn.cl fy=2014 v=onl>
+ *
+ *           Copyright 2014 Big Switch Networks, Inc.
+ *           Copyright 2014 Accton Technology Corporation.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ * </bsn.cl>
+ ************************************************************
+ *
+ * Fan Platform Implementation Defaults.
+ *
+ ***********************************************************/
+#include <onlplib/file.h>
+#include <onlp/platformi/fani.h>
+#include "platform_lib.h"
+
+#define FAN_RPM_FORMAT           "fan%d_input"
+#define FAN_FAULT_FORMAT         "fan%d_fault"
+#define FAN_PWM_FORMAT           "fan%d_pwm"
+
+enum fan_id {
+    FAN_1_ON_FAN_BOARD = 1,
+    FAN_2_ON_FAN_BOARD,
+    FAN_3_ON_FAN_BOARD,
+    FAN_4_ON_FAN_BOARD,
+    FAN_5_ON_FAN_BOARD,
+    FAN_6_ON_FAN_BOARD,
+};
+
+#define CHASSIS_FAN_INFO(fid)        \
+    { \
+        { ONLP_FAN_ID_CREATE(FAN_##fid##_ON_FAN_BOARD), "Chassis Fan - "#fid, 0 },\
+        0x0,\
+        ONLP_FAN_CAPS_SET_PERCENTAGE | ONLP_FAN_CAPS_GET_RPM | ONLP_FAN_CAPS_GET_PERCENTAGE,\
+        0,\
+        0,\
+        ONLP_FAN_MODE_INVALID,\
+    }
+
+/* Static fan information */
+onlp_fan_info_t finfo[] = {
+    { }, /* Not used */
+    CHASSIS_FAN_INFO(1),
+    CHASSIS_FAN_INFO(2),
+};
+
+#define VALIDATE(_id)                           \
+    do {                                        \
+        if(!ONLP_OID_IS_FAN(_id)) {             \
+            return ONLP_STATUS_E_INVALID;       \
+        }                                       \
+    } while(0)
+
+int
+onlp_fani_get_fan_attr_int(int fid, char *fmt, int *value)
+{
+    char attr_name[32] = {0};
+    sprintf(attr_name, fmt, fid);
+    return onlp_file_read_int(value, "%s%s", FAN_SYSFS_PATH, attr_name);
+}
+
+int
+onlp_fani_set_fan_attr_int(int fid, char *fmt, int value)
+{
+    char attr_name[32] = {0};
+    sprintf(attr_name, fmt, fid);
+    return onlp_file_write_int(value, "%s%s", FAN_SYSFS_PATH, attr_name);
+}
+
+static int
+_onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
+{
+    int value, ret;
+
+    /* get fan present status
+     */
+    info->status |= ONLP_FAN_STATUS_PRESENT;
+
+
+    /* get fan fault status (turn on when any one fails)
+     */
+    ret = onlp_fani_get_fan_attr_int(fid, FAN_FAULT_FORMAT, &value);
+    if (ret < 0) {
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    if (value > 0) {
+        info->status |= ONLP_FAN_STATUS_FAILED;
+    }
+
+
+    /* get fan direction (both : the same)
+     */
+    info->status |= ONLP_FAN_STATUS_F2B;
+
+
+    /* get fan speed
+     */
+    ret = onlp_fani_get_fan_attr_int(fid, FAN_RPM_FORMAT, &value);
+    if (ret < 0) {
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    info->rpm = value;
+
+
+    /* get speed percentage from rpm
+     */
+    ret = onlp_file_read_int(&value, "%s%s", FAN_SYSFS_PATH, "fan_max_rpm");
+    if (ret < 0) {
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    info->percentage = (info->rpm * 100)/value;
+
+    return ONLP_STATUS_OK;
+}
+
+/*
+ * This function will be called prior to all of onlp_fani_* functions.
+ */
+int
+onlp_fani_init(void)
+{
+    return ONLP_STATUS_OK;
+}
+
+int
+onlp_fani_info_get(onlp_oid_t id, onlp_fan_info_t* info)
+{
+    int rc = 0;
+    int fid;
+    VALIDATE(id);
+
+    fid = ONLP_OID_ID_GET(id);
+    *info = finfo[fid];
+
+    switch (fid)
+    {
+        case FAN_1_ON_FAN_BOARD:
+        case FAN_2_ON_FAN_BOARD:
+            rc =_onlp_fani_info_get_fan(fid, info);
+            break;
+        default:
+            rc = ONLP_STATUS_E_INVALID;
+            break;
+    }
+
+    return rc;
+}
+
+/*
+ * This function sets the fan speed of the given OID as a percentage.
+ *
+ * This will only be called if the OID has the PERCENTAGE_SET
+ * capability.
+ *
+ * It is optional if you have no fans at all with this feature.
+ */
+int
+onlp_fani_percentage_set(onlp_oid_t id, int p)
+{
+    int  fid;
+    char *path = NULL;
+
+    VALIDATE(id);
+
+    fid = ONLP_OID_ID_GET(id);
+
+    /* reject p=0 (p=0, stop fan) */
+    if (p == 0){
+        return ONLP_STATUS_E_INVALID;
+    }
+
+    if (onlp_fani_set_fan_attr_int(fid, FAN_PWM_FORMAT, p) != ONLP_STATUS_OK) {
+        AIM_LOG_ERROR("Unable to write data to file (%s)\r\n", path);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    return ONLP_STATUS_OK;
+}

--- a/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/platform_lib.h
+++ b/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/platform_lib.h
@@ -28,14 +28,14 @@
 
 #include "arm64_accton_as4564_26p_log.h"
 
-#define CHASSIS_THERMAL_COUNT	4
+#define CHASSIS_THERMAL_COUNT	5
 #define CHASSIS_LED_COUNT		0
-#define CHASSIS_FAN_COUNT       0
+#define CHASSIS_FAN_COUNT       2
 #define CHASSIS_PSU_COUNT       1
 
 #define CPLD_SYSFS_ATTR_FMT "/sys/bus/i2c/devices/0-0040/%s"
 #define PSU_SYSFS_PATH "/sys/devices/platform/as4564_26p_psu/"
-#define FAN_SYSFS_PATH "/sys/devices/platform/as4564_26p_fan/"
+#define FAN_SYSFS_PATH "/sys/devices/platform/as4564_fan/"
 #define IDPROM_PATH "/sys/class/i2c-adapter/i2c-1/1-0056/eeprom"
 
 enum onlp_thermal_id

--- a/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/sysi.c
+++ b/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/sysi.c
@@ -121,3 +121,187 @@ onlp_sysi_onie_data_free(uint8_t* data)
 {
     aim_free(data);
 }
+
+/*******************************************************************
+ * 1. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) > 133.5 = 30% FAN speed
+ * 2. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) < 131 = 15% FAN speed
+ * 3. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) > 215 = 50% FAN speed
+ * 4.One FAN failure = 60% FAN speed.
+********************************************************************/
+#define FAN_DUTY_ABSENT (60)
+#define FAN_DUTY_MAX (50)
+#define FAN_DUTY_MID (30)
+#define FAN_DUTY_LOW (15)
+#define FAN_DUTY_DEFAULT FAN_DUTY_MID
+
+static int
+sysi_fanctrl_fan_set_duty(int p, int num_of_fan)
+{
+    int i;
+    int status = 0;
+
+    for (i = 1; i <= CHASSIS_FAN_COUNT; i++) {
+        int ret = 0;
+
+        ret = onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(i), p);
+        if (ret < 0) {
+            status = ret;
+        }
+    }
+
+    return status;
+}
+
+static int
+sysi_fanctrl_fan_status_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
+                              onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
+                              int *adjusted,
+                              int num_of_fan)
+{
+    int i;
+    *adjusted = 0;
+
+    /* Bring fan speed to FAN_DUTY_MAX if any fan is not operational */
+    for (i = 0; i < num_of_fan; i++) {
+        if (!(fi[i].status & ONLP_FAN_STATUS_FAILED)) {
+            continue;
+        }
+
+        *adjusted = 1;
+        return sysi_fanctrl_fan_set_duty(60, num_of_fan);
+    }
+
+    /* Bring fan speed to FAN_DUTY_MAX if fan is not present */
+    for (i = 0; i < num_of_fan; i++) {
+        if (fi[i].status & ONLP_FAN_STATUS_PRESENT) {
+            continue;
+        }
+
+        *adjusted = 1;
+        return sysi_fanctrl_fan_set_duty(60, num_of_fan);
+    }
+
+    return ONLP_STATUS_OK;
+}
+
+static int
+sysi_fanctrl_thermal_sensor_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
+                                onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
+                                int *adjusted,
+                                int num_of_fan)
+{
+    int i;
+    int fanduty;
+    int sum_mcelsius = 0;
+
+    for (i = (THERMAL_1_ON_MAIN_BROAD); i <= (THERMAL_4_ON_MAIN_BROAD); i++) {
+        sum_mcelsius += ti[i-1].mcelsius;
+    }
+
+    *adjusted = 0;
+
+    if (onlp_file_read_int(&fanduty, "%s%s", FAN_SYSFS_PATH, "fan1_pwm") < 0) {
+        *adjusted = 1;
+        return sysi_fanctrl_fan_set_duty(FAN_DUTY_MAX, num_of_fan);
+    }
+
+    switch (fanduty) {
+    case FAN_DUTY_LOW:
+    {
+        if (sum_mcelsius >= 133500) {
+            *adjusted = 1;
+            return sysi_fanctrl_fan_set_duty(FAN_DUTY_MID, num_of_fan);
+        }
+
+        break;
+    }
+    case FAN_DUTY_MID:
+    {
+        if (sum_mcelsius >= 215000) {
+            *adjusted = 1;
+            return sysi_fanctrl_fan_set_duty(FAN_DUTY_MAX, num_of_fan);
+        }
+        else if (sum_mcelsius <= 131000) {
+            *adjusted = 1;
+            return sysi_fanctrl_fan_set_duty(FAN_DUTY_LOW, num_of_fan);
+        }
+
+        break;
+    }
+    case FAN_DUTY_MAX:
+    {
+        if (sum_mcelsius <= 131000) {
+            *adjusted = 1;
+            return sysi_fanctrl_fan_set_duty(FAN_DUTY_LOW, num_of_fan);
+        }
+
+        break;
+    }
+    default:
+        *adjusted = 1;
+        return sysi_fanctrl_fan_set_duty(FAN_DUTY_DEFAULT, num_of_fan);
+    }
+
+    /* Set as current speed to kick watchdog */
+    return sysi_fanctrl_fan_set_duty(fanduty, num_of_fan);
+}
+
+typedef int (*fan_control_policy)(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
+                                onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
+                                int *adjusted,
+                                int num_of_fan);
+
+fan_control_policy fan_control_policies[] = {
+    sysi_fanctrl_fan_status_policy,
+    sysi_fanctrl_thermal_sensor_policy,
+};
+
+int
+onlp_sysi_platform_manage_fans(void)
+{
+    int i, rc;
+    int num_of_fan = CHASSIS_FAN_COUNT;
+    onlp_fan_info_t fi[CHASSIS_FAN_COUNT];
+    onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT];
+
+    memset(fi, 0, sizeof(fi));
+    memset(ti, 0, sizeof(ti));
+
+    /* Get fan status
+     */
+    for (i = 0; i < num_of_fan; i++) {
+        rc = onlp_fani_info_get(ONLP_FAN_ID_CREATE(i+1), &fi[i]);
+
+        if (rc != ONLP_STATUS_OK) {
+            sysi_fanctrl_fan_set_duty(FAN_DUTY_MAX, num_of_fan);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    }
+
+    /* Get thermal sensor status
+     */
+    for (i = 0; i < CHASSIS_THERMAL_COUNT; i++) {
+        rc = onlp_thermali_info_get(ONLP_THERMAL_ID_CREATE(i+1), &ti[i]);
+
+        if (rc != ONLP_STATUS_OK) {
+            sysi_fanctrl_fan_set_duty(FAN_DUTY_MAX, num_of_fan);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    }
+
+    /* Apply thermal policy according the policy list,
+     * If fan duty is adjusted by one of the policies, skip the others
+     */
+    for (i = 0; i < AIM_ARRAYSIZE(fan_control_policies); i++) {
+        int adjusted = 0;
+
+        rc = fan_control_policies[i](fi, ti, &adjusted, num_of_fan);
+        if (!adjusted) {
+            continue;
+        }
+
+        return rc;
+    }
+
+    return ONLP_STATUS_OK;
+}

--- a/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/thermali.c
+++ b/packages/platforms/accton/arm64/as4564-26p/onlp/builds/arm64_accton_as4564_26p/module/src/thermali.c
@@ -41,6 +41,7 @@ static char* devfiles__[] =  /* must map with onlp_thermal_id */
     "/sys/bus/i2c/devices/1-0049*temp1_input",
     "/sys/bus/i2c/devices/1-004b*temp1_input",
     "/sys/bus/i2c/devices/1-004c*temp1_input",
+    "/sys/devices/platform/as4564_thermal/temp1_input",
 };
 
 /* Static values */
@@ -59,6 +60,10 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
     { { ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD), "Thermal 4 - U29_PSU (0x4C)", 0},
+            ONLP_THERMAL_STATUS_PRESENT,
+            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+        },
+    { { ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD), "CPU Core (A7K)", 0},
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },

--- a/packages/platforms/accton/arm64/as4564-26p/platform-config/r0/src/python/arm64_accton_as4564_26p_r0/__init__.py
+++ b/packages/platforms/accton/arm64/as4564-26p/platform-config/r0/src/python/arm64_accton_as4564_26p_r0/__init__.py
@@ -43,7 +43,7 @@ class OnlPlatform_arm64_accton_as4564_26p_r0(OnlPlatformAccton,
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port-20), shell=True)
 
         # Below platform drivers should be inserted after cpld driver is initiated.
-        for m in [ 'psu' ]:
+        for m in [ 'psu', 'fan', 'thermal' ]:
             self.insmod("arm64-accton-as4564-26p-%s" % m)
 
         # Insert prestera kernel module


### PR DESCRIPTION
The thermal policy is implemented as below:
1. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) > 133.5 = 30% FAN speed
2. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) < 131 = 15% FAN speed
3. U1(0x49)+U12(0x48)+U29(0x4C)+U88(0x4B) > 215 = 50% FAN speed
4. One FAN failure = 60% FAN speed.

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>