### PR TITLE
net: prestera: Enable autoneg for 1000Base-X

### DIFF
--- a/packages/base/any/kernels/5.10-lts/patches/0041-net-prestera-Enable-autoneg-for-1000BASE-X.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0041-net-prestera-Enable-autoneg-for-1000BASE-X.patch
@@ -1,0 +1,56 @@
+From df171d92ee466c19a544f87bc1a18d516937c2d6 Mon Sep 17 00:00:00 2001
+From: Taras <taras.chornyi@plvision.eu>
+Date: Mon, 13 Sep 2021 16:34:51 +0300
+Subject: [PATCH] net: prestera: Enable autoneg for 1000BASE-X
+
+Increment version from 3.0.0 to 3.0.1
+
+Signed-off-by: Taras <taras.chornyi@plvision.eu>
+---
+ drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h | 2 +-
+ drivers/net/ethernet/marvell/prestera/prestera_main.c    | 2 ++
+ drivers/net/ethernet/marvell/prestera/prestera_pci.c     | 2 +-
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h b/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
+index 152512e65..e5cae7ddd 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
++++ b/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
+@@ -10,7 +10,7 @@
+ #define PRESTERA_DRV_VER_MAJOR	2
+ #define PRESTERA_DRV_VER_MINOR	0
+ #define PRESTERA_DRV_VER_PATCH	0
+-#define PRESTERA_DRV_VER_EXTRA	-v3.0.0
++#define PRESTERA_DRV_VER_EXTRA	-v3.0.1
+ 
+ #define PRESTERA_DRV_VER \
+ 		__stringify(PRESTERA_DRV_VER_MAJOR)  "." \
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_main.c b/drivers/net/ethernet/marvell/prestera/prestera_main.c
+index 32d90dbb6..75cd8c36b 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_main.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_main.c
+@@ -679,6 +679,8 @@ static void prestera_link_validate(struct phylink_config *config,
+ 	case PHY_INTERFACE_MODE_1000BASEX:
+ 		phylink_set(mask, 1000baseT_Full);
+ 		phylink_set(mask, 1000baseX_Full);
++		if (state->interface != PHY_INTERFACE_MODE_NA)
++			phylink_set(mask, Autoneg);
+ 		break;
+ 	default:
+ 		goto empty_set;
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_pci.c b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+index 25adb8ed5..22cb0f514 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_pci.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+@@ -15,7 +15,7 @@
+ 
+ #define PRESTERA_SUPP_FW_MAJ_VER	3
+ #define PRESTERA_SUPP_FW_MIN_VER	0
+-#define PRESTERA_SUPP_FW_PATCH_VER	0
++#define PRESTERA_SUPP_FW_PATCH_VER	1
+ 
+ #define prestera_wait(cond, waitms) \
+ ({ \
+-- 
+2.17.1
+

--- a/packages/base/any/kernels/5.10-lts/patches/series.arm64
+++ b/packages/base/any/kernels/5.10-lts/patches/series.arm64
@@ -34,3 +34,4 @@
 0038-netfilter-nf_flow_table_free-flush-flows-before-clea.patch
 0039-net-sched-fix-infinite-loop-when-trying-to-create-tc.patch
 0040-prestera-switchdev-prestera.patch
+0041-net-prestera-Enable-autoneg-for-1000BASE-X.patch


### PR DESCRIPTION
Bump driver version to v3.0.1

Signed-off-by: Taras <taras.chornyi@plvision.eu>