### PR TITLE
Quick workaround for dst root ca x3 expiration (kernel.org)

### DIFF
--- a/setup.env
+++ b/setup.env
@@ -6,6 +6,9 @@
 #
 ############################################################
 
+# Fix expired letsencrypt root certificate https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
+sudo apt-get update; sudo apt-get install -y libgnutls30
+
 # The root of the ONL build tree is here
 export ONL=$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)
 


### PR DESCRIPTION
Signed-off-by: Steve Noble <snoble@sonn.com>

Due to the expiration of the dst root certificate, dentOS will not build.  The simplest work around is to update libgnutls30 to be able to contact kernel.org or any other site using the certificate.

https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/