### PR TITLE
Add dbus package to the build

### DIFF
--- a/builds/any/rootfs/stretch/common/all-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/all-base-packages.yml
@@ -90,3 +90,4 @@
 - memtester
 - lsb-release
 - tknos-firmware
+- dbus


### PR DESCRIPTION
w/o dbus package installed  "shutdown -r" will fail
```
localhost login: root
Password:
Linux localhost 5.10.4 #1 SMP PREEMPT Fri Sep 10 16:54:31 UTC 2021 aarch64
root@localhost:~# shutdown -r
Failed to connect to bus: No such file or directory
```
