### PR TITLE
net: prestera: update prestera driver to v3.1.0-rc1

### DIFF
--- a/packages/base/any/kernels/5.10-lts/patches/0042-switchdev-prestera-v3.1.0-rc1.patch
+++ b/packages/base/any/kernels/5.10-lts/patches/0042-switchdev-prestera-v3.1.0-rc1.patch
@@ -1,0 +1,11718 @@
+diff --git a/drivers/net/ethernet/marvell/prestera/Makefile b/drivers/net/ethernet/marvell/prestera/Makefile
+index 4b08ca6..28a9e5d 100644
+--- a/drivers/net/ethernet/marvell/prestera/Makefile
++++ b/drivers/net/ethernet/marvell/prestera/Makefile
+@@ -8,7 +8,8 @@ prestera-objs := prestera_main.o \
+ 	prestera_hw.o prestera_switchdev.o prestera_devlink.o prestera_fw_log.o \
+ 	prestera_rxtx.o prestera_dsa.o prestera_router.o \
+ 	prestera_acl.o prestera_flow.o prestera_flower.o prestera_matchall.o prestera_debugfs.o \
+-	prestera_ct.o prestera_ethtool.o prestera_counter.o
++	prestera_ct.o prestera_ethtool.o prestera_counter.o \
++	prestera_router_hw.o
+ 
+ prestera-$(CONFIG_PRESTERA_DEBUG) += prestera_log.o
+ ccflags-$(CONFIG_PRESTERA_DEBUG) += -DCONFIG_MRVL_PRESTERA_DEBUG
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera.h b/drivers/net/ethernet/marvell/prestera/prestera.h
+index 617c5ae..08cf4a4 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera.h
++++ b/drivers/net/ethernet/marvell/prestera/prestera.h
+@@ -25,6 +25,7 @@
+ #define PRESTERA_DEFAULT_AGEING_TIME 300000
+ 
+ #define PRESTERA_NHGR_SIZE_MAX 4
++#define PRESTERA_AP_PORT_MAX   (10)
+ 
+ #define PRESTERA_PORT_SRCID_ZERO 0 /* source_id */
+ 
+@@ -67,7 +68,7 @@ struct prestera_flow_block {
+ 
+ struct prestera_port_vlan {
+ 	struct list_head list;
+-	struct prestera_port *mvsw_pr_port;
++	struct prestera_port *port;
+ 	u16 vid;
+ 	struct prestera_bridge_port *bridge_port;
+ 	struct list_head bridge_vlan_node;
+@@ -113,19 +114,22 @@ struct prestera_port_caps {
+ 	u8 transceiver;
+ };
+ 
+-struct prestera_port_link_params {
+-	u64 lmode_bmap;
++struct prestera_port_mac_state {
++	bool oper;
++	u32 mode;
+ 	u32 speed;
+ 	u8 duplex;
+-	bool oper_state;
++	u8 fc;
++	u8 fec;
++};
++
++struct prestera_port_phy_state {
++	u64 lmode_bmap;
+ 	struct {
+ 		bool pause;
+ 		bool asym_pause;
+ 	} remote_fc;
+-	struct {
+-		u8 status;
+-		u8 admin_mode;
+-	} mdix;
++	u8 mdix;
+ };
+ 
+ struct prestera_rxtx_stats {
+@@ -151,6 +155,7 @@ struct prestera_port_mac_config {
+ struct prestera_port_phy_config {
+ 	bool admin;
+ 	u32 mode;
++	u8 mdix;
+ };
+ 
+ struct prestera_port {
+@@ -180,23 +185,12 @@ struct prestera_port {
+ 	struct phylink_config phy_config;
+ 	struct phylink *phy_link;
+ 
+-	struct prestera_port_link_params link_params;
++	struct prestera_port_mac_state state_mac;
++	struct prestera_port_phy_state state_phy;
+ 
+ 	struct prestera_rxtx_stats __percpu *rxtx_stats;
+ };
+ 
+-struct prestera_switchdev {
+-	struct prestera_switch *sw;
+-	struct notifier_block swdev_n;
+-	struct notifier_block swdev_blocking_n;
+-};
+-
+-struct prestera_fib {
+-	struct prestera_switch *sw;
+-	struct notifier_block fib_nb;
+-	struct notifier_block netevent_nb;
+-};
+-
+ struct prestera_device {
+ 	struct device *dev;
+ 	struct prestera_fw_rev fw_rev;
+@@ -222,43 +216,43 @@ struct prestera_device {
+ };
+ 
+ enum prestera_event_type {
+-	MVSW_EVENT_TYPE_UNSPEC,
+-	MVSW_EVENT_TYPE_PORT,
+-	MVSW_EVENT_TYPE_FDB,
+-	MVSW_EVENT_TYPE_RXTX,
+-	MVSW_EVENT_TYPE_FW_LOG,
+-	MVSW_EVENT_TYPE_PULSE,
++	PRESTERA_EVENT_TYPE_UNSPEC,
++	PRESTERA_EVENT_TYPE_PORT,
++	PRESTERA_EVENT_TYPE_FDB,
++	PRESTERA_EVENT_TYPE_RXTX,
++	PRESTERA_EVENT_TYPE_FW_LOG,
++	PRESTERA_EVENT_TYPE_PULSE,
+ 
+-	MVSW_EVENT_TYPE_MAX,
++	PRESTERA_EVENT_TYPE_MAX,
+ };
+ 
+ enum prestera_rxtx_event_id {
+-	MVSW_RXTX_EVENT_UNSPEC,
++	PRESTERA_RXTX_EVENT_UNSPEC,
+ 
+-	MVSW_RXTX_EVENT_RCV_PKT,
++	PRESTERA_RXTX_EVENT_RCV_PKT,
+ 
+-	MVSW_RXTX_EVENT_MAX,
++	PRESTERA_RXTX_EVENT_MAX,
+ };
+ 
+ enum prestera_port_event_id {
+-	MVSW_PORT_EVENT_UNSPEC,
+-	MVSW_PORT_EVENT_STATE_CHANGED,
++	PRESTERA_PORT_EVENT_UNSPEC,
++	PRESTERA_PORT_EVENT_MAC_STATE_CHANGED,
+ 
+-	MVSW_PORT_EVENT_MAX,
++	PRESTERA_PORT_EVENT_MAX,
+ };
+ 
+ enum prestera_fdb_event_id {
+-	MVSW_FDB_EVENT_UNSPEC,
+-	MVSW_FDB_EVENT_LEARNED,
+-	MVSW_FDB_EVENT_AGED,
++	PRESTERA_FDB_EVENT_UNSPEC,
++	PRESTERA_FDB_EVENT_LEARNED,
++	PRESTERA_FDB_EVENT_AGED,
+ 
+-	MVSW_FDB_EVENT_MAX,
++	PRESTERA_FDB_EVENT_MAX,
+ };
+ 
+ enum prestera_fdb_entry_type {
+-	MVSW_PR_FDB_ENTRY_TYPE_REG_PORT,
+-	MVSW_PR_FDB_ENTRY_TYPE_LAG,
+-	MVSW_PR_FDB_ENTRY_TYPE_MAX
++	PRESTERA_FDB_ENTRY_TYPE_REG_PORT,
++	PRESTERA_FDB_ENTRY_TYPE_LAG,
++	PRESTERA_FDB_ENTRY_TYPE_MAX
+ };
+ 
+ struct prestera_fdb_event {
+@@ -275,14 +269,23 @@ struct prestera_fdb_event {
+ 
+ struct prestera_port_event {
+ 	u32 port_id;
+-	struct {
+-		u64 lmode_bmap;
+-		u32 link_mode;
+-		u8 oper_state;
+-		bool pause;
+-		bool asym_pause;
+-		u8 status;
+-		u8 admin_mode;
++	union {
++		struct {
++			u8 oper;
++			u32 mode;
++			u32 speed;
++			u8 duplex;
++			u8 fc;
++			u8 fec;
++		} mac;
++		struct {
++			u8 mdix;
++			u64 lmode_bmap;
++			struct {
++				bool pause;
++				bool asym_pause;
++			} remote_fc;
++		} phy;
+ 	} data;
+ };
+ 
+@@ -313,13 +316,13 @@ struct prestera_lag {
+ 
+ enum prestera_if_type {
+ 	/* the interface is of port type (dev,port) */
+-	MVSW_IF_PORT_E = 0,
++	PRESTERA_IF_PORT_E = 0,
+ 
+ 	/* the interface is of lag type (lag-id) */
+-	MVSW_IF_LAG_E = 1,
++	PRESTERA_IF_LAG_E = 1,
+ 
+ 	/* the interface is of Vid type (vlan-id) */
+-	MVSW_IF_VID_E = 3,
++	PRESTERA_IF_VID_E = 3,
+ };
+ 
+ struct prestera_iface {
+@@ -334,7 +337,7 @@ struct prestera_iface {
+ 	u32 hw_dev_num;
+ };
+ 
+-struct prestera_bridge;
++struct prestera_switchdev;
+ struct prestera_router;
+ struct prestera_rif;
+ struct prestera_trap_data;
+@@ -356,11 +359,10 @@ struct prestera_switch {
+ 	struct prestera_storm_control *storm_control;
+ 	struct prestera_acl *acl;
+ 	struct prestera_span *span;
+-	struct prestera_bridge *bridge;
+-	struct prestera_switchdev *switchdev;
++	struct prestera_switchdev *swdev;
+ 	struct prestera_router *router;
+ 	struct prestera_lag *lags;
+-	struct notifier_block netdevice_nb;
++	struct notifier_block netdev_nb;
+ 	struct device_node *np;
+ 	struct prestera_trap_data *trap_data;
+ 	struct prestera_rxtx *rxtx;
+@@ -371,6 +373,7 @@ struct prestera_router {
+ 	struct prestera_switch *sw;
+ 	struct list_head rif_list;	/* list of mvsw_pr_rif */
+ 	struct list_head vr_list;	/* list of mvsw_pr_vr */
++	struct list_head rif_entry_list;
+ 	struct rhashtable nh_neigh_ht;
+ 	struct rhashtable nexthop_group_ht;
+ 	struct rhashtable fib_ht;
+@@ -389,16 +392,16 @@ struct prestera_router {
+ };
+ 
+ enum prestera_fdb_flush_mode {
+-	MVSW_PR_FDB_FLUSH_MODE_DYNAMIC = BIT(0),
+-	MVSW_PR_FDB_FLUSH_MODE_STATIC = BIT(1),
+-	MVSW_PR_FDB_FLUSH_MODE_ALL = MVSW_PR_FDB_FLUSH_MODE_DYNAMIC
+-				   | MVSW_PR_FDB_FLUSH_MODE_STATIC,
++	PRESTERA_FDB_FLUSH_MODE_DYNAMIC = BIT(0),
++	PRESTERA_FDB_FLUSH_MODE_STATIC = BIT(1),
++	PRESTERA_FDB_FLUSH_MODE_ALL = PRESTERA_FDB_FLUSH_MODE_DYNAMIC
++				    | PRESTERA_FDB_FLUSH_MODE_STATIC,
+ };
+ 
+ struct prestera_ip_addr {
+ 	enum {
+-		MVSW_PR_IPV4 = 0,
+-		MVSW_PR_IPV6
++		PRESTERA_IPV4 = 0,
++		PRESTERA_IPV6
+ 	} v;
+ 	union {
+ 		__be32 ipv4;
+@@ -443,14 +446,14 @@ struct prestera_acl_match {
+ };
+ 
+ enum prestera_acl_rule_action {
+-	MVSW_ACL_RULE_ACTION_ACCEPT,
+-	MVSW_ACL_RULE_ACTION_DROP,
+-	MVSW_ACL_RULE_ACTION_TRAP,
+-	MVSW_ACL_RULE_ACTION_POLICE,
+-	MVSW_ACL_RULE_ACTION_NAT,
+-	MVSW_ACL_RULE_ACTION_JUMP,
+-	MVSW_ACL_RULE_ACTION_NH,
+-	MVSW_ACL_RULE_ACTION_COUNT
++	PRESTERA_ACL_RULE_ACTION_ACCEPT,
++	PRESTERA_ACL_RULE_ACTION_DROP,
++	PRESTERA_ACL_RULE_ACTION_TRAP,
++	PRESTERA_ACL_RULE_ACTION_POLICE,
++	PRESTERA_ACL_RULE_ACTION_NAT,
++	PRESTERA_ACL_RULE_ACTION_JUMP,
++	PRESTERA_ACL_RULE_ACTION_NH,
++	PRESTERA_ACL_RULE_ACTION_COUNT
+ };
+ 
+ struct prestera_acl_action_jump {
+@@ -491,32 +494,20 @@ struct prestera_acl_hw_action_info {
+ 	};
+ };
+ 
+-struct prestera_fib_key {
+-	struct prestera_ip_addr addr;
+-	u32 prefix_len;
+-	u32 tb_id;
+-};
+-
+-struct prestera_fib_info {
+-	struct mvsw_pr_vr *vr;
+-	struct list_head vr_node;
+-	enum mvsw_pr_fib_type {
+-		MVSW_PR_FIB_TYPE_INVALID = 0,
+-		/* must be pointer to nh_grp id */
+-		MVSW_PR_FIB_TYPE_UC_NH,
+-		/* It can be connected route
+-		 * and will be overlapped with neighbours
+-		 */
+-		MVSW_PR_FIB_TYPE_TRAP,
+-		MVSW_PR_FIB_TYPE_DROP
+-	} type;
+-	/* Valid only if type = UC_NH*/
+-	struct mvsw_pr_nexthop_group *nh_grp;
+-};
+-
+ struct prestera_nh_neigh_key {
+ 	struct prestera_ip_addr addr;
+-	struct prestera_rif *rif;
++	/* Seems like rif is obsolete, because there is iface in info ?
++	 * Key can contain functional fields, or fields, which is used to
++	 * filter duplicate objects on logical level (before you pass it to
++	 * HW)... also key can be used to cover hardware restrictions.
++	 * In our case rif - is logical interface (even can be VLAN), which
++	 * is used in combination with IP address (which is also not related to
++	 * hardware nexthop) to provide logical compression of created nexthops.
++	 * You even can imagine, that rif+IPaddr is just cookie.
++	 */
++	/* struct prestera_rif *rif; */
++	/* Use just as cookie, to divide ARP domains (in order with addr) */
++	void *rif;
+ };
+ 
+ /* Used to notify nh about neigh change */
+@@ -534,8 +525,6 @@ struct prestera_nexthop_group_key {
+ 
+ struct prestera_port *dev_to_prestera_port(struct device *dev);
+ 
+-int prestera_switch_ageing_set(struct prestera_switch *sw, u32 ageing_time);
+-
+ struct prestera_port *prestera_port_find_by_fp_id(u32 fp_id);
+ 
+ int prestera_port_learning_set(struct prestera_port *port, bool learn_enable);
+@@ -551,31 +540,11 @@ void prestera_port_vlan_destroy(struct prestera_port_vlan *mvsw_pr_port_vlan);
+ int prestera_port_vlan_set(struct prestera_port *port, u16 vid,
+ 			   bool is_member, bool untagged);
+ 
+-struct prestera_bridge_device *
+-prestera_bridge_device_find(const struct prestera_bridge *bridge,
++struct prestera_bridge *
++prestera_bridge_device_find(const struct prestera_switch *sw,
+ 			    const struct net_device *br_dev);
+-u16 prestera_vlan_dev_vlan_id(struct prestera_bridge *bridge,
++u16 prestera_vlan_dev_vlan_id(struct prestera_switch *sw,
+ 			      struct net_device *dev);
+-int prestera_8021d_bridge_create(struct prestera_switch *sw, u16 *bridge_id);
+-int prestera_8021d_bridge_delete(struct prestera_switch *sw, u16 bridge_id);
+-int prestera_8021d_bridge_port_add(struct prestera_port *port, u16 bridge_id);
+-int prestera_8021d_bridge_port_delete(struct prestera_port *port,
+-				      u16 bridge_id);
+-
+-int prestera_fdb_add(struct prestera_port *port, const unsigned char *mac,
+-		     u16 vid, bool dynamic);
+-int prestera_fdb_del(struct prestera_port *port, const unsigned char *mac,
+-		     u16 vid);
+-int prestera_fdb_flush_vlan(struct prestera_switch *sw, u16 vid,
+-			    enum prestera_fdb_flush_mode mode);
+-int prestera_fdb_flush_port_vlan(struct prestera_port *port, u16 vid,
+-				 enum prestera_fdb_flush_mode mode);
+-int prestera_fdb_flush_port(struct prestera_port *port,
+-			    enum prestera_fdb_flush_mode mode);
+-int prestera_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
+-			 const u8 *mac, u16 vid);
+-int prestera_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
+-			 const u8 *mac, u16 vid);
+ 
+ int prestera_lag_member_add(struct prestera_port *port,
+ 			    struct net_device *lag_dev, u16 lag_id);
+@@ -675,8 +644,6 @@ int prestera_router_init(struct prestera_switch *sw);
+ void prestera_router_fini(struct prestera_switch *sw);
+ int prestera_netdevice_router_port_event(struct net_device *dev,
+ 					 unsigned long event, void *ptr);
+-int prestera_inetaddr_valid_event(struct notifier_block *unused,
+-				  unsigned long event, void *ptr);
+ int prestera_netdevice_vrf_event(struct net_device *dev, unsigned long event,
+ 				 struct netdev_notifier_changeupper_info *info);
+ void prestera_port_router_leave(struct prestera_port *port);
+@@ -716,8 +683,8 @@ void prestera_router_lag_member_leave(const struct prestera_port *port,
+ void prestera_lag_router_leave(struct prestera_switch *sw,
+ 			       struct net_device *lag_dev);
+ 
+-void prestera_bridge_device_rifs_destroy(struct prestera_switch *sw,
+-					 struct net_device *bridge_dev);
++void prestera_bridge_rifs_destroy(struct prestera_switch *sw,
++				  struct net_device *bridge_dev);
+ void prestera_k_arb_fdb_evt(struct prestera_switch *sw, struct net_device *dev);
+ struct prestera_neigh_info *
+ prestera_kern_neigh_cache_to_neigh_info(struct prestera_kern_neigh_cache *nc);
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_acl.c b/drivers/net/ethernet/marvell/prestera/prestera_acl.c
+index 8591c04..b7768d2 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_acl.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_acl.c
+@@ -12,6 +12,8 @@
+ #define PRESTERA_ACL_RULE_DEF_HW_TC	3
+ #define ACL_KEYMASK_SIZE	\
+ 	(sizeof(__be32) * __PRESTERA_ACL_RULE_MATCH_TYPE_MAX)
++/* Need to merge it with router_manager */
++#define MVSW_PR_NH_ACTIVE_JIFFER_FILTER 3000 /* ms */
+ 
+ struct prestera_acl_ruleset_ht_key {
+ 	struct prestera_flow_block *block;
+@@ -527,7 +529,7 @@ static int prestera_acl_nat_port_neigh_lookup(struct prestera_port *port,
+ 		if (IS_ERR(n_cache))
+ 			continue;
+ 		n_info = prestera_kern_neigh_cache_to_neigh_info(n_cache);
+-		if (n_info->iface.type == MVSW_IF_PORT_E &&
++		if (n_info->iface.type == PRESTERA_IF_PORT_E &&
+ 		    n_info->iface.dev_port.port_num == port->hw_id &&
+ 		    n_info->iface.dev_port.hw_dev_num == port->dev_id) {
+ 			memcpy(ni, n_info, sizeof(*n_info));
+@@ -874,47 +876,47 @@ static int __prestera_acl_rule_entry2hw_add(struct prestera_switch *sw,
+ 
+ 	/* accept */
+ 	if (e->accept.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_ACCEPT;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_ACCEPT;
+ 		act_num++;
+ 	}
+ 	/* drop */
+ 	if (e->drop.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_DROP;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_DROP;
+ 		act_num++;
+ 	}
+ 	/* trap */
+ 	if (e->trap.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_TRAP;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_TRAP;
+ 		act_hw[act_num].trap = e->trap.i;
+ 		act_num++;
+ 	}
+ 	/* police */
+ 	if (e->police.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_POLICE;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_POLICE;
+ 		act_hw[act_num].police = e->police.i;
+ 		act_num++;
+ 	}
+ 	/* nat */
+ 	if (e->nat.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_NAT;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_NAT;
+ 		act_hw[act_num].nat = e->nat.i;
+ 		act_num++;
+ 	}
+ 	/* jump */
+ 	if (e->jump.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_JUMP;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_JUMP;
+ 		act_hw[act_num].jump = e->jump.i;
+ 		act_num++;
+ 	}
+ 	/* nh */
+ 	if (e->nh.valid) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_NH;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_NH;
+ 		act_hw[act_num].nh = e->nh.e->hw_id;
+ 		act_num++;
+ 	}
+ 	/* counter */
+ 	if (e->counter.block) {
+-		act_hw[act_num].id = MVSW_ACL_RULE_ACTION_COUNT;
++		act_hw[act_num].id = PRESTERA_ACL_RULE_ACTION_COUNT;
+ 		act_hw[act_num].count.id = e->counter.id;
+ 		act_num++;
+ 	}
+@@ -1000,6 +1002,9 @@ __prestera_acl_rule_entry_act_construct(struct prestera_switch *sw,
+ 	return -EINVAL;
+ }
+ 
++/* TODO: move acl_rule entry and lowest objects to
++ * appropriate files (hw_nh.c, hw_match.c)
++ */
+ struct prestera_acl_rule_entry *
+ prestera_acl_rule_entry_create(struct prestera_acl *acl,
+ 			       struct prestera_acl_rule_entry_key *key,
+@@ -1164,7 +1169,8 @@ int prestera_acl_vtcam_id_get(struct prestera_acl *acl, u8 lookup,
+ 	if (!vtcam)
+ 		return -ENOMEM;
+ 
+-	err = prestera_hw_vtcam_create(acl->sw, lookup, keymask, &new_vtcam_id);
++	err = prestera_hw_vtcam_create(acl->sw, lookup, keymask, &new_vtcam_id,
++				       PRESTERA_HW_VTCAM_DIR_INGRESS);
+ 	if (err) {
+ 		kfree(vtcam);
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_acl.h b/drivers/net/ethernet/marvell/prestera/prestera_acl.h
+index d516bed..2a50d9b 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_acl.h
++++ b/drivers/net/ethernet/marvell/prestera/prestera_acl.h
+@@ -45,7 +45,6 @@
+ #define rule_match_get_u32(match_p, type)			\
+ 	(match_p[PRESTERA_ACL_RULE_MATCH_TYPE_##type])
+ 
+-#define MVSW_PR_NH_ACTIVE_JIFFER_FILTER 3000 /* ms */
+ #define MVSW_ACL_RULE_DEF_HW_CHAIN_ID	0
+ #define MVSW_ACL_RULESET_ALL		0xff
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_devlink.c b/drivers/net/ethernet/marvell/prestera/prestera_devlink.c
+index e8f14da..d209a97 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_devlink.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_devlink.c
+@@ -433,23 +433,23 @@ static int prestera_storm_control_rate_set(struct devlink *dl, u32 id,
+ 	switch (type_id) {
+ 	case PORT_PARAM_ID_BC_RATE:
+ 		param_to_set = &cfg->bc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_BC;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_BC;
+ 		break;
+ 	case PORT_PARAM_ID_UC_UNK_RATE:
+ 		param_to_set = &cfg->unk_uc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_UC_UNK;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_UC_UNK;
+ 		break;
+ 	case PORT_PARAM_ID_MC_RATE:
+ 		param_to_set = &cfg->unreg_mc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_MC;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_MC;
+ 		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+ 
+ 	if (kbyte_per_sec_rate != *param_to_set) {
+-		ret = mvsw_pr_hw_port_storm_control_cfg_set(port, storm_type,
+-							    kbyte_per_sec_rate);
++		ret = prestera_hw_port_storm_control_cfg_set(port, storm_type,
++							     kbyte_per_sec_rate);
+ 		if (ret)
+ 			return ret;
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h b/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
+index e5cae7d..553c73d 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
++++ b/drivers/net/ethernet/marvell/prestera/prestera_drv_ver.h
+@@ -10,7 +10,7 @@
+ #define PRESTERA_DRV_VER_MAJOR	2
+ #define PRESTERA_DRV_VER_MINOR	0
+ #define PRESTERA_DRV_VER_PATCH	0
+-#define PRESTERA_DRV_VER_EXTRA	-v3.0.1
++#define PRESTERA_DRV_VER_EXTRA	-v3.1.0-rc1
+ 
+ #define PRESTERA_DRV_VER \
+ 		__stringify(PRESTERA_DRV_VER_MAJOR)  "." \
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_dsa.c b/drivers/net/ethernet/marvell/prestera/prestera_dsa.c
+index 0dd4027..96103af 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_dsa.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_dsa.c
+@@ -220,7 +220,7 @@ static int net_if_dsa_tag_from_cpu_build(const struct mvsw_pr_dsa *dsa_info_ptr,
+ 	const struct mvsw_pr_dsa_from_cpu *from_cpu_ptr =
+ 	    &dsa_info_ptr->dsa_info.from_cpu;
+ 
+-	if (unlikely(from_cpu_ptr->dst_iface.type != MVSW_IF_PORT_E))
++	if (unlikely(from_cpu_ptr->dst_iface.type != PRESTERA_IF_PORT_E))
+ 		/* only sending to port interface is supported */
+ 		return -EINVAL;
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c b/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c
+index ad6a64a..531eb58 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_ethtool.c
+@@ -26,180 +26,180 @@ struct prestera_link_mode {
+ };
+ 
+ static const struct prestera_link_mode
+-prestera_link_modes[MVSW_LINK_MODE_MAX] = {
+-	[MVSW_LINK_MODE_10baseT_Half_BIT] = {
++prestera_link_modes[PRESTERA_LINK_MODE_MAX] = {
++	[PRESTERA_LINK_MODE_10baseT_Half] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_10baseT_Half_BIT,
+ 		.speed = 10,
+-		.pr_mask = 1 << MVSW_LINK_MODE_10baseT_Half_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_HALF,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_10baseT_Half,
++		.duplex = PRESTERA_PORT_DUPLEX_HALF,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_10baseT_Full_BIT] = {
++	[PRESTERA_LINK_MODE_10baseT_Full] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_10baseT_Full_BIT,
+ 		.speed = 10,
+-		.pr_mask = 1 << MVSW_LINK_MODE_10baseT_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_10baseT_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_100baseT_Half_BIT] = {
++	[PRESTERA_LINK_MODE_100baseT_Half] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_100baseT_Half_BIT,
+ 		.speed = 100,
+-		.pr_mask = 1 << MVSW_LINK_MODE_100baseT_Half_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_HALF,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_100baseT_Half,
++		.duplex = PRESTERA_PORT_DUPLEX_HALF,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_100baseT_Full_BIT] = {
++	[PRESTERA_LINK_MODE_100baseT_Full] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_100baseT_Full_BIT,
+ 		.speed = 100,
+-		.pr_mask = 1 << MVSW_LINK_MODE_100baseT_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_100baseT_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_1000baseT_Half_BIT] = {
++	[PRESTERA_LINK_MODE_1000baseT_Half] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_1000baseT_Half_BIT,
+ 		.speed = 1000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_1000baseT_Half_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_HALF,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_1000baseT_Half,
++		.duplex = PRESTERA_PORT_DUPLEX_HALF,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_1000baseT_Full_BIT] = {
++	[PRESTERA_LINK_MODE_1000baseT_Full] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+ 		.speed = 1000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_1000baseT_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_1000baseT_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_1000baseX_Full_BIT] = {
++	[PRESTERA_LINK_MODE_1000baseX_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_1000baseX_Full_BIT,
+ 		.speed = 1000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_1000baseX_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_1000baseX_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_1000baseKX_Full_BIT] = {
++	[PRESTERA_LINK_MODE_1000baseKX_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_1000baseKX_Full_BIT,
+ 		.speed = 1000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_1000baseKX_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_1000baseKX_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_2500baseX_Full_BIT] = {
++	[PRESTERA_LINK_MODE_2500baseX_Full] = {
+ 		.eth_mode =  ETHTOOL_LINK_MODE_2500baseX_Full_BIT,
+ 		.speed = 2500,
+-		.pr_mask = 1 << MVSW_LINK_MODE_2500baseX_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_2500baseX_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
+ 	},
+-	[MVSW_LINK_MODE_10GbaseKR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_10GbaseKR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_10000baseKR_Full_BIT,
+ 		.speed = 10000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_10GbaseKR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_10GbaseKR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_10GbaseSR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_10GbaseSR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_10000baseSR_Full_BIT,
+ 		.speed = 10000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_10GbaseSR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_10GbaseSR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_10GbaseLR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_10GbaseLR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_10000baseLR_Full_BIT,
+ 		.speed = 10000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_10GbaseLR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_10GbaseLR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_20GbaseKR2_Full_BIT] = {
++	[PRESTERA_LINK_MODE_20GbaseKR2_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_20000baseKR2_Full_BIT,
+ 		.speed = 20000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_20GbaseKR2_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_20GbaseKR2_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_25GbaseCR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_25GbaseCR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_25000baseCR_Full_BIT,
+ 		.speed = 25000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_25GbaseCR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_DA,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_25GbaseCR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_DA,
+ 	},
+-	[MVSW_LINK_MODE_25GbaseKR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_25GbaseKR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_25000baseKR_Full_BIT,
+ 		.speed = 25000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_25GbaseKR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_25GbaseKR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_25GbaseSR_Full_BIT] = {
++	[PRESTERA_LINK_MODE_25GbaseSR_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_25000baseSR_Full_BIT,
+ 		.speed = 25000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_25GbaseSR_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_25GbaseSR_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_40GbaseKR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_40GbaseKR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_40000baseKR4_Full_BIT,
+ 		.speed = 40000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_40GbaseKR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_40GbaseKR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_40GbaseCR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_40GbaseCR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_40000baseCR4_Full_BIT,
+ 		.speed = 40000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_40GbaseCR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_DA,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_40GbaseCR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_DA,
+ 	},
+-	[MVSW_LINK_MODE_40GbaseSR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_40GbaseSR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_40000baseSR4_Full_BIT,
+ 		.speed = 40000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_40GbaseSR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_40GbaseSR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_50GbaseCR2_Full_BIT] = {
++	[PRESTERA_LINK_MODE_50GbaseCR2_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_50000baseCR2_Full_BIT,
+ 		.speed = 50000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_50GbaseCR2_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_DA,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_50GbaseCR2_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_DA,
+ 	},
+-	[MVSW_LINK_MODE_50GbaseKR2_Full_BIT] = {
++	[PRESTERA_LINK_MODE_50GbaseKR2_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_50000baseKR2_Full_BIT,
+ 		.speed = 50000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_50GbaseKR2_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_50GbaseKR2_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_50GbaseSR2_Full_BIT] = {
++	[PRESTERA_LINK_MODE_50GbaseSR2_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_50000baseSR2_Full_BIT,
+ 		.speed = 50000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_50GbaseSR2_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_50GbaseSR2_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_100GbaseKR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_100GbaseKR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_100000baseKR4_Full_BIT,
+ 		.speed = 100000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_100GbaseKR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_TP,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_100GbaseKR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_TP,
+ 	},
+-	[MVSW_LINK_MODE_100GbaseSR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_100GbaseSR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_100000baseSR4_Full_BIT,
+ 		.speed = 100000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_100GbaseSR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_FIBRE,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_100GbaseSR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_FIBRE,
+ 	},
+-	[MVSW_LINK_MODE_100GbaseCR4_Full_BIT] = {
++	[PRESTERA_LINK_MODE_100GbaseCR4_Full] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_100000baseCR4_Full_BIT,
+ 		.speed = 100000,
+-		.pr_mask = 1 << MVSW_LINK_MODE_100GbaseCR4_Full_BIT,
+-		.duplex = MVSW_PORT_DUPLEX_FULL,
+-		.port_type = MVSW_PORT_TYPE_DA,
++		.pr_mask = 1 << PRESTERA_LINK_MODE_100GbaseCR4_Full,
++		.duplex = PRESTERA_PORT_DUPLEX_FULL,
++		.port_type = PRESTERA_PORT_TYPE_DA,
+ 	}
+ };
+ 
+@@ -209,21 +209,21 @@ struct prestera_fec {
+ 	u8 pr_fec;
+ };
+ 
+-static const struct prestera_fec prestera_fec_caps[MVSW_PORT_FEC_MAX] = {
+-	[MVSW_PORT_FEC_OFF_BIT] = {
++static const struct prestera_fec prestera_fec_caps[PRESTERA_PORT_FEC_MAX] = {
++	[PRESTERA_PORT_FEC_OFF] = {
+ 		.eth_fec = ETHTOOL_FEC_OFF,
+ 		.eth_mode = ETHTOOL_LINK_MODE_FEC_NONE_BIT,
+-		.pr_fec = 1 << MVSW_PORT_FEC_OFF_BIT,
++		.pr_fec = 1 << PRESTERA_PORT_FEC_OFF,
+ 	},
+-	[MVSW_PORT_FEC_BASER_BIT] = {
++	[PRESTERA_PORT_FEC_BASER] = {
+ 		.eth_fec = ETHTOOL_FEC_BASER,
+ 		.eth_mode = ETHTOOL_LINK_MODE_FEC_BASER_BIT,
+-		.pr_fec = 1 << MVSW_PORT_FEC_BASER_BIT,
++		.pr_fec = 1 << PRESTERA_PORT_FEC_BASER,
+ 	},
+-	[MVSW_PORT_FEC_RS_BIT] = {
++	[PRESTERA_PORT_FEC_RS] = {
+ 		.eth_fec = ETHTOOL_FEC_RS,
+ 		.eth_mode = ETHTOOL_LINK_MODE_FEC_RS_BIT,
+-		.pr_fec = 1 << MVSW_PORT_FEC_RS_BIT,
++		.pr_fec = 1 << PRESTERA_PORT_FEC_RS,
+ 	}
+ };
+ 
+@@ -233,36 +233,36 @@ struct prestera_port_type {
+ };
+ 
+ static const struct prestera_port_type
+-prestera_port_types[MVSW_PORT_TYPE_MAX] = {
+-	[MVSW_PORT_TYPE_NONE] = {
++prestera_port_types[PRESTERA_PORT_TYPE_MAX] = {
++	[PRESTERA_PORT_TYPE_NONE] = {
+ 		.eth_mode = __ETHTOOL_LINK_MODE_MASK_NBITS,
+ 		.eth_type = PORT_NONE,
+ 	},
+-	[MVSW_PORT_TYPE_TP] = {
++	[PRESTERA_PORT_TYPE_TP] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_TP_BIT,
+ 		.eth_type = PORT_TP,
+ 	},
+-	[MVSW_PORT_TYPE_AUI] = {
++	[PRESTERA_PORT_TYPE_AUI] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_AUI_BIT,
+ 		.eth_type = PORT_AUI,
+ 	},
+-	[MVSW_PORT_TYPE_MII] = {
++	[PRESTERA_PORT_TYPE_MII] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_MII_BIT,
+ 		.eth_type = PORT_MII,
+ 	},
+-	[MVSW_PORT_TYPE_FIBRE] = {
++	[PRESTERA_PORT_TYPE_FIBRE] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_FIBRE_BIT,
+ 		.eth_type = PORT_FIBRE,
+ 	},
+-	[MVSW_PORT_TYPE_BNC] = {
++	[PRESTERA_PORT_TYPE_BNC] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_BNC_BIT,
+ 		.eth_type = PORT_BNC,
+ 	},
+-	[MVSW_PORT_TYPE_DA] = {
++	[PRESTERA_PORT_TYPE_DA] = {
+ 		.eth_mode = ETHTOOL_LINK_MODE_TP_BIT,
+ 		.eth_type = PORT_TP,
+ 	},
+-	[MVSW_PORT_TYPE_OTHER] = {
++	[PRESTERA_PORT_TYPE_OTHER] = {
+ 		.eth_mode = __ETHTOOL_LINK_MODE_MASK_NBITS,
+ 		.eth_type = PORT_OTHER,
+ 	}
+@@ -306,16 +306,16 @@ static void prestera_modes_to_eth(unsigned long *eth_modes, u64 link_modes,
+ {
+ 	u32 mode;
+ 
+-	for (mode = 0; mode < MVSW_LINK_MODE_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_LINK_MODE_MAX; mode++) {
+ 		if ((prestera_link_modes[mode].pr_mask & link_modes) == 0)
+ 			continue;
+-		if (type != MVSW_PORT_TYPE_NONE &&
++		if (type != PRESTERA_PORT_TYPE_NONE &&
+ 		    prestera_link_modes[mode].port_type != type)
+ 			continue;
+ 		__set_bit(prestera_link_modes[mode].eth_mode, eth_modes);
+ 	}
+ 
+-	for (mode = 0; mode < MVSW_PORT_FEC_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_PORT_FEC_MAX; mode++) {
+ 		if ((prestera_fec_caps[mode].pr_fec & fec) == 0)
+ 			continue;
+ 		__set_bit(prestera_fec_caps[mode].eth_mode, eth_modes);
+@@ -324,18 +324,11 @@ static void prestera_modes_to_eth(unsigned long *eth_modes, u64 link_modes,
+ 
+ static void prestera_port_remote_cap_cache(struct prestera_port *port)
+ {
+-	struct prestera_port_link_params *params = &port->link_params;
++	struct prestera_port_phy_state *state = &port->state_phy;
+ 
+-	if (!params->oper_state)
+-		return;
+-
+-	if (params->lmode_bmap &&
+-	    (params->remote_fc.pause || params->remote_fc.asym_pause))
+-		return;
+-
+-	if (mvsw_pr_hw_port_remote_cap_get(port, &params->lmode_bmap,
+-					   &params->remote_fc.pause,
+-					   &params->remote_fc.asym_pause))
++	if (prestera_hw_port_phy_mode_get(port, NULL, &state->lmode_bmap,
++					  &state->remote_fc.pause,
++					  &state->remote_fc.asym_pause))
+ 		netdev_warn(port->net_dev,
+ 			    "Remote link caps get failed %d",
+ 			    port->caps.transceiver);
+@@ -343,43 +336,36 @@ static void prestera_port_remote_cap_cache(struct prestera_port *port)
+ 
+ static void prestera_port_mdix_cache(struct prestera_port *port)
+ {
+-	struct prestera_port_link_params *params = &port->link_params;
+-
+-	if (!params->oper_state)
+-		return;
++	struct prestera_port_phy_state *state = &port->state_phy;
+ 
+-	if (params->mdix.status == ETH_TP_MDI_INVALID ||
+-	    params->mdix.admin_mode == ETH_TP_MDI_INVALID) {
+-		if (mvsw_pr_hw_port_mdix_get(port, &params->mdix.status,
+-					     &params->mdix.admin_mode)) {
+-			netdev_warn(port->net_dev, "MDIX params get failed");
+-			params->mdix.status = ETH_TP_MDI_INVALID;
+-			params->mdix.admin_mode = ETH_TP_MDI_INVALID;
+-		}
++	if (prestera_hw_port_phy_mode_get(port, &state->mdix,
++					  NULL, NULL, NULL)) {
++		netdev_warn(port->net_dev, "MDIX params get failed");
++		state->mdix = ETH_TP_MDI_INVALID;
+ 	}
+ }
+ 
+ static void prestera_port_link_mode_cache(struct prestera_port *port)
+ {
+-	struct prestera_port_link_params *params = &port->link_params;
++	struct prestera_port_mac_state *state = &port->state_mac;
+ 	u32 speed;
+ 	u8 duplex;
+ 	int err;
+ 
+-	if (!params->oper_state)
++	if (!port->state_mac.oper)
+ 		return;
+ 
+-	if (params->speed == SPEED_UNKNOWN ||
+-	    params->duplex == DUPLEX_UNKNOWN) {
++	if (state->speed == SPEED_UNKNOWN ||
++	    state->duplex == DUPLEX_UNKNOWN) {
+ 
+-		err = mvsw_pr_hw_port_mac_mode_get(port, NULL, &speed,
+-						   &duplex, NULL);
++		err = prestera_hw_port_mac_mode_get(port, NULL, &speed,
++						    &duplex, NULL);
+ 		if (err) {
+-			params->speed = SPEED_UNKNOWN;
+-			params->duplex = DUPLEX_UNKNOWN;
++			state->speed = SPEED_UNKNOWN;
++			state->duplex = DUPLEX_UNKNOWN;
+ 		} else {
+-			params->speed = speed;
+-			params->duplex = duplex == MVSW_PORT_DUPLEX_FULL ?
++			state->speed = speed;
++			state->duplex = duplex == PRESTERA_PORT_DUPLEX_FULL ?
+ 					  DUPLEX_FULL : DUPLEX_HALF;
+ 		}
+ 	}
+@@ -390,24 +376,24 @@ static void prestera_port_mdix_get(struct ethtool_link_ksettings *ecmd,
+ {
+ 	prestera_port_mdix_cache(port);
+ 
+-	ecmd->base.eth_tp_mdix = port->link_params.mdix.status;
+-	ecmd->base.eth_tp_mdix_ctrl = port->link_params.mdix.admin_mode;
++	ecmd->base.eth_tp_mdix = port->state_phy.mdix;
++	ecmd->base.eth_tp_mdix_ctrl = port->cfg_phy.mdix;
+ }
+ 
+ static void prestera_port_remote_cap_get(struct ethtool_link_ksettings *ecmd,
+ 					 struct prestera_port *port)
+ {
+-	struct prestera_port_link_params *params = &port->link_params;
++	struct prestera_port_phy_state *state = &port->state_phy;
+ 	bool asym_pause;
+ 	bool pause;
+ 	u64 bitmap;
+ 
+ 	prestera_port_remote_cap_cache(port);
+ 
+-	bitmap = params->lmode_bmap;
++	bitmap = state->lmode_bmap;
+ 
+ 	prestera_modes_to_eth(ecmd->link_modes.lp_advertising,
+-			      bitmap, 0, MVSW_PORT_TYPE_NONE);
++			      bitmap, 0, PRESTERA_PORT_TYPE_NONE);
+ 
+ 	if (!bitmap_empty(ecmd->link_modes.lp_advertising,
+ 			  __ETHTOOL_LINK_MODE_MASK_NBITS)) {
+@@ -416,8 +402,8 @@ static void prestera_port_remote_cap_get(struct ethtool_link_ksettings *ecmd,
+ 						     Autoneg);
+ 	}
+ 
+-	pause = params->remote_fc.pause;
+-	asym_pause = params->remote_fc.asym_pause;
++	pause = state->remote_fc.pause;
++	asym_pause = state->remote_fc.asym_pause;
+ 
+ 	if (pause)
+ 		ethtool_link_ksettings_add_link_mode(ecmd,
+@@ -435,10 +421,10 @@ static void prestera_port_remote_cap_get(struct ethtool_link_ksettings *ecmd,
+ int prestera_port_link_mode_set(struct prestera_port *port,
+ 				u32 speed, u8 duplex, u8 type)
+ {
+-	u32 new_mode = MVSW_LINK_MODE_MAX;
++	u32 new_mode = PRESTERA_LINK_MODE_MAX;
+ 	u32 mode;
+ 
+-	for (mode = 0; mode < MVSW_LINK_MODE_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_LINK_MODE_MAX; mode++) {
+ 		if (speed != SPEED_UNKNOWN &&
+ 		    speed != prestera_link_modes[mode].speed)
+ 			continue;
+@@ -455,20 +441,21 @@ int prestera_port_link_mode_set(struct prestera_port *port,
+ 		/* Find highest compatible mode */
+ 	}
+ 
+-	if (new_mode == MVSW_LINK_MODE_MAX) {
++	if (new_mode == PRESTERA_LINK_MODE_MAX) {
+ 		netdev_err(port->net_dev, "Unsupported speed/duplex requested");
+ 		return -EINVAL;
+ 	}
+ 
+-	if (mvsw_pr_hw_port_phy_mode_set(port, port->cfg_phy.admin,
+-					 false, new_mode, 0))
++	if (prestera_hw_port_phy_mode_set(port, port->cfg_phy.admin,
++					  false, new_mode, 0,
++					  port->cfg_phy.mdix))
+ 		return -EINVAL;
+ 
+ 	/* TODO: move all this parameters to cfg_phy */
+ 	port->autoneg = false;
+ 	port->cfg_phy.mode = new_mode;
+ 	port->adver_link_modes = 0;
+-	port->adver_fec = BIT(MVSW_PORT_FEC_OFF_BIT);
++	port->adver_fec = BIT(PRESTERA_PORT_FEC_OFF);
+ 
+ 	return 0;
+ }
+@@ -483,7 +470,7 @@ static void prestera_port_autoneg_get(struct ethtool_link_ksettings *ecmd,
+ 			      port->caps.supp_fec,
+ 			      port->caps.type);
+ 
+-	if (port->caps.type != MVSW_PORT_TYPE_TP)
++	if (port->caps.type != PRESTERA_PORT_TYPE_TP)
+ 		return;
+ 
+ 	ethtool_link_ksettings_add_link_mode(ecmd, supported, Autoneg);
+@@ -498,7 +485,7 @@ static void prestera_port_autoneg_get(struct ethtool_link_ksettings *ecmd,
+ 				      port->caps.type);
+ 		ethtool_link_ksettings_add_link_mode(ecmd, advertising,
+ 						     Autoneg);
+-	} else if (port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER)
++	} else if (port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER)
+ 		ethtool_link_ksettings_add_link_mode(ecmd, advertising,
+ 						     Autoneg);
+ }
+@@ -529,7 +516,7 @@ static int prestera_modes_from_eth(struct prestera_port *port,
+ 
+ 	*link_modes  = 0;
+ 	*fec = 0;
+-	for (mode = 0; mode < MVSW_LINK_MODE_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_LINK_MODE_MAX; mode++) {
+ 		if (!test_bit(prestera_link_modes[mode].eth_mode, advertising))
+ 			continue;
+ 		if (prestera_link_modes[mode].port_type != port->caps.type)
+@@ -537,7 +524,7 @@ static int prestera_modes_from_eth(struct prestera_port *port,
+ 		*link_modes |= prestera_link_modes[mode].pr_mask;
+ 	}
+ 
+-	for (mode = 0; mode < MVSW_PORT_FEC_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_PORT_FEC_MAX; mode++) {
+ 		if (!test_bit(prestera_fec_caps[mode].eth_mode, advertising))
+ 			continue;
+ 		*fec |= prestera_fec_caps[mode].pr_fec;
+@@ -551,7 +538,7 @@ static int prestera_modes_from_eth(struct prestera_port *port,
+ 		*link_modes = port->adver_link_modes;
+ 	if (*fec == 0)
+ 		*fec = port->adver_fec ? port->adver_fec :
+-					 BIT(MVSW_PORT_FEC_OFF_BIT);
++					 BIT(PRESTERA_PORT_FEC_OFF);
+ 
+ 	return 0;
+ }
+@@ -562,7 +549,7 @@ static void prestera_port_supp_types_get(struct ethtool_link_ksettings *ecmd,
+ 	u32 mode;
+ 	u8 ptype;
+ 
+-	for (mode = 0; mode < MVSW_LINK_MODE_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_LINK_MODE_MAX; mode++) {
+ 		if ((prestera_link_modes[mode].pr_mask &
+ 		    port->caps.supp_link_modes) == 0)
+ 			continue;
+@@ -577,8 +564,8 @@ static void prestera_port_link_mode_get(struct ethtool_link_ksettings *ecmd,
+ {
+ 	prestera_port_link_mode_cache(port);
+ 
+-	ecmd->base.speed = port->link_params.speed;
+-	ecmd->base.duplex = port->link_params.duplex;
++	ecmd->base.speed = port->state_mac.speed;
++	ecmd->base.duplex = port->state_mac.duplex;
+ }
+ 
+ static void prestera_port_get_drvinfo(struct net_device *dev,
+@@ -600,7 +587,7 @@ static void prestera_port_get_drvinfo(struct net_device *dev,
+ static void prestera_port_type_get(struct ethtool_link_ksettings *ecmd,
+ 				   struct prestera_port *port)
+ {
+-	if (port->caps.type < MVSW_PORT_TYPE_MAX)
++	if (port->caps.type < PRESTERA_PORT_TYPE_MAX)
+ 		ecmd->base.port = prestera_port_types[port->caps.type].eth_type;
+ 	else
+ 		ecmd->base.port = PORT_OTHER;
+@@ -611,9 +598,9 @@ static int prestera_port_type_set(const struct ethtool_link_ksettings *ecmd,
+ {
+ 	int err;
+ 	u32 type, mode;
+-	u32 new_mode = MVSW_LINK_MODE_MAX;
++	u32 new_mode = PRESTERA_LINK_MODE_MAX;
+ 
+-	for (type = 0; type < MVSW_PORT_TYPE_MAX; type++) {
++	for (type = 0; type < PRESTERA_PORT_TYPE_MAX; type++) {
+ 		if (prestera_port_types[type].eth_type == ecmd->base.port &&
+ 		    test_bit(prestera_port_types[type].eth_mode,
+ 			     ecmd->link_modes.supported)) {
+@@ -627,12 +614,12 @@ static int prestera_port_type_set(const struct ethtool_link_ksettings *ecmd,
+ 	if (type != port->caps.type && ecmd->base.autoneg == AUTONEG_ENABLE)
+ 		return -EINVAL;
+ 
+-	if (type == MVSW_PORT_TYPE_MAX) {
++	if (type == PRESTERA_PORT_TYPE_MAX) {
+ 		pr_err("Unsupported port type requested\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	for (mode = 0; mode < MVSW_LINK_MODE_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_LINK_MODE_MAX; mode++) {
+ 		if ((prestera_link_modes[mode].pr_mask &
+ 		    port->caps.supp_link_modes) &&
+ 		    type == prestera_link_modes[mode].port_type) {
+@@ -640,7 +627,7 @@ static int prestera_port_type_set(const struct ethtool_link_ksettings *ecmd,
+ 		}
+ 	}
+ 
+-	if (new_mode < MVSW_LINK_MODE_MAX)
++	if (new_mode < PRESTERA_LINK_MODE_MAX)
+ 	{
+ 		/* err = mvsw_pr_hw_port_link_mode_set(port, new_mode); */
+ 		pr_err("Unexpected call of type set on integral phy");
+@@ -659,10 +646,15 @@ static int prestera_port_mdix_set(const struct ethtool_link_ksettings *ecmd,
+ 				  struct prestera_port *port)
+ {
+ 	if (ecmd->base.eth_tp_mdix_ctrl != ETH_TP_MDI_INVALID &&
+-	    port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER &&
+-	    port->caps.type == MVSW_PORT_TYPE_TP)
+-		return mvsw_pr_hw_port_mdix_set(port,
+-						ecmd->base.eth_tp_mdix_ctrl);
++	    port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER &&
++	    port->caps.type == PRESTERA_PORT_TYPE_TP) {
++		port->cfg_phy.mdix = ecmd->base.eth_tp_mdix_ctrl;
++		return prestera_hw_port_phy_mode_set(port, port->cfg_phy.admin,
++						     port->autoneg,
++						     port->cfg_phy.mode,
++						     port->adver_link_modes,
++						     port->cfg_phy.mdix);
++	}
+ 	return 0;
+ }
+ 
+@@ -691,7 +683,7 @@ static int prestera_port_get_link_ksettings(struct net_device *dev,
+ 	prestera_port_autoneg_get(ecmd, port);
+ 
+ 	if (port->autoneg && netif_carrier_ok(dev) &&
+-	    port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER)
++	    port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER)
+ 		prestera_port_remote_cap_get(ecmd, port);
+ 
+ 	if (netif_carrier_ok(dev))
+@@ -699,8 +691,8 @@ static int prestera_port_get_link_ksettings(struct net_device *dev,
+ 
+ 	prestera_port_type_get(ecmd, port);
+ 
+-	if (port->caps.type == MVSW_PORT_TYPE_TP &&
+-	    port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER)
++	if (port->caps.type == PRESTERA_PORT_TYPE_TP &&
++	    port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER)
+ 		prestera_port_mdix_get(ecmd, port);
+ 
+ 	return 0;
+@@ -724,7 +716,7 @@ static int prestera_port_set_link_ksettings(struct net_device *dev,
+ 	if (err)
+ 		return err;
+ 
+-	if (port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER) {
++	if (port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER) {
+ 		err = prestera_port_mdix_set(ecmd, port);
+ 		if (err)
+ 			return err;
+@@ -749,8 +741,8 @@ static int prestera_port_set_link_ksettings(struct net_device *dev,
+ 						  DUPLEX_UNKNOWN :
+ 						  (ecmd->base.duplex ==
+ 						   DUPLEX_HALF ?
+-						   MVSW_PORT_DUPLEX_HALF :
+-						   MVSW_PORT_DUPLEX_FULL),
++						   PRESTERA_PORT_DUPLEX_HALF :
++						   PRESTERA_PORT_DUPLEX_FULL),
+ 						  port->caps.type);
+ 	else
+ 		err = prestera_port_autoneg_set(port, adver_modes);
+@@ -766,9 +758,9 @@ static int prestera_port_nway_reset(struct net_device *dev)
+ 	struct prestera_port *port = netdev_priv(dev);
+ 
+ 	if (netif_running(dev) &&
+-	    port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER &&
+-	    port->caps.type == MVSW_PORT_TYPE_TP)
+-		return mvsw_pr_hw_port_autoneg_restart(port);
++	    port->caps.transceiver == PRESTERA_PORT_TCVR_COPPER &&
++	    port->caps.type == PRESTERA_PORT_TYPE_TP)
++		return prestera_hw_port_autoneg_restart(port);
+ 
+ 	return -EINVAL;
+ }
+@@ -781,18 +773,18 @@ static int prestera_port_get_fecparam(struct net_device *dev,
+ 	u8 active;
+ 	int err;
+ 
+-	err = mvsw_pr_hw_port_mac_mode_get(port, NULL, NULL, NULL, &active);
++	err = prestera_hw_port_mac_mode_get(port, NULL, NULL, NULL, &active);
+ 	if (err)
+ 		return err;
+ 
+ 	fecparam->fec = 0;
+-	for (mode = 0; mode < MVSW_PORT_FEC_MAX; mode++) {
++	for (mode = 0; mode < PRESTERA_PORT_FEC_MAX; mode++) {
+ 		if ((prestera_fec_caps[mode].pr_fec & port->caps.supp_fec) == 0)
+ 			continue;
+ 		fecparam->fec |= prestera_fec_caps[mode].eth_fec;
+ 	}
+ 
+-	if (active < MVSW_PORT_FEC_MAX)
++	if (active < PRESTERA_PORT_FEC_MAX)
+ 		fecparam->active_fec = prestera_fec_caps[active].eth_fec;
+ 	else
+ 		fecparam->active_fec = ETHTOOL_FEC_AUTO;
+@@ -813,13 +805,13 @@ static int prestera_port_set_fecparam(struct net_device *dev,
+ 		return -EINVAL;
+ 	}
+ 
+-	if (port->caps.transceiver == MVSW_PORT_TRANSCEIVER_SFP) {
++	if (port->caps.transceiver == PRESTERA_PORT_TCVR_SFP) {
+ 		netdev_err(dev, "FEC set is not allowed on non-SFP ports\n");
+ 		return -EINVAL;
+ 	}
+ 
+-	fec = MVSW_PORT_FEC_MAX;
+-	for (mode = 0; mode < MVSW_PORT_FEC_MAX; mode++) {
++	fec = PRESTERA_PORT_FEC_MAX;
++	for (mode = 0; mode < PRESTERA_PORT_FEC_MAX; mode++) {
+ 		if ((prestera_fec_caps[mode].eth_fec & fecparam->fec) &&
+ 		    (prestera_fec_caps[mode].pr_fec & port->caps.supp_fec)) {
+ 			fec = mode;
+@@ -832,7 +824,7 @@ static int prestera_port_set_fecparam(struct net_device *dev,
+ 	if (fec == cfg_mac.fec)
+ 		return 0;
+ 
+-	if (fec == MVSW_PORT_FEC_MAX) {
++	if (fec == PRESTERA_PORT_FEC_MAX) {
+ 		netdev_err(dev, "Unsupported FEC requested");
+ 		return -EINVAL;
+ 	}
+@@ -874,35 +866,22 @@ static void prestera_port_get_strings(struct net_device *dev,
+ void prestera_ethtool_port_state_changed(struct prestera_port *port,
+ 					 struct prestera_port_event *evt)
+ {
+-	struct prestera_port_link_params *params = &port->link_params;
+-
+-	params->oper_state = evt->data.oper_state;
++	struct prestera_port_mac_state *smac = &port->state_mac;
+ 
+-	if (params->oper_state) {
+-		if (port->autoneg &&
+-		    port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER) {
+-			params->lmode_bmap = evt->data.lmode_bmap;
+-			params->remote_fc.pause = evt->data.pause;
+-			params->remote_fc.asym_pause = evt->data.asym_pause;
+-		}
+-
+-		/* TODO: must be different modes senses for MAC/PHY link */
+-		params->speed = prestera_link_modes[evt->data.link_mode].speed;
+-		params->duplex = prestera_link_modes[evt->data.link_mode].duplex;
++	smac->oper = evt->data.mac.oper;
+ 
+-		if (port->caps.transceiver == MVSW_PORT_TRANSCEIVER_COPPER &&
+-		    port->caps.type == MVSW_PORT_TYPE_TP) {
+-			params->mdix.status = evt->data.status;
+-			params->mdix.admin_mode = evt->data.admin_mode;
+-		}
++	if (smac->oper) {
++		smac->mode = evt->data.mac.mode;
++		smac->speed = evt->data.mac.speed;
++		smac->duplex = evt->data.mac.duplex;
++		smac->fc = evt->data.mac.fc;
++		smac->fec = evt->data.mac.fec;
+ 	} else {
+-		params->remote_fc.pause = false;
+-		params->remote_fc.asym_pause = false;
+-		params->lmode_bmap = 0;
+-		params->speed = SPEED_UNKNOWN;
+-		params->duplex = DUPLEX_UNKNOWN;
+-		params->mdix.status = ETH_TP_MDI_INVALID;
+-		params->mdix.admin_mode = ETH_TP_MDI_INVALID;
++		smac->mode = PRESTERA_MAC_MODE_MAX;
++		smac->speed = SPEED_UNKNOWN;
++		smac->duplex = DUPLEX_UNKNOWN;
++		smac->fc = 0;
++		smac->fec = 0;
+ 	}
+ }
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_fw_log.c b/drivers/net/ethernet/marvell/prestera/prestera_fw_log.c
+index 5369bbc..c5ef238 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_fw_log.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_fw_log.c
+@@ -48,7 +48,7 @@ struct mvsw_pr_fw_log_prv_debugfs {
+ 	char *read_buf;
+ };
+ 
+-static u8 fw_log_lib_type_config[MVSW_FW_LOG_LIB_MAX] = { 0 };
++static u8 fw_log_lib_type_config[PRESTERA_FW_LOG_LIB_MAX] = { 0 };
+ 
+ static struct mvsw_pr_fw_log_prv_debugfs fw_log_debugfs_handle = {
+ 	.cfg_dir = NULL,
+@@ -60,68 +60,68 @@ static struct mvsw_pr_fw_log_prv_debugfs fw_log_debugfs_handle = {
+ 	}
+ };
+ 
+-static const char *mvsw_pr_fw_log_lib_id2name[MVSW_FW_LOG_LIB_MAX] = {
+-	[MVSW_FW_LOG_LIB_ALL] =  "all",
+-	[MVSW_FW_LOG_LIB_BRIDGE] =  "bridge",
+-	[MVSW_FW_LOG_LIB_CNC] =  "cnc",
+-	[MVSW_FW_LOG_LIB_CONFIG] =  "config",
+-	[MVSW_FW_LOG_LIB_COS] =  "cos",
+-	[MVSW_FW_LOG_LIB_CSCD] =  "cscd",
+-	[MVSW_FW_LOG_LIB_CUT_THROUGH] =  "cut-through",
+-	[MVSW_FW_LOG_LIB_DIAG] =  "diag",
+-	[MVSW_FW_LOG_LIB_DRAGONITE] =  "dragonite",
+-	[MVSW_FW_LOG_LIB_EGRESS] =  "egress",
+-	[MVSW_FW_LOG_LIB_EXACT_MATCH] =  "exact-match",
+-	[MVSW_FW_LOG_LIB_FABRIC] =  "fabric",
+-	[MVSW_FW_LOG_LIB_BRIDGE_FDB_MANAGER] =  "fdb-manager",
+-	[MVSW_FW_LOG_LIB_FLOW_MANAGER] =  "flow-manager",
+-	[MVSW_FW_LOG_LIB_HW_INIT] =  "hw-init",
+-	[MVSW_FW_LOG_LIB_I2C] =  "i2c",
+-	[MVSW_FW_LOG_LIB_INGRESS] =  "ingress",
+-	[MVSW_FW_LOG_LIB_INIT] =  "init",
+-	[MVSW_FW_LOG_LIB_IPFIX] =  "ipfix",
+-	[MVSW_FW_LOG_LIB_IP] =  "ip",
+-	[MVSW_FW_LOG_LIB_IP_LPM] =  "ip-lpm",
+-	[MVSW_FW_LOG_LIB_L2_MLL] =  "l2-mll",
+-	[MVSW_FW_LOG_LIB_LATENCY_MONITORING] =  "latency-monitoring",
+-	[MVSW_FW_LOG_LIB_LOGICAL_TARGET] =  "logical-target",
+-	[MVSW_FW_LOG_LIB_LPM] =  "lpm",
+-	[MVSW_FW_LOG_LIB_MIRROR] =  "mirror",
+-	[MVSW_FW_LOG_LIB_MULTI_PORT_GROUP] =  "multi-port-group",
+-	[MVSW_FW_LOG_LIB_NETWORK_IF] =  "network-if",
+-	[MVSW_FW_LOG_LIB_NST] =  "nst",
+-	[MVSW_FW_LOG_LIB_OAM] =  "oam",
+-	[MVSW_FW_LOG_LIB_PACKET_ANALYZER] =  "packet-analyzer",
+-	[MVSW_FW_LOG_LIB_PCL] =  "pcl",
+-	[MVSW_FW_LOG_LIB_PHA] =  "pha",
+-	[MVSW_FW_LOG_LIB_PHY] =  "phy",
+-	[MVSW_FW_LOG_LIB_POLICER] =  "policer",
+-	[MVSW_FW_LOG_LIB_PROTECTION] =  "protection",
+-	[MVSW_FW_LOG_LIB_PTP] =  "ptp",
+-	[MVSW_FW_LOG_LIB_RESOURCE_MANAGER] =  "resource-manager",
+-	[MVSW_FW_LOG_LIB_SMI] =  "smi",
+-	[MVSW_FW_LOG_LIB_SYSTEM_RECOVERY] =  "system-recovery",
+-	[MVSW_FW_LOG_LIB_TAM] =  "tam",
+-	[MVSW_FW_LOG_LIB_TCAM] =  "tcam",
+-	[MVSW_FW_LOG_LIB_TM] =  "tm",
+-	[MVSW_FW_LOG_LIB_TM_GLUE] =  "tm-glue",
+-	[MVSW_FW_LOG_LIB_TRUNK] =  "trunk",
+-	[MVSW_FW_LOG_LIB_TTI] =  "tti",
+-	[MVSW_FW_LOG_LIB_TUNNEL] =  "tunnel",
+-	[MVSW_FW_LOG_LIB_VERSION] =  "version",
+-	[MVSW_FW_LOG_LIB_VIRTUAL_TCAM] =  "virtual-tcam",
+-	[MVSW_FW_LOG_LIB_VNT] =  "vnt",
+-	[MVSW_FW_LOG_LIB_PPU] = "ppu",
+-	[MVSW_FW_LOG_LIB_EXACT_MATCH_MANAGER] = "exact-match-manager",
+-	[MVSW_FW_LOG_LIB_MAC_SEC] = "mac-sec",
++static const char *mvsw_pr_fw_log_lib_id2name[PRESTERA_FW_LOG_LIB_MAX] = {
++	[PRESTERA_FW_LOG_LIB_ALL] =  "all",
++	[PRESTERA_FW_LOG_LIB_BRIDGE] =  "bridge",
++	[PRESTERA_FW_LOG_LIB_CNC] =  "cnc",
++	[PRESTERA_FW_LOG_LIB_CONFIG] =  "config",
++	[PRESTERA_FW_LOG_LIB_COS] =  "cos",
++	[PRESTERA_FW_LOG_LIB_CSCD] =  "cscd",
++	[PRESTERA_FW_LOG_LIB_CUT_THROUGH] =  "cut-through",
++	[PRESTERA_FW_LOG_LIB_DIAG] =  "diag",
++	[PRESTERA_FW_LOG_LIB_DRAGONITE] =  "dragonite",
++	[PRESTERA_FW_LOG_LIB_EGRESS] =  "egress",
++	[PRESTERA_FW_LOG_LIB_EXACT_MATCH] =  "exact-match",
++	[PRESTERA_FW_LOG_LIB_FABRIC] =  "fabric",
++	[PRESTERA_FW_LOG_LIB_BRIDGE_FDB_MANAGER] =  "fdb-manager",
++	[PRESTERA_FW_LOG_LIB_FLOW_MANAGER] =  "flow-manager",
++	[PRESTERA_FW_LOG_LIB_HW_INIT] =  "hw-init",
++	[PRESTERA_FW_LOG_LIB_I2C] =  "i2c",
++	[PRESTERA_FW_LOG_LIB_INGRESS] =  "ingress",
++	[PRESTERA_FW_LOG_LIB_INIT] =  "init",
++	[PRESTERA_FW_LOG_LIB_IPFIX] =  "ipfix",
++	[PRESTERA_FW_LOG_LIB_IP] =  "ip",
++	[PRESTERA_FW_LOG_LIB_IP_LPM] =  "ip-lpm",
++	[PRESTERA_FW_LOG_LIB_L2_MLL] =  "l2-mll",
++	[PRESTERA_FW_LOG_LIB_LATENCY_MONITORING] =  "latency-monitoring",
++	[PRESTERA_FW_LOG_LIB_LOGICAL_TARGET] =  "logical-target",
++	[PRESTERA_FW_LOG_LIB_LPM] =  "lpm",
++	[PRESTERA_FW_LOG_LIB_MIRROR] =  "mirror",
++	[PRESTERA_FW_LOG_LIB_MULTI_PORT_GROUP] =  "multi-port-group",
++	[PRESTERA_FW_LOG_LIB_NETWORK_IF] =  "network-if",
++	[PRESTERA_FW_LOG_LIB_NST] =  "nst",
++	[PRESTERA_FW_LOG_LIB_OAM] =  "oam",
++	[PRESTERA_FW_LOG_LIB_PACKET_ANALYZER] =  "packet-analyzer",
++	[PRESTERA_FW_LOG_LIB_PCL] =  "pcl",
++	[PRESTERA_FW_LOG_LIB_PHA] =  "pha",
++	[PRESTERA_FW_LOG_LIB_PHY] =  "phy",
++	[PRESTERA_FW_LOG_LIB_POLICER] =  "policer",
++	[PRESTERA_FW_LOG_LIB_PROTECTION] =  "protection",
++	[PRESTERA_FW_LOG_LIB_PTP] =  "ptp",
++	[PRESTERA_FW_LOG_LIB_RESOURCE_MANAGER] =  "resource-manager",
++	[PRESTERA_FW_LOG_LIB_SMI] =  "smi",
++	[PRESTERA_FW_LOG_LIB_SYSTEM_RECOVERY] =  "system-recovery",
++	[PRESTERA_FW_LOG_LIB_TAM] =  "tam",
++	[PRESTERA_FW_LOG_LIB_TCAM] =  "tcam",
++	[PRESTERA_FW_LOG_LIB_TM] =  "tm",
++	[PRESTERA_FW_LOG_LIB_TM_GLUE] =  "tm-glue",
++	[PRESTERA_FW_LOG_LIB_TRUNK] =  "trunk",
++	[PRESTERA_FW_LOG_LIB_TTI] =  "tti",
++	[PRESTERA_FW_LOG_LIB_TUNNEL] =  "tunnel",
++	[PRESTERA_FW_LOG_LIB_VERSION] =  "version",
++	[PRESTERA_FW_LOG_LIB_VIRTUAL_TCAM] =  "virtual-tcam",
++	[PRESTERA_FW_LOG_LIB_VNT] =  "vnt",
++	[PRESTERA_FW_LOG_LIB_PPU] = "ppu",
++	[PRESTERA_FW_LOG_LIB_EXACT_MATCH_MANAGER] = "exact-match-manager",
++	[PRESTERA_FW_LOG_LIB_MAC_SEC] = "mac-sec",
+ };
+ 
+-static const char *mvsw_pr_fw_log_prv_type_id2name[MVSW_FW_LOG_TYPE_MAX] = {
+-	[MVSW_FW_LOG_TYPE_INFO] = "info",
+-	[MVSW_FW_LOG_TYPE_ENTRY_LEVEL_FUNCTION] = "entry-level-function",
+-	[MVSW_FW_LOG_TYPE_ERROR] = "error",
+-	[MVSW_FW_LOG_TYPE_ALL] = "all",
+-	[MVSW_FW_LOG_TYPE_NONE]  = "none",
++static const char *mvsw_pr_fw_log_prv_type_id2name[PRESTERA_FW_LOG_TYPE_MAX] = {
++	[PRESTERA_FW_LOG_TYPE_INFO] = "info",
++	[PRESTERA_FW_LOG_TYPE_ENTRY_LEVEL_FUNCTION] = "entry-level-function",
++	[PRESTERA_FW_LOG_TYPE_ERROR] = "error",
++	[PRESTERA_FW_LOG_TYPE_ALL] = "all",
++	[PRESTERA_FW_LOG_TYPE_NONE]  = "none",
+ };
+ 
+ static void mvsw_pr_fw_log_evt_handler(struct prestera_switch *sw,
+@@ -151,9 +151,9 @@ static ssize_t mvsw_pr_fw_log_format_str(void)
+ 
+ 	chars_written += ret;
+ 
+-	for (type = 0; type < MVSW_FW_LOG_TYPE_MAX; ++type) {
+-		if (type == MVSW_FW_LOG_TYPE_NONE ||
+-		    type == MVSW_FW_LOG_TYPE_ALL)
++	for (type = 0; type < PRESTERA_FW_LOG_TYPE_MAX; ++type) {
++		if (type == PRESTERA_FW_LOG_TYPE_NONE ||
++		    type == PRESTERA_FW_LOG_TYPE_ALL)
+ 			continue;
+ 
+ 		ret = snprintf(buf + chars_written,
+@@ -169,8 +169,8 @@ static ssize_t mvsw_pr_fw_log_format_str(void)
+ 	strcat(buf, "\n");
+ 	++chars_written;
+ 
+-	for (lib = 0; lib < MVSW_FW_LOG_LIB_MAX; ++lib) {
+-		if (lib == MVSW_FW_LOG_LIB_ALL ||
++	for (lib = 0; lib < PRESTERA_FW_LOG_LIB_MAX; ++lib) {
++		if (lib == PRESTERA_FW_LOG_LIB_ALL ||
+ 		    !mvsw_pr_fw_log_lib_id2name[lib])
+ 			continue;
+ 
+@@ -183,9 +183,9 @@ static ssize_t mvsw_pr_fw_log_format_str(void)
+ 
+ 		chars_written += ret;
+ 
+-		for (type = 0; type < MVSW_FW_LOG_TYPE_MAX; ++type) {
+-			if (type == MVSW_FW_LOG_TYPE_NONE ||
+-			    type == MVSW_FW_LOG_TYPE_ALL)
++		for (type = 0; type < PRESTERA_FW_LOG_TYPE_MAX; ++type) {
++			if (type == PRESTERA_FW_LOG_TYPE_NONE ||
++			    type == PRESTERA_FW_LOG_TYPE_ALL)
+ 				continue;
+ 
+ 			ret = snprintf(buf + chars_written,
+@@ -255,9 +255,10 @@ static int mvsw_pr_fw_log_parse_usr_input(int *name, int *type,
+ 	*name = mvsw_pr_fw_log_get_lib_from_str(lib_str);
+ 	*type = mvsw_pr_fw_log_get_type_from_str(type_str);
+ 
+-	if (*name >= MVSW_FW_LOG_LIB_MAX ||
+-	    *type >= MVSW_FW_LOG_TYPE_MAX ||
+-	    (*name != MVSW_FW_LOG_LIB_ALL && *type == MVSW_FW_LOG_TYPE_NONE))
++	if (*name >= PRESTERA_FW_LOG_LIB_MAX ||
++	    *type >= PRESTERA_FW_LOG_TYPE_MAX ||
++	    (*name != PRESTERA_FW_LOG_LIB_ALL &&
++	     *type == PRESTERA_FW_LOG_TYPE_NONE))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -276,33 +277,36 @@ static ssize_t mvsw_pr_fw_log_debugfs_write(struct file *file,
+ 	if (err)
+ 		goto error;
+ 
+-	err = mvsw_pr_hw_fw_log_level_set(sw, lib, type);
++	err = prestera_hw_fw_log_level_set(sw, lib, type);
+ 	if (err) {
+ 		dev_err(mvsw_dev(sw), "Failed to send request to firmware\n");
+ 		return err;
+ 	}
+ 
+ 	/* specific lib and specific type */
+-	if (lib != MVSW_FW_LOG_LIB_ALL && type != MVSW_FW_LOG_TYPE_ALL) {
++	if (lib != PRESTERA_FW_LOG_LIB_ALL &&
++	    type != PRESTERA_FW_LOG_TYPE_ALL) {
+ 		/* special type 'NONE' to disable feature */
+-		if (type == MVSW_FW_LOG_TYPE_NONE)
++		if (type == PRESTERA_FW_LOG_TYPE_NONE)
+ 			memset(fw_log_lib_type_config, 0,
+ 			       sizeof(fw_log_lib_type_config));
+ 		/* Actual type should be switched */
+ 		else
+ 			fw_log_lib_type_config[lib] ^= (1 << type);
+ 	/* specific lib but all types */
+-	} else if (lib != MVSW_FW_LOG_LIB_ALL && type == MVSW_FW_LOG_TYPE_ALL) {
+-		for (j = 0; j < MVSW_FW_LOG_TYPE_ALL; ++j)
++	} else if (lib != PRESTERA_FW_LOG_LIB_ALL &&
++		   type == PRESTERA_FW_LOG_TYPE_ALL) {
++		for (j = 0; j < PRESTERA_FW_LOG_TYPE_ALL; ++j)
+ 			fw_log_lib_type_config[lib] ^= (1 << j);
+ 	/* specific type but all libs */
+-	} else if (lib == MVSW_FW_LOG_LIB_ALL && type != MVSW_FW_LOG_TYPE_ALL) {
+-		for (i = 0; i < MVSW_FW_LOG_LIB_ALL; ++i)
++	} else if (lib == PRESTERA_FW_LOG_LIB_ALL &&
++		   type != PRESTERA_FW_LOG_TYPE_ALL) {
++		for (i = 0; i < PRESTERA_FW_LOG_LIB_ALL; ++i)
+ 			fw_log_lib_type_config[i] |= (1 << type);
+ 	/* all libs and all types */
+ 	} else {
+-		for (i = 0; i < MVSW_FW_LOG_LIB_ALL; ++i) {
+-			for (j = 0; j < MVSW_FW_LOG_TYPE_ALL; ++j)
++		for (i = 0; i < PRESTERA_FW_LOG_LIB_ALL; ++i) {
++			for (j = 0; j < PRESTERA_FW_LOG_TYPE_ALL; ++j)
+ 				fw_log_lib_type_config[i] |= (1 << j);
+ 		}
+ 	}
+@@ -330,7 +334,7 @@ static inline int mvsw_pr_fw_log_get_type_from_str(const char *str)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < MVSW_FW_LOG_TYPE_MAX; ++i) {
++	for (i = 0; i < PRESTERA_FW_LOG_TYPE_MAX; ++i) {
+ 		if (!mvsw_pr_fw_log_prv_type_id2name[i])
+ 			continue;
+ 
+@@ -338,14 +342,14 @@ static inline int mvsw_pr_fw_log_get_type_from_str(const char *str)
+ 			return i;
+ 	}
+ 
+-	return MVSW_FW_LOG_TYPE_MAX;
++	return PRESTERA_FW_LOG_TYPE_MAX;
+ }
+ 
+ static inline int mvsw_pr_fw_log_get_lib_from_str(const char *str)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < MVSW_FW_LOG_LIB_MAX; ++i) {
++	for (i = 0; i < PRESTERA_FW_LOG_LIB_MAX; ++i) {
+ 		if (!mvsw_pr_fw_log_lib_id2name[i])
+ 			continue;
+ 
+@@ -353,19 +357,20 @@ static inline int mvsw_pr_fw_log_get_lib_from_str(const char *str)
+ 			return i;
+ 	}
+ 
+-	return MVSW_FW_LOG_LIB_MAX;
++	return PRESTERA_FW_LOG_LIB_MAX;
+ }
+ 
+ static int mvsw_pr_fw_log_event_handler_register(struct prestera_switch *sw)
+ {
+-	return mvsw_pr_hw_event_handler_register(sw, MVSW_EVENT_TYPE_FW_LOG,
+-						 mvsw_pr_fw_log_evt_handler,
+-						 NULL);
++	return prestera_hw_event_handler_register(sw,
++						  PRESTERA_EVENT_TYPE_FW_LOG,
++						  mvsw_pr_fw_log_evt_handler,
++						  NULL);
+ }
+ 
+ static void mvsw_pr_fw_log_event_handler_unregister(struct prestera_switch *sw)
+ {
+-	mvsw_pr_hw_event_handler_unregister(sw, MVSW_EVENT_TYPE_FW_LOG);
++	prestera_hw_event_handler_unregister(sw, PRESTERA_EVENT_TYPE_FW_LOG);
+ }
+ 
+ int mvsw_pr_fw_log_init(struct prestera_switch *sw)
+@@ -398,8 +403,8 @@ int mvsw_pr_fw_log_init(struct prestera_switch *sw)
+ 	if (!fw_log_debugfs_handle.read_buf)
+ 		goto error;
+ 
+-	mvsw_pr_hw_fw_log_level_set(sw, MVSW_FW_LOG_LIB_ALL,
+-				    MVSW_FW_LOG_TYPE_NONE);
++	prestera_hw_fw_log_level_set(sw, PRESTERA_FW_LOG_LIB_ALL,
++				     PRESTERA_FW_LOG_TYPE_NONE);
+ 	mvsw_pr_fw_log_format_str();
+ 
+ 	return 0;
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_hw.c b/drivers/net/ethernet/marvell/prestera/prestera_hw.c
+index 25eb50b..4c18d3f 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_hw.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_hw.c
+@@ -14,243 +14,232 @@
+ #include "prestera_counter.h"
+ #include "prestera_rxtx.h"
+ 
+-#define MVSW_PR_INIT_TIMEOUT 30000000	/* 30sec */
+-#define MVSW_PR_MIN_MTU 64
+-#define MVSW_PR_MSG_BUFF_CHUNK_SIZE	32	/* bytes */
+-
+-#ifndef MVSW_FW_WD_KICK_TIMEOUT
+-#define MVSW_FW_WD_KICK_TIMEOUT		1000
+-#endif /* MVSW_FW_WD_KICK_TIMEOUT */
+-
+-#ifndef MVSW_FW_KEEPALIVE_WD_MAX_KICKS
+-#define MVSW_FW_KEEPALIVE_WD_MAX_KICKS			15
+-#endif /* MVSW_FW_KEEPALIVE_WD_MAX_KICKS */
+-
+-enum mvsw_msg_type {
+-	MVSW_MSG_TYPE_SWITCH_INIT = 0x1,
+-	MVSW_MSG_TYPE_SWITCH_ATTR_SET = 0x2,
+-
+-	MVSW_MSG_TYPE_KEEPALIVE_INIT = 0x3,
+-	MVSW_MSG_TYPE_SWITCH_RESET = 0x4,
+-
+-	MVSW_MSG_TYPE_PORT_ATTR_SET = 0x100,
+-	MVSW_MSG_TYPE_PORT_ATTR_GET = 0x101,
+-	MVSW_MSG_TYPE_PORT_INFO_GET = 0x110,
+-	MVSW_MSG_TYPE_PORT_RATE_LIMIT_MODE_SET = 0x111,
+-
+-	MVSW_MSG_TYPE_VLAN_CREATE = 0x200,
+-	MVSW_MSG_TYPE_VLAN_DELETE = 0x201,
+-	MVSW_MSG_TYPE_VLAN_PORT_SET = 0x202,
+-	MVSW_MSG_TYPE_VLAN_PVID_SET = 0x203,
+-
+-	MVSW_MSG_TYPE_FDB_ADD = 0x300,
+-	MVSW_MSG_TYPE_FDB_DELETE = 0x301,
+-	MVSW_MSG_TYPE_FDB_FLUSH_PORT = 0x310,
+-	MVSW_MSG_TYPE_FDB_FLUSH_VLAN = 0x311,
+-	MVSW_MSG_TYPE_FDB_FLUSH_PORT_VLAN = 0x312,
+-	MVSW_MSG_TYPE_FDB_MACVLAN_ADD = 0x320,
+-	MVSW_MSG_TYPE_FDB_MACVLAN_DEL = 0x321,
+-
+-	MVSW_MSG_TYPE_LOG_LEVEL_SET,
+-
+-	MVSW_MSG_TYPE_BRIDGE_CREATE = 0x400,
+-	MVSW_MSG_TYPE_BRIDGE_DELETE = 0x401,
+-	MVSW_MSG_TYPE_BRIDGE_PORT_ADD = 0x402,
+-	MVSW_MSG_TYPE_BRIDGE_PORT_DELETE = 0x403,
+-
+-	MVSW_MSG_TYPE_COUNTER_GET = 0x510,
+-	MVSW_MSG_TYPE_COUNTER_ABORT = 0x511,
+-	MVSW_MSG_TYPE_COUNTER_TRIGGER = 0x512,
+-	MVSW_MSG_TYPE_COUNTER_BLOCK_GET = 0x513,
+-	MVSW_MSG_TYPE_COUNTER_BLOCK_RELEASE = 0x514,
+-	MVSW_MSG_TYPE_COUNTER_CLEAR = 0x515,
+-
+-	MVSW_MSG_TYPE_VTCAM_CREATE = 0x540,
+-	MVSW_MSG_TYPE_VTCAM_DESTROY = 0x541,
+-	MVSW_MSG_TYPE_VTCAM_RULE_ADD = 0x550,
+-	MVSW_MSG_TYPE_VTCAM_RULE_DELETE = 0x551,
+-	MVSW_MSG_TYPE_VTCAM_IFACE_BIND = 0x560,
+-	MVSW_MSG_TYPE_VTCAM_IFACE_UNBIND = 0x561,
+-
+-	MVSW_MSG_TYPE_ROUTER_RIF_CREATE = 0x600,
+-	MVSW_MSG_TYPE_ROUTER_RIF_DELETE = 0x601,
+-	MVSW_MSG_TYPE_ROUTER_RIF_SET = 0x602,
+-	MVSW_MSG_TYPE_ROUTER_LPM_ADD = 0x610,
+-	MVSW_MSG_TYPE_ROUTER_LPM_DELETE = 0x611,
+-	MVSW_MSG_TYPE_ROUTER_NH_GRP_SET = 0x622,
+-	MVSW_MSG_TYPE_ROUTER_NH_GRP_GET = 0x644,
+-	MVSW_MSG_TYPE_ROUTER_NH_GRP_BLK_GET = 0x645,
+-	MVSW_MSG_TYPE_ROUTER_NH_GRP_ADD = 0x623,
+-	MVSW_MSG_TYPE_ROUTER_NH_GRP_DELETE = 0x624,
+-	MVSW_MSG_TYPE_ROUTER_VR_CREATE = 0x630,
+-	MVSW_MSG_TYPE_ROUTER_VR_DELETE = 0x631,
+-	MVSW_MSG_TYPE_ROUTER_VR_ABORT = 0x632,
+-	MVSW_MSG_TYPE_ROUTER_MP_HASH_SET = 0x650,
+-
+-	MVSW_MSG_TYPE_RXTX_INIT = 0x800,
+-
+-	MVSW_MSG_TYPE_LAG_ADD = 0x900,
+-	MVSW_MSG_TYPE_LAG_DELETE = 0x901,
+-	MVSW_MSG_TYPE_LAG_ENABLE = 0x902,
+-	MVSW_MSG_TYPE_LAG_DISABLE = 0x903,
+-	MVSW_MSG_TYPE_LAG_ROUTER_LEAVE = 0x904,
+-
+-	MVSW_MSG_TYPE_STP_PORT_SET = 0x1000,
+-
+-	MVSW_MSG_TYPE_SPAN_GET = 0X1100,
+-	MVSW_MSG_TYPE_SPAN_BIND = 0X1101,
+-	MVSW_MSG_TYPE_SPAN_UNBIND = 0X1102,
+-	MVSW_MSG_TYPE_SPAN_RELEASE = 0X1103,
+-
+-	MVSW_MSG_TYPE_NAT_PORT_NEIGH_UPDATE = 0X1200,
+-
+-	MVSW_MSG_TYPE_NAT_NH_MANGLE_ADD = 0X1211,
+-	MVSW_MSG_TYPE_NAT_NH_MANGLE_SET = 0X1212,
+-	MVSW_MSG_TYPE_NAT_NH_MANGLE_DEL = 0X1213,
+-	MVSW_MSG_TYPE_NAT_NH_MANGLE_GET = 0X1214,
+-
+-	MVSW_MSG_TYPE_CPU_CODE_COUNTERS_GET = 0x2000,
+-
+-	MVSW_MSG_TYPE_ACK = 0x10000,
+-	MVSW_MSG_TYPE_MAX
++#define PRESTERA_HW_INIT_TIMEOUT 30000000	/* 30sec */
++#define PRESTERA_HW_MIN_MTU 64
++
++#ifndef PRESTERA_FW_WD_KICK_TIMEOUT
++#define PRESTERA_FW_WD_KICK_TIMEOUT		1000
++#endif /* PRESTERA_FW_WD_KICK_TIMEOUT */
++
++#ifndef PRESTERA_FW_KEEPALIVE_WD_MAX_KICKS
++#define PRESTERA_FW_KEEPALIVE_WD_MAX_KICKS	15
++#endif /* PRESTERA_FW_KEEPALIVE_WD_MAX_KICKS */
++
++enum prestera_cmd_type_t {
++	PRESTERA_CMD_TYPE_SWITCH_INIT = 0x1,
++	PRESTERA_CMD_TYPE_SWITCH_ATTR_SET = 0x2,
++
++	PRESTERA_CMD_TYPE_KEEPALIVE_INIT = 0x3,
++	PRESTERA_CMD_TYPE_SWITCH_RESET = 0x4,
++
++	PRESTERA_CMD_TYPE_PORT_ATTR_SET = 0x100,
++	PRESTERA_CMD_TYPE_PORT_ATTR_GET = 0x101,
++	PRESTERA_CMD_TYPE_PORT_INFO_GET = 0x110,
++	PRESTERA_CMD_TYPE_PORT_RATE_LIMIT_MODE_SET = 0x111,
++
++	PRESTERA_CMD_TYPE_VLAN_CREATE = 0x200,
++	PRESTERA_CMD_TYPE_VLAN_DELETE = 0x201,
++	PRESTERA_CMD_TYPE_VLAN_PORT_SET = 0x202,
++	PRESTERA_CMD_TYPE_VLAN_PVID_SET = 0x203,
++
++	PRESTERA_CMD_TYPE_FDB_ADD = 0x300,
++	PRESTERA_CMD_TYPE_FDB_DELETE = 0x301,
++	PRESTERA_CMD_TYPE_FDB_FLUSH_PORT = 0x310,
++	PRESTERA_CMD_TYPE_FDB_FLUSH_VLAN = 0x311,
++	PRESTERA_CMD_TYPE_FDB_FLUSH_PORT_VLAN = 0x312,
++	PRESTERA_CMD_TYPE_FDB_MACVLAN_ADD = 0x320,
++	PRESTERA_CMD_TYPE_FDB_MACVLAN_DEL = 0x321,
++
++	PRESTERA_CMD_TYPE_LOG_LEVEL_SET,
++
++	PRESTERA_CMD_TYPE_BRIDGE_CREATE = 0x400,
++	PRESTERA_CMD_TYPE_BRIDGE_DELETE = 0x401,
++	PRESTERA_CMD_TYPE_BRIDGE_PORT_ADD = 0x402,
++	PRESTERA_CMD_TYPE_BRIDGE_PORT_DELETE = 0x403,
++
++	PRESTERA_CMD_TYPE_COUNTER_GET = 0x510,
++	PRESTERA_CMD_TYPE_COUNTER_ABORT = 0x511,
++	PRESTERA_CMD_TYPE_COUNTER_TRIGGER = 0x512,
++	PRESTERA_CMD_TYPE_COUNTER_BLOCK_GET = 0x513,
++	PRESTERA_CMD_TYPE_COUNTER_BLOCK_RELEASE = 0x514,
++	PRESTERA_CMD_TYPE_COUNTER_CLEAR = 0x515,
++
++	PRESTERA_CMD_TYPE_VTCAM_CREATE = 0x540,
++	PRESTERA_CMD_TYPE_VTCAM_DESTROY = 0x541,
++	PRESTERA_CMD_TYPE_VTCAM_RULE_ADD = 0x550,
++	PRESTERA_CMD_TYPE_VTCAM_RULE_DELETE = 0x551,
++	PRESTERA_CMD_TYPE_VTCAM_IFACE_BIND = 0x560,
++	PRESTERA_CMD_TYPE_VTCAM_IFACE_UNBIND = 0x561,
++
++	PRESTERA_CMD_TYPE_ROUTER_RIF_CREATE = 0x600,
++	PRESTERA_CMD_TYPE_ROUTER_RIF_DELETE = 0x601,
++	PRESTERA_CMD_TYPE_ROUTER_RIF_SET = 0x602,
++	PRESTERA_CMD_TYPE_ROUTER_LPM_ADD = 0x610,
++	PRESTERA_CMD_TYPE_ROUTER_LPM_DELETE = 0x611,
++	PRESTERA_CMD_TYPE_ROUTER_NH_GRP_SET = 0x622,
++	PRESTERA_CMD_TYPE_ROUTER_NH_GRP_GET = 0x644,
++	PRESTERA_CMD_TYPE_ROUTER_NH_GRP_BLK_GET = 0x645,
++	PRESTERA_CMD_TYPE_ROUTER_NH_GRP_ADD = 0x623,
++	PRESTERA_CMD_TYPE_ROUTER_NH_GRP_DELETE = 0x624,
++	PRESTERA_CMD_TYPE_ROUTER_VR_CREATE = 0x630,
++	PRESTERA_CMD_TYPE_ROUTER_VR_DELETE = 0x631,
++	PRESTERA_CMD_TYPE_ROUTER_VR_ABORT = 0x632,
++	PRESTERA_CMD_TYPE_ROUTER_MP_HASH_SET = 0x650,
++
++	PRESTERA_CMD_TYPE_RXTX_INIT = 0x800,
++
++	PRESTERA_CMD_TYPE_LAG_ADD = 0x900,
++	PRESTERA_CMD_TYPE_LAG_DELETE = 0x901,
++	PRESTERA_CMD_TYPE_LAG_ENABLE = 0x902,
++	PRESTERA_CMD_TYPE_LAG_DISABLE = 0x903,
++	PRESTERA_CMD_TYPE_LAG_ROUTER_LEAVE = 0x904,
++
++	PRESTERA_CMD_TYPE_STP_PORT_SET = 0x1000,
++
++	PRESTERA_CMD_TYPE_SPAN_GET = 0X1100,
++	PRESTERA_CMD_TYPE_SPAN_BIND = 0X1101,
++	PRESTERA_CMD_TYPE_SPAN_UNBIND = 0X1102,
++	PRESTERA_CMD_TYPE_SPAN_RELEASE = 0X1103,
++
++	PRESTERA_CMD_TYPE_NAT_PORT_NEIGH_UPDATE = 0X1200,
++
++	PRESTERA_CMD_TYPE_NAT_NH_MANGLE_ADD = 0X1211,
++	PRESTERA_CMD_TYPE_NAT_NH_MANGLE_SET = 0X1212,
++	PRESTERA_CMD_TYPE_NAT_NH_MANGLE_DEL = 0X1213,
++	PRESTERA_CMD_TYPE_NAT_NH_MANGLE_GET = 0X1214,
++
++	PRESTERA_CMD_TYPE_CPU_CODE_COUNTERS_GET = 0x2000,
++
++	PRESTERA_CMD_TYPE_ACK = 0x10000,
++	PRESTERA_CMD_TYPE_MAX
+ };
+ 
+-enum mvsw_msg_port_attr {
+-	MVSW_MSG_PORT_ATTR_OPER_STATE = 2,
+-	MVSW_MSG_PORT_ATTR_MTU = 3,
+-	MVSW_MSG_PORT_ATTR_MAC = 4,
+-	MVSW_MSG_PORT_ATTR_ACCEPT_FRAME_TYPE = 6,
+-	MVSW_MSG_PORT_ATTR_LEARNING = 7,
+-	MVSW_MSG_PORT_ATTR_FLOOD = 8,
+-	MVSW_MSG_PORT_ATTR_CAPABILITY = 9,
+-	MVSW_MSG_PORT_ATTR_REMOTE_CAPABILITY = 10,
+-	MVSW_MSG_PORT_ATTR_PHY_MODE = 12,
+-	MVSW_MSG_PORT_ATTR_TYPE = 13,
+-	MVSW_MSG_PORT_ATTR_STATS = 17,
+-	MVSW_MSG_PORT_ATTR_MDIX = 18,
+-	MVSW_MSG_PORT_ATTR_AUTONEG_RESTART = 19,
+-	MVSW_MSG_PORT_ATTR_SOURCE_ID_DEFAULT = 20,
+-	MVSW_MSG_PORT_ATTR_SOURCE_ID_FILTER = 21,
+-	MVSW_MSG_PORT_ATTR_MAC_MODE = 22,
+-	MVSW_MSG_PORT_ATTR_MAX
+-};
+-
+-enum mvsw_msg_switch_attr {
+-	MVSW_MSG_SWITCH_ATTR_MAC = 1,
+-	MVSW_MSG_SWITCH_ATTR_AGEING = 2,
+-	MVSW_MSG_SWITCH_ATTR_TRAP_POLICER = 3,
++enum {
++	PRESTERA_CMD_PORT_ATTR_MTU = 3,
++	PRESTERA_CMD_PORT_ATTR_MAC = 4,
++	PRESTERA_CMD_PORT_ATTR_ACCEPT_FRAME_TYPE = 6,
++	PRESTERA_CMD_PORT_ATTR_LEARNING = 7,
++	PRESTERA_CMD_PORT_ATTR_FLOOD = 8,
++	PRESTERA_CMD_PORT_ATTR_CAPABILITY = 9,
++	PRESTERA_CMD_PORT_ATTR_PHY_MODE = 12,
++	PRESTERA_CMD_PORT_ATTR_STATS = 17,
++	PRESTERA_CMD_PORT_ATTR_MAC_AUTONEG_RESTART = 18,
++	PRESTERA_CMD_PORT_ATTR_PHY_AUTONEG_RESTART = 19,
++	PRESTERA_CMD_PORT_ATTR_SOURCE_ID_DEFAULT = 20,
++	PRESTERA_CMD_PORT_ATTR_SOURCE_ID_FILTER = 21,
++	PRESTERA_CMD_PORT_ATTR_MAC_MODE = 22,
++	PRESTERA_CMD_PORT_ATTR_MAX
+ };
+ 
+ enum {
+-	MVSW_MSG_ACK_OK,
+-	MVSW_MSG_ACK_FAILED,
+-	MVSW_MSG_ACK_MAX
++	PRESTERA_CMD_SWITCH_ATTR_MAC = 1,
++	PRESTERA_CMD_SWITCH_ATTR_AGEING = 2,
++	PRESTERA_CMD_SWITCH_ATTR_TRAP_POLICER = 3,
+ };
+ 
+ enum {
+-	MVSW_PORT_TP_NA,
+-	MVSW_PORT_TP_MDI,
+-	MVSW_PORT_TP_MDIX,
+-	MVSW_PORT_TP_AUTO
++	PRESTERA_CMD_ACK_OK,
++	PRESTERA_CMD_ACK_FAILED,
++	PRESTERA_CMD_ACK_MAX
+ };
+ 
+ enum {
+-	MVSW_PORT_GOOD_OCTETS_RCV_CNT,
+-	MVSW_PORT_BAD_OCTETS_RCV_CNT,
+-	MVSW_PORT_MAC_TRANSMIT_ERR_CNT,
+-	MVSW_PORT_BRDC_PKTS_RCV_CNT,
+-	MVSW_PORT_MC_PKTS_RCV_CNT,
+-	MVSW_PORT_PKTS_64_OCTETS_CNT,
+-	MVSW_PORT_PKTS_65TO127_OCTETS_CNT,
+-	MVSW_PORT_PKTS_128TO255_OCTETS_CNT,
+-	MVSW_PORT_PKTS_256TO511_OCTETS_CNT,
+-	MVSW_PORT_PKTS_512TO1023_OCTETS_CNT,
+-	MVSW_PORT_PKTS_1024TOMAX_OCTETS_CNT,
+-	MVSW_PORT_EXCESSIVE_COLLISIONS_CNT,
+-	MVSW_PORT_MC_PKTS_SENT_CNT,
+-	MVSW_PORT_BRDC_PKTS_SENT_CNT,
+-	MVSW_PORT_FC_SENT_CNT,
+-	MVSW_PORT_GOOD_FC_RCV_CNT,
+-	MVSW_PORT_DROP_EVENTS_CNT,
+-	MVSW_PORT_UNDERSIZE_PKTS_CNT,
+-	MVSW_PORT_FRAGMENTS_PKTS_CNT,
+-	MVSW_PORT_OVERSIZE_PKTS_CNT,
+-	MVSW_PORT_JABBER_PKTS_CNT,
+-	MVSW_PORT_MAC_RCV_ERROR_CNT,
+-	MVSW_PORT_BAD_CRC_CNT,
+-	MVSW_PORT_COLLISIONS_CNT,
+-	MVSW_PORT_LATE_COLLISIONS_CNT,
+-	MVSW_PORT_GOOD_UC_PKTS_RCV_CNT,
+-	MVSW_PORT_GOOD_UC_PKTS_SENT_CNT,
+-	MVSW_PORT_MULTIPLE_PKTS_SENT_CNT,
+-	MVSW_PORT_DEFERRED_PKTS_SENT_CNT,
+-	MVSW_PORT_GOOD_OCTETS_SENT_CNT,
+-	MVSW_PORT_CNT_MAX,
++	PRESTERA_PORT_GOOD_OCTETS_RCV_CNT,
++	PRESTERA_PORT_BAD_OCTETS_RCV_CNT,
++	PRESTERA_PORT_MAC_TRANSMIT_ERR_CNT,
++	PRESTERA_PORT_BRDC_PKTS_RCV_CNT,
++	PRESTERA_PORT_MC_PKTS_RCV_CNT,
++	PRESTERA_PORT_PKTS_64_OCTETS_CNT,
++	PRESTERA_PORT_PKTS_65TO127_OCTETS_CNT,
++	PRESTERA_PORT_PKTS_128TO255_OCTETS_CNT,
++	PRESTERA_PORT_PKTS_256TO511_OCTETS_CNT,
++	PRESTERA_PORT_PKTS_512TO1023_OCTETS_CNT,
++	PRESTERA_PORT_PKTS_1024TOMAX_OCTETS_CNT,
++	PRESTERA_PORT_EXCESSIVE_COLLISIONS_CNT,
++	PRESTERA_PORT_MC_PKTS_SENT_CNT,
++	PRESTERA_PORT_BRDC_PKTS_SENT_CNT,
++	PRESTERA_PORT_FC_SENT_CNT,
++	PRESTERA_PORT_GOOD_FC_RCV_CNT,
++	PRESTERA_PORT_DROP_EVENTS_CNT,
++	PRESTERA_PORT_UNDERSIZE_PKTS_CNT,
++	PRESTERA_PORT_FRAGMENTS_PKTS_CNT,
++	PRESTERA_PORT_OVERSIZE_PKTS_CNT,
++	PRESTERA_PORT_JABBER_PKTS_CNT,
++	PRESTERA_PORT_MAC_RCV_ERROR_CNT,
++	PRESTERA_PORT_BAD_CRC_CNT,
++	PRESTERA_PORT_COLLISIONS_CNT,
++	PRESTERA_PORT_LATE_COLLISIONS_CNT,
++	PRESTERA_PORT_GOOD_UC_PKTS_RCV_CNT,
++	PRESTERA_PORT_GOOD_UC_PKTS_SENT_CNT,
++	PRESTERA_PORT_MULTIPLE_PKTS_SENT_CNT,
++	PRESTERA_PORT_DEFERRED_PKTS_SENT_CNT,
++	PRESTERA_PORT_GOOD_OCTETS_SENT_CNT,
++	PRESTERA_PORT_CNT_MAX,
+ };
+ 
+ enum {
+-	MVSW_FC_NONE,
+-	MVSW_FC_SYMMETRIC,
+-	MVSW_FC_ASYMMETRIC,
+-	MVSW_FC_SYMM_ASYMM,
++	PRESTERA_FC_NONE,
++	PRESTERA_FC_SYMMETRIC,
++	PRESTERA_FC_ASYMMETRIC,
++	PRESTERA_FC_SYMM_ASYMM,
+ };
+ 
+ enum {
+-	MVSW_HW_FDB_ENTRY_TYPE_REG_PORT = 0,
+-	MVSW_HW_FDB_ENTRY_TYPE_LAG = 1,
+-	MVSW_HW_FDB_ENTRY_TYPE_MAX = 2,
++	PRESTERA_PORT_TP_NA,
++	PRESTERA_PORT_TP_MDI,
++	PRESTERA_PORT_TP_MDIX,
++	PRESTERA_PORT_TP_AUTO
+ };
+ 
+ enum {
+-	MVSW_PORT_FLOOD_TYPE_UC = 0,
+-	MVSW_PORT_FLOOD_TYPE_MC = 1,
+-	MVSW_PORT_FLOOD_TYPE_BC = 2,
++	PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT = 0,
++	PRESTERA_HW_FDB_ENTRY_TYPE_LAG = 1,
++	PRESTERA_HW_FDB_ENTRY_TYPE_MAX = 2,
+ };
+ 
+ enum {
+-	MVSW_COUNTER_CLIENT_LOOKUP_0 = 0,
+-	MVSW_COUNTER_CLIENT_LOOKUP_1 = 1,
+-	MVSW_COUNTER_CLIENT_LOOKUP_2 = 2,
++	PRESTERA_PORT_FLOOD_TYPE_UC = 0,
++	PRESTERA_PORT_FLOOD_TYPE_MC = 1,
++	PRESTERA_PORT_FLOOD_TYPE_BC = 2,
+ };
+ 
+-struct mvsw_msg_buff {
+-	u32 free;
+-	u32 total;
+-	u32 used;
+-	void *data;
++enum {
++	PRESTERA_HW_COUNTER_CLIENT_LOOKUP_0 = 0,
++	PRESTERA_HW_COUNTER_CLIENT_LOOKUP_1 = 1,
++	PRESTERA_HW_COUNTER_CLIENT_LOOKUP_2 = 2,
+ };
+ 
+-struct mvsw_msg_cmd {
++struct prestera_msg_cmd {
+ 	u32 type;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_ret {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_ret {
++	struct prestera_msg_cmd cmd;
+ 	u32 status;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_common_request {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_common_req {
++	struct prestera_msg_cmd cmd;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_common_response {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_common_resp {
++	struct prestera_msg_ret ret;
+ } __packed __aligned(4);
+ 
+-union mvsw_msg_switch_param {
++union prestera_msg_switch_param {
+ 	u32 ageing_timeout;
+ 	u8  mac[ETH_ALEN];
+ 	u32 trap_policer_profile;
+ };
+ 
+-struct mvsw_msg_switch_attr_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_switch_attr_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 attr;
+-	union mvsw_msg_switch_param param;
++	union prestera_msg_switch_param param;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_switch_init_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_switch_init_resp {
++	struct prestera_msg_ret ret;
+ 	u32 port_count;
+ 	u32 mtu_max;
+ 	u8  switch_id;
+@@ -259,13 +248,25 @@ struct mvsw_msg_switch_init_ret {
+ 	u32 size_tbl_router_nexthop;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_autoneg_param {
+-	u64 link_mode;
+-	u8  enable;
+-	u8  fec;
+-};
++struct prestera_msg_event_port_param {
++	union {
++		struct {
++			u8 oper;
++			u32 mode;
++			u32 speed;
++			u8 duplex;
++			u8 fc;
++			u8 fec;
++		} mac;
++		struct {
++			u8 mdix;
++			u64 lmode_bmap;
++			u8 fc;
++		} phy;
++	};
++} __packed __aligned(4);
+ 
+-struct mvsw_msg_port_cap_param {
++struct prestera_msg_port_cap_param {
+ 	u64 link_mode;
+ 	u8  type;
+ 	u8  fec;
+@@ -273,17 +274,12 @@ struct mvsw_msg_port_cap_param {
+ 	u8  transceiver;
+ };
+ 
+-struct mvsw_msg_port_mdix_param {
+-	u8 status;
+-	u8 admin_mode;
+-};
+-
+-struct mvsw_msg_port_flood_param {
++struct prestera_msg_port_flood_param {
+ 	u8 type;
+ 	u8 enable;
+ };
+ 
+-union mvsw_msg_port_param {
++union prestera_msg_port_param {
+ 	u8  oper_state;
+ 	u32 mtu;
+ 	u8  mac[ETH_ALEN];
+@@ -293,12 +289,24 @@ union mvsw_msg_port_param {
+ 		struct {
+ 			/* TODO: merge it with "mode" */
+ 			u8 admin:1;
+-			u32 mode;
+-			u8  inband:1;
+-			u32 speed;
+-			u8  duplex;
+-			u8  fec;
+ 			u8  fc;
++			u8 ap_enable;
++			union {
++				struct {
++					u32 mode;
++					u8  inband:1;
++					u32 speed;
++					u8  duplex;
++					u8  fec;
++					u8  fec_supp;
++				} reg_mode;
++				struct {
++					u32 mode;
++					u32 speed;
++					u8  fec;
++					u8  fec_supp;
++				} ap_modes[PRESTERA_AP_PORT_MAX];
++			};
+ 		} mac;
+ 		struct {
+ 			/* TODO: merge it with "mode" */
+@@ -307,57 +315,58 @@ union mvsw_msg_port_param {
+ 			u64 modes;
+ 			/* TODO: merge it with modes */
+ 			u32 mode;
++			u8 mdix;
+ 		} phy;
+ 	} link;
+ 	u8  type;
+-	struct mvsw_msg_port_mdix_param mdix;
+-	struct mvsw_msg_port_autoneg_param autoneg;
+-	struct mvsw_msg_port_cap_param cap;
+-	struct mvsw_msg_port_flood_param flood;
++	struct prestera_msg_port_cap_param cap;
++	struct prestera_msg_port_flood_param flood;
+ 	u32 source_id_default;
+ 	u32 source_id_filter;
++	/* Used for return */
++	struct prestera_msg_event_port_param link_evt;
+ };
+ 
+-struct mvsw_msg_port_attr_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_port_attr_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 attr;
+ 	u32 port;
+ 	u32 dev;
+-	union mvsw_msg_port_param param;
++	union prestera_msg_port_param param;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_attr_ret {
+-	struct mvsw_msg_ret ret;
+-	union mvsw_msg_port_param param;
++struct prestera_msg_port_attr_resp {
++	struct prestera_msg_ret ret;
++	union prestera_msg_port_param param;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_stats_ret {
+-	struct mvsw_msg_ret ret;
+-	u64 stats[MVSW_PORT_CNT_MAX];
++struct prestera_msg_port_stats_resp {
++	struct prestera_msg_ret ret;
++	u64 stats[PRESTERA_PORT_CNT_MAX];
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_info_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_port_info_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_info_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_port_info_resp {
++	struct prestera_msg_ret ret;
+ 	u32 hw_id;
+ 	u32 dev_id;
+ 	u16 fp_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_port_storm_control_cfg_set_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_port_storm_control_cfg_set_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u32 storm_type;
+ 	u32 kbyte_per_sec_rate;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vlan_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vlan_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u16 vid;
+@@ -365,8 +374,8 @@ struct mvsw_msg_vlan_cmd {
+ 	u8  is_tagged;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_fdb_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_fdb_req {
++	struct prestera_msg_cmd cmd;
+ 	u8 dest_type;
+ 	union {
+ 		struct {
+@@ -381,13 +390,13 @@ struct mvsw_msg_fdb_cmd {
+ 	u32 flush_mode;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_log_lvl_set_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_log_lvl_set_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 lib;
+ 	u32 type;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_iface {
++struct prestera_msg_iface {
+ 	u8 type;
+ 	u16 vid;
+ 	u16 vr_id;
+@@ -400,36 +409,44 @@ struct mvsw_msg_iface {
+ 	};
+ } __packed;
+ 
+-struct mvsw_msg_nh {
+-	struct mvsw_msg_iface oif;
++struct prestera_msg_ip_addr {
++	u8 v; /* e.g. PRESTERA_IPV4 */
++	union {
++		__be32 ipv4;
++		__be32 ipv6[4];
++	} u;
++} __packed;
++
++struct prestera_msg_nh {
++	struct prestera_msg_iface oif;
+ 	u8 is_active;
+ 	u32 hw_id;
+ 	u8 mac[ETH_ALEN];
+ } __packed;
+ 
+-struct mvsw_msg_nh_mangle_info {
++struct prestera_msg_nh_mangle_info {
+ 	u8 l4_src_valid:1, l4_dst_valid:1,
+ 	   sip_valid:1, dip_valid:1;
+ 	__be16 l4_src;
+ 	__be16 l4_dst;
+ 	__be32 sip;
+ 	__be32 dip;
+-	struct mvsw_msg_nh nh;
++	struct prestera_msg_nh nh;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_mangle_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_nh_mangle_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 nh_id;
+-	struct mvsw_msg_nh_mangle_info info;
++	struct prestera_msg_nh_mangle_info info;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_mangle_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_nh_mangle_resp {
++	struct prestera_msg_ret ret;
+ 	u32 nh_id;
+-	struct mvsw_msg_nh_mangle_info info;
++	struct prestera_msg_nh_mangle_info info;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_acl_action {
++struct prestera_msg_acl_action {
+ 	u32 id;
+ 	union {
+ 		struct {
+@@ -458,19 +475,20 @@ struct mvsw_msg_acl_action {
+ 	};
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_create_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vtcam_create_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 keymask[__PRESTERA_ACL_RULE_MATCH_TYPE_MAX];
+ 	u8 lookup;
++	u32 direction;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_destroy_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vtcam_destroy_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 vtcam_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_rule_add_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vtcam_rule_add_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 key[__PRESTERA_ACL_RULE_MATCH_TYPE_MAX];
+ 	u32 keymask[__PRESTERA_ACL_RULE_MATCH_TYPE_MAX];
+ 	u32 vtcam_id;
+@@ -478,14 +496,14 @@ struct mvsw_msg_vtcam_rule_add_cmd {
+ 	u8 n_act;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_rule_del_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vtcam_rule_del_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 vtcam_id;
+ 	u32 id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_bind_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vtcam_bind_req {
++	struct prestera_msg_cmd cmd;
+ 	union {
+ 		struct {
+ 			u32 hw_id;
+@@ -498,234 +516,225 @@ struct mvsw_msg_vtcam_bind_cmd {
+ 	u8 type;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vtcam_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_vtcam_resp {
++	struct prestera_msg_ret ret;
+ 	u32 vtcam_id;
+ 	u32 rule_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_counter_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_counter_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 client;
+ 	u32 block_id;
+ 	u32 num_counters;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_counter_stats {
++struct prestera_msg_counter_stats {
+ 	u64 packets;
+ 	u64 bytes;
+ } __packed;
+ 
+-struct mvsw_msg_counter_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_counter_resp {
++	struct prestera_msg_ret ret;
+ 	u32 block_id;
+ 	u32 offset;
+ 	u32 num_counters;
+ 	u32 done;
+-	struct mvsw_msg_counter_stats stats[0];
++	struct prestera_msg_counter_stats stats[0];
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nat_port_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_nat_port_req {
++	struct prestera_msg_cmd cmd;
+ 	u8 neigh_mac[ETH_ALEN];
+ 	u32 port;
+ 	u32 dev;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_span_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_span_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u8 id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_span_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_span_resp {
++	struct prestera_msg_ret ret;
+ 	u8 id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_event {
++struct prestera_msg_event {
+ 	u16 type;
+ 	u16 id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_event_log {
+-	struct mvsw_msg_event id;
++struct prestera_msg_event_log {
++	struct prestera_msg_event id;
+ 	u32 log_string_size;
+ 	u8 log_string[0];
+ } __packed __aligned(4);
+ 
+-union mvsw_msg_event_fdb_param {
++union prestera_msg_event_fdb_param {
+ 	u8 mac[ETH_ALEN];
+ };
+ 
+-struct mvsw_msg_event_fdb {
+-	struct mvsw_msg_event id;
++struct prestera_msg_event_fdb {
++	struct prestera_msg_event id;
+ 	u8 dest_type;
+ 	union {
+ 		u32 port_id;
+ 		u16 lag_id;
+ 	} dest;
+ 	u32 vid;
+-	union mvsw_msg_event_fdb_param param;
+-} __packed __aligned(4);
+-
+-struct mvsw_msg_event_port_param {
+-	u64 lmode_bmap;
+-	u32 link_mode;
+-	u8 oper_state;
+-	u8 fc;
+-	u8 status;
+-	u8 admin_mode;
++	union prestera_msg_event_fdb_param param;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_event_port {
+-	struct mvsw_msg_event id;
++struct prestera_msg_event_port {
++	struct prestera_msg_event id;
+ 	u32 port_id;
+-	struct mvsw_msg_event_port_param param;
++	struct prestera_msg_event_port_param param;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_bridge_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_bridge_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u16 bridge;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_bridge_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_bridge_resp {
++	struct prestera_msg_ret ret;
+ 	u16 bridge;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_macvlan_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_macvlan_req {
++	struct prestera_msg_cmd cmd;
+ 	u16 vr_id;
+ 	u8 mac[ETH_ALEN];
+ 	u16 vid;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_stp_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_stp_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u16 vid;
+ 	u8  state;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_rif_cmd {
+-	struct mvsw_msg_cmd cmd;
+-	struct mvsw_msg_iface iif;
++struct prestera_msg_rif_req {
++	struct prestera_msg_cmd cmd;
++	struct prestera_msg_iface iif;
+ 	u16 rif_id;
+ 	u8 mac[ETH_ALEN];
+ 	u32 mtu;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_rif_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_rif_resp {
++	struct prestera_msg_ret ret;
+ 	u16 rif_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_lpm_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_lpm_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 grp_id;
+-	__be32 dst;
++	struct prestera_msg_ip_addr dst;
+ 	u32 dst_len;
+ 	u16 vr_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_nh_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 size;
+ 	u32 grp_id;
+-	struct mvsw_msg_nh nh[PRESTERA_NHGR_SIZE_MAX];
++	struct prestera_msg_nh nh[PRESTERA_NHGR_SIZE_MAX];
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_ret {
+-	struct mvsw_msg_ret ret;
+-	struct mvsw_msg_nh nh[PRESTERA_NHGR_SIZE_MAX];
++struct prestera_msg_nh_resp {
++	struct prestera_msg_ret ret;
++	struct prestera_msg_nh nh[PRESTERA_NHGR_SIZE_MAX];
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_chunk_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_nh_chunk_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 offset;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_chunk_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_nh_chunk_resp {
++	struct prestera_msg_ret ret;
+ 	u8 hw_state[PRESTERA_MSG_CHUNK_SIZE];
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_grp_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_nh_grp_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 grp_id;
+ 	u32 size;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_nh_grp_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_nh_grp_resp {
++	struct prestera_msg_ret ret;
+ 	u32 grp_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_mp_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_mp_req {
++	struct prestera_msg_cmd cmd;
+ 	u8 hash_policy;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_rxtx_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_rxtx_req {
++	struct prestera_msg_cmd cmd;
+ 	u8 use_sdma;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_rxtx_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_rxtx_resp {
++	struct prestera_msg_ret ret;
+ 	u32 map_addr;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vr_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_vr_req {
++	struct prestera_msg_cmd cmd;
+ 	u16 vr_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_vr_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_vr_resp {
++	struct prestera_msg_ret ret;
+ 	u16 vr_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_lag_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_lag_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 port;
+ 	u32 dev;
+ 	u16 lag_id;
+ 	u16 vr_id;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_keepalive_init_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_keepalive_init_req {
++	struct prestera_msg_cmd cmd;
+ 	u32 pulse_timeout_ms;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_cpu_code_counter_cmd {
+-	struct mvsw_msg_cmd cmd;
++struct prestera_msg_cpu_code_counter_req {
++	struct prestera_msg_cmd cmd;
+ 	u8 counter_type;
+ 	u8 code;
+ } __packed __aligned(4);
+ 
+-struct mvsw_msg_cpu_code_counter_ret {
+-	struct mvsw_msg_ret ret;
++struct prestera_msg_cpu_code_counter_resp {
++	struct prestera_msg_ret ret;
+ 	u64 packet_count;
+ } __packed __aligned(4);
+ 
+ static void fw_reset_wdog(struct prestera_device *dev);
+ 
+-static int mvsw_pr_cmd_qid_by_req_type(enum mvsw_msg_type type)
++static int prestera_cmd_qid_by_req_type(enum prestera_cmd_type_t type)
+ {
+ 	switch (type) {
+-	case MVSW_MSG_TYPE_COUNTER_GET:
+-	case MVSW_MSG_TYPE_COUNTER_ABORT:
+-	case MVSW_MSG_TYPE_COUNTER_TRIGGER:
+-	case MVSW_MSG_TYPE_COUNTER_BLOCK_GET:
+-	case MVSW_MSG_TYPE_COUNTER_BLOCK_RELEASE:
+-	case MVSW_MSG_TYPE_COUNTER_CLEAR:
++	case PRESTERA_CMD_TYPE_COUNTER_GET:
++	case PRESTERA_CMD_TYPE_COUNTER_ABORT:
++	case PRESTERA_CMD_TYPE_COUNTER_TRIGGER:
++	case PRESTERA_CMD_TYPE_COUNTER_BLOCK_GET:
++	case PRESTERA_CMD_TYPE_COUNTER_BLOCK_RELEASE:
++	case PRESTERA_CMD_TYPE_COUNTER_CLEAR:
+ 		return 1;
+ 	default:
+ 		return 0;
+@@ -736,9 +745,9 @@ static int mvsw_pr_cmd_qid_by_req_type(enum mvsw_msg_type type)
+ ({								\
+ 	int __er = 0;						\
+ 	typeof(_response) __r = (_response);			\
+-	if (__r->ret.cmd.type != MVSW_MSG_TYPE_ACK)		\
++	if (__r->ret.cmd.type != PRESTERA_CMD_TYPE_ACK)		\
+ 		__er = -EBADE;					\
+-	else if (__r->ret.status != MVSW_MSG_ACK_OK)		\
++	else if (__r->ret.status != PRESTERA_CMD_ACK_OK)		\
+ 		__er = -EINVAL;					\
+ 	(__er);							\
+ })
+@@ -753,7 +762,7 @@ _response, _resp_size, _wait)					\
+ 	typeof(_type) __type = (_type);				\
+ 	__req->cmd.type = (__type);				\
+ 	__e = __sw->dev->send_req(__sw->dev,			\
+-		mvsw_pr_cmd_qid_by_req_type(__type),		\
++		prestera_cmd_qid_by_req_type(__type),		\
+ 		(u8 *)__req, _req_size,				\
+ 		(u8 *)__resp, _resp_size,			\
+ 		_wait);						\
+@@ -792,11 +801,11 @@ _response, _resp_size, _wait)					\
+ 
+ #define fw_send_req(_sw, _t, _req)	\
+ ({							\
+-	struct mvsw_msg_common_response __re;		\
++	struct prestera_msg_common_resp __re;		\
+ 	(fw_send_req_resp(_sw, _t, _req, &__re));	\
+ })
+ 
+-struct mvsw_fw_event_handler {
++struct prestera_fw_event_handler {
+ 	struct list_head list;
+ 	enum prestera_event_type type;
+ 	void (*func)(struct prestera_switch *sw,
+@@ -806,9 +815,16 @@ struct mvsw_fw_event_handler {
+ };
+ 
+ static void prestera_hw_remote_fc_to_eth(u8 fc, bool *pause, bool *asym_pause);
+-static u8 mvsw_mdix_to_eth(u8 mode);
++static u8 prestera_hw_mdix_to_eth(u8 mode);
++
++static void prestera_fw_wdog_restart(struct prestera_device *dev)
++{
++	queue_delayed_work(system_long_wq,
++			   &dev->keepalive_wdog_work,
++			   msecs_to_jiffies(PRESTERA_FW_WD_KICK_TIMEOUT));
++}
+ 
+-static void mvsw_pr_fw_keepalive_wd_work_fn(struct work_struct *work)
++static void prestera_fw_keepalive_wd_work_fn(struct work_struct *work)
+ {
+ 	struct delayed_work *dl_work =
+ 		container_of(work, struct delayed_work, work);
+@@ -818,10 +834,8 @@ static void mvsw_pr_fw_keepalive_wd_work_fn(struct work_struct *work)
+ 
+ 	atomic_t *ctr = &dev->keepalive_wdog_counter;
+ 
+-	if (atomic_add_unless(ctr, 1, MVSW_FW_KEEPALIVE_WD_MAX_KICKS)) {
+-		queue_delayed_work(system_long_wq,
+-				   &dev->keepalive_wdog_work,
+-				   msecs_to_jiffies(MVSW_FW_WD_KICK_TIMEOUT));
++	if (atomic_add_unless(ctr, 1, PRESTERA_FW_KEEPALIVE_WD_MAX_KICKS)) {
++		prestera_fw_wdog_restart(dev);
+ 		return;
+ 	}
+ 
+@@ -832,19 +846,19 @@ static void mvsw_pr_fw_keepalive_wd_work_fn(struct work_struct *work)
+ 
+ static int fw_parse_port_evt(u8 *msg, struct prestera_event *evt)
+ {
+-	struct mvsw_msg_event_port *hw_evt = (struct mvsw_msg_event_port *)msg;
++	struct prestera_msg_event_port *hw_evt;
++
++	hw_evt = (struct prestera_msg_event_port *)msg;
+ 
+ 	evt->port_evt.port_id = hw_evt->port_id;
+ 
+-	if (evt->id == MVSW_PORT_EVENT_STATE_CHANGED) {
+-		evt->port_evt.data.oper_state = hw_evt->param.oper_state;
+-		evt->port_evt.data.lmode_bmap = hw_evt->param.lmode_bmap;
+-		prestera_hw_remote_fc_to_eth(hw_evt->param.fc,
+-					     &evt->port_evt.data.pause,
+-					     &evt->port_evt.data.asym_pause);
+-		evt->port_evt.data.status = hw_evt->param.status;
+-		evt->port_evt.data.admin_mode = hw_evt->param.admin_mode;
+-		evt->port_evt.data.link_mode = hw_evt->param.link_mode;
++	if (evt->id == PRESTERA_PORT_EVENT_MAC_STATE_CHANGED) {
++		evt->port_evt.data.mac.oper = hw_evt->param.mac.oper;
++		evt->port_evt.data.mac.mode = hw_evt->param.mac.mode;
++		evt->port_evt.data.mac.speed = hw_evt->param.mac.speed;
++		evt->port_evt.data.mac.duplex = hw_evt->param.mac.duplex;
++		evt->port_evt.data.mac.fc = hw_evt->param.mac.fc;
++		evt->port_evt.data.mac.fec = hw_evt->param.mac.fec;
+ 	} else {
+ 		return -EINVAL;
+ 	}
+@@ -854,15 +868,17 @@ static int fw_parse_port_evt(u8 *msg, struct prestera_event *evt)
+ 
+ static int fw_parse_fdb_evt(u8 *msg, struct prestera_event *evt)
+ {
+-	struct mvsw_msg_event_fdb *hw_evt = (struct mvsw_msg_event_fdb *)msg;
++	struct prestera_msg_event_fdb *hw_evt;
++
++	hw_evt = (struct prestera_msg_event_fdb *)msg;
+ 
+ 	switch (hw_evt->dest_type) {
+-	case MVSW_HW_FDB_ENTRY_TYPE_REG_PORT:
+-		evt->fdb_evt.type = MVSW_PR_FDB_ENTRY_TYPE_REG_PORT;
++	case PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT:
++		evt->fdb_evt.type = PRESTERA_FDB_ENTRY_TYPE_REG_PORT;
+ 		evt->fdb_evt.dest.port_id = hw_evt->dest.port_id;
+ 		break;
+-	case MVSW_HW_FDB_ENTRY_TYPE_LAG:
+-		evt->fdb_evt.type = MVSW_PR_FDB_ENTRY_TYPE_LAG;
++	case PRESTERA_HW_FDB_ENTRY_TYPE_LAG:
++		evt->fdb_evt.type = PRESTERA_FDB_ENTRY_TYPE_LAG;
+ 		evt->fdb_evt.dest.lag_id = hw_evt->dest.lag_id;
+ 		break;
+ 	default:
+@@ -878,7 +894,9 @@ static int fw_parse_fdb_evt(u8 *msg, struct prestera_event *evt)
+ 
+ static int fw_parse_log_evt(u8 *msg, struct prestera_event *evt)
+ {
+-	struct mvsw_msg_event_log *hw_evt = (struct mvsw_msg_event_log *)msg;
++	struct prestera_msg_event_log *hw_evt;
++
++	hw_evt = (struct prestera_msg_event_log *)msg;
+ 
+ 	evt->fw_log_evt.log_len	= hw_evt->log_string_size;
+ 	evt->fw_log_evt.data	= hw_evt->log_string;
+@@ -886,21 +904,21 @@ static int fw_parse_log_evt(u8 *msg, struct prestera_event *evt)
+ 	return 0;
+ }
+ 
+-struct mvsw_fw_evt_parser {
++struct prestera_fw_evt_parser {
+ 	int (*func)(u8 *msg, struct prestera_event *evt);
+ };
+ 
+-static struct mvsw_fw_evt_parser fw_event_parsers[MVSW_EVENT_TYPE_MAX] = {
+-	[MVSW_EVENT_TYPE_PORT] = {.func = fw_parse_port_evt},
+-	[MVSW_EVENT_TYPE_FDB] = {.func = fw_parse_fdb_evt},
+-	[MVSW_EVENT_TYPE_FW_LOG] = {.func = fw_parse_log_evt}
++static struct prestera_fw_evt_parser fw_event_parsers[PRESTERA_EVENT_TYPE_MAX] = {
++	[PRESTERA_EVENT_TYPE_PORT] = {.func = fw_parse_port_evt},
++	[PRESTERA_EVENT_TYPE_FDB] = {.func = fw_parse_fdb_evt},
++	[PRESTERA_EVENT_TYPE_FW_LOG] = {.func = fw_parse_log_evt}
+ };
+ 
+-static struct mvsw_fw_event_handler *
++static struct prestera_fw_event_handler *
+ __find_event_handler(const struct prestera_switch *sw,
+ 		     enum prestera_event_type type)
+ {
+-	struct mvsw_fw_event_handler *eh;
++	struct prestera_fw_event_handler *eh;
+ 
+ 	list_for_each_entry_rcu(eh, &sw->event_handlers, list) {
+ 		if (eh->type == type)
+@@ -910,11 +928,11 @@ __find_event_handler(const struct prestera_switch *sw,
+ 	return NULL;
+ }
+ 
+-static int mvsw_find_event_handler(const struct prestera_switch *sw,
+-				   enum prestera_event_type type,
+-				   struct mvsw_fw_event_handler *eh)
++static int prestera_find_event_handler(const struct prestera_switch *sw,
++				       enum prestera_event_type type,
++				       struct prestera_fw_event_handler *eh)
+ {
+-	struct mvsw_fw_event_handler *tmp;
++	struct prestera_fw_event_handler *tmp;
+ 	int err = 0;
+ 
+ 	rcu_read_lock();
+@@ -936,18 +954,18 @@ static void fw_reset_wdog(struct prestera_device *dev)
+ 
+ static int fw_event_recv(struct prestera_device *dev, u8 *buf, size_t size)
+ {
+-	struct mvsw_msg_event *msg = (struct mvsw_msg_event *)buf;
++	struct prestera_msg_event *msg = (struct prestera_msg_event *)buf;
+ 	struct prestera_switch *sw = dev->priv;
+-	struct mvsw_fw_event_handler eh;
++	struct prestera_fw_event_handler eh;
+ 	struct prestera_event evt;
+ 	int err;
+ 
+ 	fw_reset_wdog(dev);
+ 
+-	if (msg->type >= MVSW_EVENT_TYPE_MAX)
++	if (msg->type >= PRESTERA_EVENT_TYPE_MAX)
+ 		return -EINVAL;
+ 
+-	err = mvsw_find_event_handler(sw, msg->type, &eh);
++	err = prestera_find_event_handler(sw, msg->type, &eh);
+ 
+ 	if (err || !fw_event_parsers[msg->type].func)
+ 		return 0;
+@@ -964,29 +982,29 @@ static int fw_event_recv(struct prestera_device *dev, u8 *buf, size_t size)
+ static void fw_pkt_recv(struct prestera_device *dev)
+ {
+ 	struct prestera_switch *sw = dev->priv;
+-	struct mvsw_fw_event_handler eh;
++	struct prestera_fw_event_handler eh;
+ 	struct prestera_event ev;
+ 	int err;
+ 
+-	ev.id = MVSW_RXTX_EVENT_RCV_PKT;
++	ev.id = PRESTERA_RXTX_EVENT_RCV_PKT;
+ 
+-	err = mvsw_find_event_handler(sw, MVSW_EVENT_TYPE_RXTX, &eh);
++	err = prestera_find_event_handler(sw, PRESTERA_EVENT_TYPE_RXTX, &eh);
+ 	if (err)
+ 		return;
+ 
+ 	eh.func(sw, &ev, eh.arg);
+ }
+ 
+-int mvsw_pr_hw_port_info_get(const struct prestera_port *port,
+-			     u16 *fp_id, u32 *hw_id, u32 *dev_id)
++int prestera_hw_port_info_get(const struct prestera_port *port,
++			      u16 *fp_id, u32 *hw_id, u32 *dev_id)
+ {
+-	struct mvsw_msg_port_info_ret resp;
+-	struct mvsw_msg_port_info_cmd req = {
++	struct prestera_msg_port_info_resp resp;
++	struct prestera_msg_port_info_req req = {
+ 		.port = port->id
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_INFO_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_INFO_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -998,25 +1016,25 @@ int mvsw_pr_hw_port_info_get(const struct prestera_port *port,
+ 	return 0;
+ }
+ 
+-int mvsw_pr_hw_switch_init(struct prestera_switch *sw)
++int prestera_hw_switch_init(struct prestera_switch *sw)
+ {
+-	struct mvsw_msg_keepalive_init_cmd keepalive_init_req = {
+-		.pulse_timeout_ms = MVSW_FW_WD_KICK_TIMEOUT
++	struct prestera_msg_keepalive_init_req keepalive_init_req = {
++		.pulse_timeout_ms = PRESTERA_FW_WD_KICK_TIMEOUT
+ 	};
+-	struct mvsw_msg_switch_init_ret resp;
+-	struct mvsw_msg_common_request req;
++	struct prestera_msg_switch_init_resp resp;
++	struct prestera_msg_common_req req;
+ 	int err = 0;
+ 
+ 	INIT_LIST_HEAD(&sw->event_handlers);
+ 
+-	err = fw_send_req_resp_wait(sw, MVSW_MSG_TYPE_SWITCH_INIT, &req, &resp,
+-				    MVSW_PR_INIT_TIMEOUT);
++	err = fw_send_req_resp_wait(sw, PRESTERA_CMD_TYPE_SWITCH_INIT,
++				    &req, &resp, PRESTERA_HW_INIT_TIMEOUT);
+ 	if (err)
+ 		return err;
+ 
+ 	sw->id = resp.switch_id;
+ 	sw->port_count = resp.port_count;
+-	sw->mtu_min = MVSW_PR_MIN_MTU;
++	sw->mtu_min = PRESTERA_HW_MIN_MTU;
+ 	sw->mtu_max = resp.mtu_max;
+ 	sw->lag_max = resp.lag_max;
+ 	sw->lag_member_max = resp.lag_member_max;
+@@ -1024,83 +1042,81 @@ int mvsw_pr_hw_switch_init(struct prestera_switch *sw)
+ 	sw->dev->recv_msg = fw_event_recv;
+ 	sw->dev->recv_pkt = fw_pkt_recv;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_KEEPALIVE_INIT,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_KEEPALIVE_INIT,
+ 			       &keepalive_init_req, &resp);
+ 	if (err)
+ 		return err;
+ 
+ 	INIT_DELAYED_WORK(&sw->dev->keepalive_wdog_work,
+-			  mvsw_pr_fw_keepalive_wd_work_fn);
++			  prestera_fw_keepalive_wd_work_fn);
+ 
+-	queue_delayed_work(system_long_wq,
+-			   &sw->dev->keepalive_wdog_work,
+-			   msecs_to_jiffies(MVSW_FW_WD_KICK_TIMEOUT));
++	prestera_fw_wdog_restart(sw->dev);
+ 
+ 	return err;
+ }
+ 
+-void mvsw_pr_hw_keepalive_fini(const struct prestera_switch *sw)
++void prestera_hw_keepalive_fini(const struct prestera_switch *sw)
+ {
+ 	if (sw->dev->running)
+ 		cancel_delayed_work_sync(&sw->dev->keepalive_wdog_work);
+ }
+ 
+-int mvsw_pr_hw_switch_ageing_set(const struct prestera_switch *sw,
+-				 u32 ageing_time)
++int prestera_hw_switch_ageing_set(const struct prestera_switch *sw,
++				  u32 ageing_time)
+ {
+-	struct mvsw_msg_switch_attr_cmd req = {
++	struct prestera_msg_switch_attr_req req = {
+ 		.param = {.ageing_timeout = ageing_time},
+-		.attr = MVSW_MSG_SWITCH_ATTR_AGEING,
++		.attr = PRESTERA_CMD_SWITCH_ATTR_AGEING,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_SWITCH_ATTR_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_SWITCH_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_switch_mac_set(const struct prestera_switch *sw, const u8 *mac)
++int prestera_hw_switch_mac_set(const struct prestera_switch *sw, const u8 *mac)
+ {
+-	struct mvsw_msg_switch_attr_cmd req = {
+-		.attr = MVSW_MSG_SWITCH_ATTR_MAC,
++	struct prestera_msg_switch_attr_req req = {
++		.attr = PRESTERA_CMD_SWITCH_ATTR_MAC,
+ 	};
+ 
+ 	memcpy(req.param.mac, mac, sizeof(req.param.mac));
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_SWITCH_ATTR_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_SWITCH_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_switch_trap_policer_set(const struct prestera_switch *sw,
+-				       u8 profile)
++int prestera_hw_switch_trap_policer_set(const struct prestera_switch *sw,
++					u8 profile)
+ {
+-	struct mvsw_msg_switch_attr_cmd req = {
++	struct prestera_msg_switch_attr_req req = {
+ 		.param = {.trap_policer_profile = profile},
+-		.attr = MVSW_MSG_SWITCH_ATTR_TRAP_POLICER,
++		.attr = PRESTERA_CMD_SWITCH_ATTR_TRAP_POLICER,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_SWITCH_ATTR_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_SWITCH_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_mtu_set(const struct prestera_port *port, u32 mtu)
++int prestera_hw_port_mtu_set(const struct prestera_port *port, u32 mtu)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MTU,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MTU,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {.mtu = mtu}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_mtu_get(const struct prestera_port *port, u32 *mtu)
++int prestera_hw_port_mtu_get(const struct prestera_port *port, u32 *mtu)
+ {
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MTU,
++	struct prestera_msg_port_attr_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MTU,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -1110,29 +1126,29 @@ int mvsw_pr_hw_port_mtu_get(const struct prestera_port *port, u32 *mtu)
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_port_mac_set(const struct prestera_port *port, char *mac)
++int prestera_hw_port_mac_set(const struct prestera_port *port, char *mac)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MAC,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MAC,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	memcpy(&req.param.mac, mac, sizeof(req.param.mac));
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_mac_get(const struct prestera_port *port, char *mac)
++int prestera_hw_port_mac_get(const struct prestera_port *port, char *mac)
+ {
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MAC,
++	struct prestera_msg_port_attr_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MAC,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -1142,39 +1158,39 @@ int mvsw_pr_hw_port_mac_get(const struct prestera_port *port, char *mac)
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_port_accept_frame_type_set(const struct prestera_port *port,
+-					  enum mvsw_pr_accept_frame_type type)
++int prestera_hw_port_accept_frame_type_set(const struct prestera_port *port,
++					   enum prestera_accept_frame_type type)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_ACCEPT_FRAME_TYPE,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_ACCEPT_FRAME_TYPE,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {.accept_frm_type = type}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_learning_set(const struct prestera_port *port, bool enable)
++int prestera_hw_port_learning_set(const struct prestera_port *port, bool enable)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_LEARNING,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_LEARNING,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {.learning = enable ? 1 : 0}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_event_handler_register(struct prestera_switch *sw,
+-				      enum prestera_event_type type,
+-				      void (*cb)(struct prestera_switch *sw,
+-						 struct prestera_event *evt,
+-						 void *arg),
+-				      void *arg)
++int prestera_hw_event_handler_register(struct prestera_switch *sw,
++				       enum prestera_event_type type,
++				       void (*cb)(struct prestera_switch *sw,
++						  struct prestera_event *evt,
++						  void *arg),
++				       void *arg)
+ {
+-	struct mvsw_fw_event_handler *eh;
++	struct prestera_fw_event_handler *eh;
+ 
+ 	eh = __find_event_handler(sw, type);
+ 	if (eh)
+@@ -1194,10 +1210,10 @@ int mvsw_pr_hw_event_handler_register(struct prestera_switch *sw,
+ 	return 0;
+ }
+ 
+-void mvsw_pr_hw_event_handler_unregister(struct prestera_switch *sw,
+-					 enum prestera_event_type type)
++void prestera_hw_event_handler_unregister(struct prestera_switch *sw,
++					  enum prestera_event_type type)
+ {
+-	struct mvsw_fw_event_handler *eh;
++	struct prestera_fw_event_handler *eh;
+ 
+ 	eh = __find_event_handler(sw, type);
+ 	if (!eh)
+@@ -1208,28 +1224,28 @@ void mvsw_pr_hw_event_handler_unregister(struct prestera_switch *sw,
+ 	kfree(eh);
+ }
+ 
+-int mvsw_pr_hw_vlan_create(const struct prestera_switch *sw, u16 vid)
++int prestera_hw_vlan_create(const struct prestera_switch *sw, u16 vid)
+ {
+-	struct mvsw_msg_vlan_cmd req = {
++	struct prestera_msg_vlan_req req = {
+ 		.vid = vid,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VLAN_CREATE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VLAN_CREATE, &req);
+ }
+ 
+-int mvsw_pr_hw_vlan_delete(const struct prestera_switch *sw, u16 vid)
++int prestera_hw_vlan_delete(const struct prestera_switch *sw, u16 vid)
+ {
+-	struct mvsw_msg_vlan_cmd req = {
++	struct prestera_msg_vlan_req req = {
+ 		.vid = vid,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VLAN_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VLAN_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_vlan_port_set(const struct prestera_port *port,
+-			     u16 vid, bool is_member, bool untagged)
++int prestera_hw_vlan_port_set(const struct prestera_port *port,
++			      u16 vid, bool is_member, bool untagged)
+ {
+-	struct mvsw_msg_vlan_cmd req = {
++	struct prestera_msg_vlan_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.vid = vid,
+@@ -1237,71 +1253,71 @@ int mvsw_pr_hw_vlan_port_set(const struct prestera_port *port,
+ 		.is_tagged = untagged ? 0 : 1
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_VLAN_PORT_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_VLAN_PORT_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_vlan_port_vid_set(const struct prestera_port *port, u16 vid)
++int prestera_hw_vlan_port_vid_set(const struct prestera_port *port, u16 vid)
+ {
+-	struct mvsw_msg_vlan_cmd req = {
++	struct prestera_msg_vlan_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.vid = vid
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_VLAN_PVID_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_VLAN_PVID_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_vid_stp_set(struct prestera_port *port, u16 vid, u8 state)
++int prestera_hw_port_vid_stp_set(struct prestera_port *port, u16 vid, u8 state)
+ {
+-	struct mvsw_msg_stp_cmd req = {
++	struct prestera_msg_stp_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.vid = vid,
+ 		.state = state
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_STP_PORT_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_STP_PORT_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_uc_flood_set(const struct prestera_port *port, bool flood)
++int prestera_hw_port_uc_flood_set(const struct prestera_port *port, bool flood)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_FLOOD,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_FLOOD,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+ 			.flood = {
+-				.type = MVSW_PORT_FLOOD_TYPE_UC,
++				.type = PRESTERA_PORT_FLOOD_TYPE_UC,
+ 				.enable = flood ? 1 : 0,
+ 			}
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_mc_flood_set(const struct prestera_port *port, bool flood)
++int prestera_hw_port_mc_flood_set(const struct prestera_port *port, bool flood)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_FLOOD,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_FLOOD,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+ 			.flood = {
+-				.type = MVSW_PORT_FLOOD_TYPE_MC,
++				.type = PRESTERA_PORT_FLOOD_TYPE_MC,
+ 				.enable = flood ? 1 : 0,
+ 			}
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+ int prestera_hw_port_srcid_default_set(const struct prestera_port *port,
+ 				       u32 sourceid)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_SOURCE_ID_DEFAULT,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_SOURCE_ID_DEFAULT,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+@@ -1309,14 +1325,14 @@ int prestera_hw_port_srcid_default_set(const struct prestera_port *port,
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+ int prestera_hw_port_srcid_filter_set(const struct prestera_port *port,
+ 				      u32 sourceid)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_SOURCE_ID_FILTER,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_SOURCE_ID_FILTER,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+@@ -1324,14 +1340,14 @@ int prestera_hw_port_srcid_filter_set(const struct prestera_port *port,
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_add(const struct prestera_port *port,
+-		       const unsigned char *mac, u16 vid, bool dynamic)
++int prestera_hw_fdb_add(const struct prestera_port *port,
++			const unsigned char *mac, u16 vid, bool dynamic)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_REG_PORT,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT,
+ 		.dest = {
+ 			.dev = port->dev_id,
+ 			.port = port->hw_id,
+@@ -1342,14 +1358,14 @@ int mvsw_pr_hw_fdb_add(const struct prestera_port *port,
+ 
+ 	memcpy(req.mac, mac, sizeof(req.mac));
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_FDB_ADD, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_FDB_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_fdb_add(const struct prestera_switch *sw, u16 lag_id,
+-			   const unsigned char *mac, u16 vid, bool dynamic)
++int prestera_hw_lag_fdb_add(const struct prestera_switch *sw, u16 lag_id,
++			    const unsigned char *mac, u16 vid, bool dynamic)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_LAG,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_LAG,
+ 		.dest = { .lag_id = lag_id },
+ 		.vid = vid,
+ 		.dynamic = dynamic
+@@ -1357,14 +1373,14 @@ int mvsw_pr_hw_lag_fdb_add(const struct prestera_switch *sw, u16 lag_id,
+ 
+ 	memcpy(req.mac, mac, sizeof(req.mac));
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_ADD, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_del(const struct prestera_port *port,
+-		       const unsigned char *mac, u16 vid)
++int prestera_hw_fdb_del(const struct prestera_port *port,
++			const unsigned char *mac, u16 vid)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_REG_PORT,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT,
+ 		.dest = {
+ 			.dev = port->dev_id,
+ 			.port = port->hw_id,
+@@ -1374,35 +1390,35 @@ int mvsw_pr_hw_fdb_del(const struct prestera_port *port,
+ 
+ 	memcpy(req.mac, mac, sizeof(req.mac));
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_FDB_DELETE, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_FDB_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_fdb_del(const struct prestera_switch *sw, u16 lag_id,
+-			   const unsigned char *mac, u16 vid)
++int prestera_hw_lag_fdb_del(const struct prestera_switch *sw, u16 lag_id,
++			    const unsigned char *mac, u16 vid)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_LAG,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_LAG,
+ 		.dest = { .lag_id = lag_id },
+ 		.vid = vid
+ 	};
+ 
+ 	memcpy(req.mac, mac, sizeof(req.mac));
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_port_cap_get(const struct prestera_port *port,
+-			    struct prestera_port_caps *caps)
++int prestera_hw_port_cap_get(const struct prestera_port *port,
++			     struct prestera_port_caps *caps)
+ {
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_CAPABILITY,
++	struct prestera_msg_port_attr_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_CAPABILITY,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -1415,70 +1431,46 @@ int mvsw_pr_hw_port_cap_get(const struct prestera_port *port,
+ 	return err;
+ }
+ 
+-/* TODO: make name, that explicity show relation to PHY */
+-int mvsw_pr_hw_port_remote_cap_get(const struct prestera_port *port,
+-				   u64 *link_mode_bitmap,
+-				   bool *pause, bool *asym_pause)
+-{
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_REMOTE_CAPABILITY,
+-		.port = port->hw_id,
+-		.dev = port->dev_id
+-	};
+-	int err;
+-
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
+-			       &req, &resp);
+-	if (err)
+-		return err;
+-
+-	*link_mode_bitmap = resp.param.cap.link_mode;
+-	prestera_hw_remote_fc_to_eth(resp.param.cap.fc, pause, asym_pause);
+-
+-	return err;
+-}
+-
+-static u8 mvsw_mdix_to_eth(u8 mode)
++static u8 prestera_hw_mdix_to_eth(u8 mode)
+ {
+ 	switch (mode) {
+-	case MVSW_PORT_TP_MDI:
++	case PRESTERA_PORT_TP_MDI:
+ 		return ETH_TP_MDI;
+-	case MVSW_PORT_TP_MDIX:
++	case PRESTERA_PORT_TP_MDIX:
+ 		return ETH_TP_MDI_X;
+-	case MVSW_PORT_TP_AUTO:
++	case PRESTERA_PORT_TP_AUTO:
+ 		return ETH_TP_MDI_AUTO;
+ 	}
+ 
+ 	return ETH_TP_MDI_INVALID;
+ }
+ 
+-static u8 mvsw_mdix_from_eth(u8 mode)
++static u8 prestera_hw_mdix_from_eth(u8 mode)
+ {
+ 	switch (mode) {
+ 	case ETH_TP_MDI:
+-		return MVSW_PORT_TP_MDI;
++		return PRESTERA_PORT_TP_MDI;
+ 	case ETH_TP_MDI_X:
+-		return MVSW_PORT_TP_MDIX;
++		return PRESTERA_PORT_TP_MDIX;
+ 	case ETH_TP_MDI_AUTO:
+-		return MVSW_PORT_TP_AUTO;
++		return PRESTERA_PORT_TP_AUTO;
+ 	}
+ 
+-	return MVSW_PORT_TP_NA;
++	return PRESTERA_PORT_TP_NA;
+ }
+ 
+ static void prestera_hw_remote_fc_to_eth(u8 fc, bool *pause, bool *asym_pause)
+ {
+ 	switch (fc) {
+-	case MVSW_FC_SYMMETRIC:
++	case PRESTERA_FC_SYMMETRIC:
+ 		*pause = true;
+ 		*asym_pause = false;
+ 		break;
+-	case MVSW_FC_ASYMMETRIC:
++	case PRESTERA_FC_ASYMMETRIC:
+ 		*pause = false;
+ 		*asym_pause = true;
+ 		break;
+-	case MVSW_FC_SYMM_ASYMM:
++	case PRESTERA_FC_SYMM_ASYMM:
+ 		*pause = true;
+ 		*asym_pause = true;
+ 		break;
+@@ -1488,140 +1480,92 @@ static void prestera_hw_remote_fc_to_eth(u8 fc, bool *pause, bool *asym_pause)
+ 	};
+ }
+ 
+-int mvsw_pr_hw_port_mdix_get(const struct prestera_port *port, u8 *status,
+-			     u8 *admin_mode)
+-{
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MDIX,
+-		.port = port->hw_id,
+-		.dev = port->dev_id
+-	};
+-	int err;
+-
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
+-			       &req, &resp);
+-	if (err)
+-		return err;
+-
+-	*status = mvsw_mdix_to_eth(resp.param.mdix.status);
+-	*admin_mode = mvsw_mdix_to_eth(resp.param.mdix.admin_mode);
+-
+-	return 0;
+-}
+-
+-int mvsw_pr_hw_port_mdix_set(const struct prestera_port *port, u8 mode)
+-{
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MDIX,
+-		.port = port->hw_id,
+-		.dev = port->dev_id
+-	};
+-
+-	req.param.mdix.admin_mode = mvsw_mdix_from_eth(mode);
+-
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
+-}
+-
+-int mvsw_pr_hw_port_type_get(const struct prestera_port *port, u8 *type)
+-{
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_TYPE,
+-		.port = port->hw_id,
+-		.dev = port->dev_id
+-	};
+-	int err;
+-
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
+-			       &req, &resp);
+-	if (err)
+-		return err;
+-
+-	*type = resp.param.type;
+-
+-	return err;
+-}
+-
+-int mvsw_pr_hw_fw_log_level_set(const struct prestera_switch *sw,
+-				u32 lib, u32 type)
++int prestera_hw_fw_log_level_set(const struct prestera_switch *sw,
++				 u32 lib, u32 type)
+ {
+-	struct mvsw_msg_log_lvl_set_cmd req = {
++	struct prestera_msg_log_lvl_set_req req = {
+ 		.lib = lib,
+ 		.type = type
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req(sw, MVSW_MSG_TYPE_LOG_LEVEL_SET, &req);
++	err = fw_send_req(sw, PRESTERA_CMD_TYPE_LOG_LEVEL_SET, &req);
+ 	if (err)
+ 		return err;
+ 
+ 	return 0;
+ }
+ 
+-int mvsw_pr_hw_port_stats_get(const struct prestera_port *port,
+-			      struct prestera_port_stats *stats)
++int prestera_hw_port_stats_get(const struct prestera_port *port,
++			       struct prestera_port_stats *stats)
+ {
+-	struct mvsw_msg_port_stats_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_STATS,
++	struct prestera_msg_port_stats_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_STATS,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	u64 *hw_val = resp.stats;
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+-	stats->good_octets_received = hw_val[MVSW_PORT_GOOD_OCTETS_RCV_CNT];
+-	stats->bad_octets_received = hw_val[MVSW_PORT_BAD_OCTETS_RCV_CNT];
+-	stats->mac_trans_error = hw_val[MVSW_PORT_MAC_TRANSMIT_ERR_CNT];
+-	stats->broadcast_frames_received = hw_val[MVSW_PORT_BRDC_PKTS_RCV_CNT];
+-	stats->multicast_frames_received = hw_val[MVSW_PORT_MC_PKTS_RCV_CNT];
+-	stats->frames_64_octets = hw_val[MVSW_PORT_PKTS_64_OCTETS_CNT];
++	stats->good_octets_received = hw_val[PRESTERA_PORT_GOOD_OCTETS_RCV_CNT];
++	stats->bad_octets_received = hw_val[PRESTERA_PORT_BAD_OCTETS_RCV_CNT];
++	stats->mac_trans_error = hw_val[PRESTERA_PORT_MAC_TRANSMIT_ERR_CNT];
++	stats->broadcast_frames_received =
++		hw_val[PRESTERA_PORT_BRDC_PKTS_RCV_CNT];
++	stats->multicast_frames_received =
++		hw_val[PRESTERA_PORT_MC_PKTS_RCV_CNT];
++	stats->frames_64_octets = hw_val[PRESTERA_PORT_PKTS_64_OCTETS_CNT];
+ 	stats->frames_65_to_127_octets =
+-		hw_val[MVSW_PORT_PKTS_65TO127_OCTETS_CNT];
++		hw_val[PRESTERA_PORT_PKTS_65TO127_OCTETS_CNT];
+ 	stats->frames_128_to_255_octets =
+-		hw_val[MVSW_PORT_PKTS_128TO255_OCTETS_CNT];
++		hw_val[PRESTERA_PORT_PKTS_128TO255_OCTETS_CNT];
+ 	stats->frames_256_to_511_octets =
+-		hw_val[MVSW_PORT_PKTS_256TO511_OCTETS_CNT];
++		hw_val[PRESTERA_PORT_PKTS_256TO511_OCTETS_CNT];
+ 	stats->frames_512_to_1023_octets =
+-		hw_val[MVSW_PORT_PKTS_512TO1023_OCTETS_CNT];
++		hw_val[PRESTERA_PORT_PKTS_512TO1023_OCTETS_CNT];
+ 	stats->frames_1024_to_max_octets =
+-		hw_val[MVSW_PORT_PKTS_1024TOMAX_OCTETS_CNT];
+-	stats->excessive_collision = hw_val[MVSW_PORT_EXCESSIVE_COLLISIONS_CNT];
+-	stats->multicast_frames_sent = hw_val[MVSW_PORT_MC_PKTS_SENT_CNT];
+-	stats->broadcast_frames_sent = hw_val[MVSW_PORT_BRDC_PKTS_SENT_CNT];
+-	stats->fc_sent = hw_val[MVSW_PORT_FC_SENT_CNT];
+-	stats->fc_received = hw_val[MVSW_PORT_GOOD_FC_RCV_CNT];
+-	stats->buffer_overrun = hw_val[MVSW_PORT_DROP_EVENTS_CNT];
+-	stats->undersize = hw_val[MVSW_PORT_UNDERSIZE_PKTS_CNT];
+-	stats->fragments = hw_val[MVSW_PORT_FRAGMENTS_PKTS_CNT];
+-	stats->oversize = hw_val[MVSW_PORT_OVERSIZE_PKTS_CNT];
+-	stats->jabber = hw_val[MVSW_PORT_JABBER_PKTS_CNT];
+-	stats->rx_error_frame_received = hw_val[MVSW_PORT_MAC_RCV_ERROR_CNT];
+-	stats->bad_crc = hw_val[MVSW_PORT_BAD_CRC_CNT];
+-	stats->collisions = hw_val[MVSW_PORT_COLLISIONS_CNT];
+-	stats->late_collision = hw_val[MVSW_PORT_LATE_COLLISIONS_CNT];
+-	stats->unicast_frames_received = hw_val[MVSW_PORT_GOOD_UC_PKTS_RCV_CNT];
+-	stats->unicast_frames_sent = hw_val[MVSW_PORT_GOOD_UC_PKTS_SENT_CNT];
+-	stats->sent_multiple = hw_val[MVSW_PORT_MULTIPLE_PKTS_SENT_CNT];
+-	stats->sent_deferred = hw_val[MVSW_PORT_DEFERRED_PKTS_SENT_CNT];
+-	stats->good_octets_sent = hw_val[MVSW_PORT_GOOD_OCTETS_SENT_CNT];
++		hw_val[PRESTERA_PORT_PKTS_1024TOMAX_OCTETS_CNT];
++	stats->excessive_collision =
++		hw_val[PRESTERA_PORT_EXCESSIVE_COLLISIONS_CNT];
++	stats->multicast_frames_sent = hw_val[PRESTERA_PORT_MC_PKTS_SENT_CNT];
++	stats->broadcast_frames_sent = hw_val[PRESTERA_PORT_BRDC_PKTS_SENT_CNT];
++	stats->fc_sent = hw_val[PRESTERA_PORT_FC_SENT_CNT];
++	stats->fc_received = hw_val[PRESTERA_PORT_GOOD_FC_RCV_CNT];
++	stats->buffer_overrun = hw_val[PRESTERA_PORT_DROP_EVENTS_CNT];
++	stats->undersize = hw_val[PRESTERA_PORT_UNDERSIZE_PKTS_CNT];
++	stats->fragments = hw_val[PRESTERA_PORT_FRAGMENTS_PKTS_CNT];
++	stats->oversize = hw_val[PRESTERA_PORT_OVERSIZE_PKTS_CNT];
++	stats->jabber = hw_val[PRESTERA_PORT_JABBER_PKTS_CNT];
++	stats->rx_error_frame_received =
++		hw_val[PRESTERA_PORT_MAC_RCV_ERROR_CNT];
++	stats->bad_crc = hw_val[PRESTERA_PORT_BAD_CRC_CNT];
++	stats->collisions = hw_val[PRESTERA_PORT_COLLISIONS_CNT];
++	stats->late_collision = hw_val[PRESTERA_PORT_LATE_COLLISIONS_CNT];
++	stats->unicast_frames_received =
++		hw_val[PRESTERA_PORT_GOOD_UC_PKTS_RCV_CNT];
++	stats->unicast_frames_sent =
++		hw_val[PRESTERA_PORT_GOOD_UC_PKTS_SENT_CNT];
++	stats->sent_multiple = hw_val[PRESTERA_PORT_MULTIPLE_PKTS_SENT_CNT];
++	stats->sent_deferred = hw_val[PRESTERA_PORT_DEFERRED_PKTS_SENT_CNT];
++	stats->good_octets_sent = hw_val[PRESTERA_PORT_GOOD_OCTETS_SENT_CNT];
+ 
+ 	return 0;
+ }
+ 
+-int mvsw_pr_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id)
++int prestera_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id)
+ {
+-	struct mvsw_msg_bridge_cmd req;
+-	struct mvsw_msg_bridge_ret resp;
++	struct prestera_msg_bridge_req req;
++	struct prestera_msg_bridge_resp resp;
+ 	int err;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_BRIDGE_CREATE, &req, &resp);
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_BRIDGE_CREATE,
++			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -1629,68 +1573,69 @@ int mvsw_pr_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id)
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_bridge_delete(const struct prestera_switch *sw, u16 bridge_id)
++int prestera_hw_bridge_delete(const struct prestera_switch *sw, u16 bridge_id)
+ {
+-	struct mvsw_msg_bridge_cmd req = {
++	struct prestera_msg_bridge_req req = {
+ 		.bridge = bridge_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_BRIDGE_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_BRIDGE_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_bridge_port_add(const struct prestera_port *port, u16 bridge_id)
++int prestera_hw_bridge_port_add(const struct prestera_port *port, u16 bridge_id)
+ {
+-	struct mvsw_msg_bridge_cmd req = {
++	struct prestera_msg_bridge_req req = {
+ 		.bridge = bridge_id,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_BRIDGE_PORT_ADD, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_BRIDGE_PORT_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_bridge_port_delete(const struct prestera_port *port,
+-				  u16 bridge_id)
++int prestera_hw_bridge_port_delete(const struct prestera_port *port,
++				   u16 bridge_id)
+ {
+-	struct mvsw_msg_bridge_cmd req = {
++	struct prestera_msg_bridge_req req = {
+ 		.bridge = bridge_id,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_BRIDGE_PORT_DELETE, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_BRIDGE_PORT_DELETE,
++			   &req);
+ }
+ 
+-int mvsw_pr_hw_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
+-			   const u8 *mac, u16 vid)
++int prestera_hw_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
++			    const u8 *mac, u16 vid)
+ {
+-	struct mvsw_msg_macvlan_cmd req = {
++	struct prestera_msg_macvlan_req req = {
+ 		.vr_id = vr_id,
+ 		.vid = vid
+ 	};
+ 
+ 	memcpy(req.mac, mac, ETH_ALEN);
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_MACVLAN_ADD, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_MACVLAN_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
+-			   const u8 *mac, u16 vid)
++int prestera_hw_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
++			    const u8 *mac, u16 vid)
+ {
+-	struct mvsw_msg_macvlan_cmd req = {
++	struct prestera_msg_macvlan_req req = {
+ 		.vr_id = vr_id,
+ 		.vid = vid
+ 	};
+ 
+ 	memcpy(req.mac, mac, ETH_ALEN);
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_MACVLAN_DEL, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_MACVLAN_DEL, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_flush_port(const struct prestera_port *port, u32 mode)
++int prestera_hw_fdb_flush_port(const struct prestera_port *port, u32 mode)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_REG_PORT,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT,
+ 		.dest = {
+ 			.dev = port->dev_id,
+ 			.port = port->hw_id,
+@@ -1698,37 +1643,37 @@ int mvsw_pr_hw_fdb_flush_port(const struct prestera_port *port, u32 mode)
+ 		.flush_mode = mode,
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_FDB_FLUSH_PORT, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_FDB_FLUSH_PORT, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_flush_lag(const struct prestera_switch *sw, u16 lag_id,
+-			     u32 mode)
++int prestera_hw_fdb_flush_lag(const struct prestera_switch *sw, u16 lag_id,
++			      u32 mode)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_LAG,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_LAG,
+ 		.dest = { .lag_id = lag_id },
+ 		.flush_mode = mode,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_FLUSH_PORT, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_FLUSH_PORT, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_flush_vlan(const struct prestera_switch *sw, u16 vid,
+-			      u32 mode)
++int prestera_hw_fdb_flush_vlan(const struct prestera_switch *sw, u16 vid,
++			       u32 mode)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
++	struct prestera_msg_fdb_req req = {
+ 		.vid = vid,
+ 		.flush_mode = mode,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_FLUSH_VLAN, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_FLUSH_VLAN, &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
+-				   u32 mode)
++int prestera_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
++				    u32 mode)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_REG_PORT,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_REG_PORT,
+ 		.dest = {
+ 			.dev = port->dev_id,
+ 			.port = port->hw_id,
+@@ -1737,83 +1682,115 @@ int mvsw_pr_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
+ 		.flush_mode = mode,
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_FDB_FLUSH_PORT_VLAN, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_FDB_FLUSH_PORT_VLAN,
++			   &req);
+ }
+ 
+-int mvsw_pr_hw_fdb_flush_lag_vlan(const struct prestera_switch *sw,
+-				  u16 lag_id, u16 vid, u32 mode)
++int prestera_hw_fdb_flush_lag_vlan(const struct prestera_switch *sw,
++				   u16 lag_id, u16 vid, u32 mode)
+ {
+-	struct mvsw_msg_fdb_cmd req = {
+-		.dest_type = MVSW_HW_FDB_ENTRY_TYPE_LAG,
++	struct prestera_msg_fdb_req req = {
++		.dest_type = PRESTERA_HW_FDB_ENTRY_TYPE_LAG,
+ 		.dest = { .lag_id = lag_id },
+ 		.vid = vid,
+ 		.flush_mode = mode,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_FDB_FLUSH_PORT_VLAN, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_FDB_FLUSH_PORT_VLAN, &req);
+ }
+ 
+-int mvsw_pr_hw_port_mac_mode_get(const struct prestera_port *port,
+-				 u32 *mode, u32 *speed, u8 *duplex, u8 *fec)
++int prestera_hw_port_mac_mode_get(const struct prestera_port *port,
++				  u32 *mode, u32 *speed, u8 *duplex, u8 *fec)
+ {
+-	struct mvsw_msg_port_attr_ret resp;
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MAC_MODE,
++	struct prestera_msg_port_attr_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MAC_MODE,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id
+ 	};
+ 	int err;
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_PORT_ATTR_GET,
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+ 	if (mode)
+-		*mode = resp.param.link.mac.mode;
++		*mode = resp.param.link_evt.mac.mode;
+ 
+ 	if (speed)
+-		*speed = resp.param.link.mac.speed;
++		*speed = resp.param.link_evt.mac.speed;
+ 
+ 	if (duplex)
+-		*duplex = resp.param.link.mac.duplex;
++		*duplex = resp.param.link_evt.mac.duplex;
+ 
+ 	if (fec)
+-		*fec = resp.param.link.mac.fec;
++		*fec = resp.param.link_evt.mac.fec;
+ 
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_port_mac_mode_set(const struct prestera_port *port,
+-				 bool admin, u32 mode, u8 inband,
+-				 u32 speed, u8 duplex, u8 fec)
++int prestera_hw_port_mac_mode_set(const struct prestera_port *port,
++				  bool admin, u32 mode, u8 inband,
++				  u32 speed, u8 duplex, u8 fec)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_MAC_MODE,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_MAC_MODE,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+ 			.link = {
+ 				.mac = {
+ 					.admin = admin,
+-					.mode = mode,
+-					.inband = inband,
+-					.speed = speed,
+-					.duplex = duplex,
+-					.fec = fec
++					.reg_mode.mode = mode,
++					.reg_mode.inband = inband,
++					.reg_mode.speed = speed,
++					.reg_mode.duplex = duplex,
++					.reg_mode.fec = fec
+ 				}
+ 			}
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_phy_mode_set(const struct prestera_port *port,
+-				 bool admin, bool adv, u32 mode, u64 modes)
++int prestera_hw_port_phy_mode_get(const struct prestera_port *port,
++				  u8 *mdix, u64 *lmode_bmap,
++				  bool *fc_pause, bool *fc_asym)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_PHY_MODE,
++	struct prestera_msg_port_attr_resp resp;
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_PHY_MODE,
++		.port = port->hw_id,
++		.dev = port->dev_id
++	};
++	int err;
++
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_GET,
++			       &req, &resp);
++	if (err)
++		return err;
++
++	if (mdix)
++		*mdix = prestera_hw_mdix_to_eth(resp.param.link_evt.phy.mdix);
++
++	if (lmode_bmap)
++		*lmode_bmap = resp.param.link_evt.phy.lmode_bmap;
++
++	if (fc_pause && fc_asym)
++		prestera_hw_remote_fc_to_eth(resp.param.link_evt.phy.fc,
++					     fc_pause, fc_asym);
++
++	return err;
++}
++
++int prestera_hw_port_phy_mode_set(const struct prestera_port *port,
++				  bool admin, bool adv, u32 mode, u64 modes,
++				  u8 mdix)
++{
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_PHY_MODE,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.param = {
+@@ -1822,40 +1799,41 @@ int mvsw_pr_hw_port_phy_mode_set(const struct prestera_port *port,
+ 					.admin = admin,
+ 					.adv_enable = adv ? 1 : 0,
+ 					.mode = mode,
+-					.modes = modes
++					.modes = modes,
+ 				}
+ 			}
+ 		}
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	req.param.link.phy.mdix = prestera_hw_mdix_from_eth(mdix);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_port_storm_control_cfg_set(const struct prestera_port *port,
+-					  u32 storm_type,
+-					  u32 kbyte_per_sec_rate)
++int prestera_hw_port_storm_control_cfg_set(const struct prestera_port *port,
++					   u32 storm_type,
++					   u32 kbyte_per_sec_rate)
+ {
+-	struct mvsw_msg_port_storm_control_cfg_set_cmd req = {
++	struct prestera_msg_port_storm_control_cfg_set_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.storm_type = storm_type,
+ 		.kbyte_per_sec_rate = kbyte_per_sec_rate
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_RATE_LIMIT_MODE_SET,
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_RATE_LIMIT_MODE_SET,
+ 			   &req);
+ }
+ 
+-static int mvsw_pr_iface_to_msg(struct prestera_iface *iface,
+-				struct mvsw_msg_iface *msg_if)
++static int prestera_iface_to_msg(struct prestera_iface *iface,
++				 struct prestera_msg_iface *msg_if)
+ {
+ 	switch (iface->type) {
+-	case MVSW_IF_PORT_E:
+-	case MVSW_IF_VID_E:
++	case PRESTERA_IF_PORT_E:
++	case PRESTERA_IF_VID_E:
+ 		msg_if->port = iface->dev_port.port_num;
+ 		msg_if->dev = iface->dev_port.hw_dev_num;
+ 		break;
+-	case MVSW_IF_LAG_E:
++	case PRESTERA_IF_LAG_E:
+ 		msg_if->lag_id = iface->lag_id;
+ 		break;
+ 	default:
+@@ -1868,20 +1846,20 @@ static int mvsw_pr_iface_to_msg(struct prestera_iface *iface,
+ 	return 0;
+ }
+ 
+-int mvsw_pr_hw_rif_create(const struct prestera_switch *sw,
+-			  struct prestera_iface *iif, u8 *mac, u16 *rif_id)
++int prestera_hw_rif_create(const struct prestera_switch *sw,
++			   struct prestera_iface *iif, u8 *mac, u16 *rif_id)
+ {
+-	struct mvsw_msg_rif_cmd req;
+-	struct mvsw_msg_rif_ret resp;
++	struct prestera_msg_rif_req req;
++	struct prestera_msg_rif_resp resp;
+ 	int err;
+ 
+ 	memcpy(req.mac, mac, ETH_ALEN);
+ 
+-	err = mvsw_pr_iface_to_msg(iif, &req.iif);
++	err = prestera_iface_to_msg(iif, &req.iif);
+ 	if (err)
+ 		return err;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_RIF_CREATE,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_ROUTER_RIF_CREATE,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -1890,37 +1868,38 @@ int mvsw_pr_hw_rif_create(const struct prestera_switch *sw,
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_rif_delete(const struct prestera_switch *sw, u16 rif_id,
+-			  struct prestera_iface *iif)
++int prestera_hw_rif_delete(const struct prestera_switch *sw, u16 rif_id,
++			   struct prestera_iface *iif)
+ {
+-	struct mvsw_msg_rif_cmd req = {
++	struct prestera_msg_rif_req req = {
+ 		.rif_id = rif_id,
+ 	};
+ 	int err;
+ 
+-	err = mvsw_pr_iface_to_msg(iif, &req.iif);
++	err = prestera_iface_to_msg(iif, &req.iif);
+ 	if (err)
+ 		return err;
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_RIF_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_RIF_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_rif_set(const struct prestera_switch *sw, u16 *rif_id,
+-		       struct prestera_iface *iif, u8 *mac)
++int prestera_hw_rif_set(const struct prestera_switch *sw, u16 *rif_id,
++			struct prestera_iface *iif, u8 *mac)
+ {
+-	struct mvsw_msg_rif_ret resp;
+-	struct mvsw_msg_rif_cmd req = {
++	struct prestera_msg_rif_resp resp;
++	struct prestera_msg_rif_req req = {
+ 		.rif_id = *rif_id,
+ 	};
+ 	int err;
+ 
+ 	memcpy(req.mac, mac, ETH_ALEN);
+ 
+-	err = mvsw_pr_iface_to_msg(iif, &req.iif);
++	err = prestera_iface_to_msg(iif, &req.iif);
+ 	if (err)
+ 		return err;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_RIF_SET, &req, &resp);
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_ROUTER_RIF_SET,
++			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -1928,13 +1907,14 @@ int mvsw_pr_hw_rif_set(const struct prestera_switch *sw, u16 *rif_id,
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_vr_create(const struct prestera_switch *sw, u16 *vr_id)
++int prestera_hw_vr_create(const struct prestera_switch *sw, u16 *vr_id)
+ {
+ 	int err;
+-	struct mvsw_msg_vr_ret resp;
+-	struct mvsw_msg_vr_cmd req;
++	struct prestera_msg_vr_resp resp;
++	struct prestera_msg_vr_req req;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_VR_CREATE, &req, &resp);
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_ROUTER_VR_CREATE,
++			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -1942,76 +1922,78 @@ int mvsw_pr_hw_vr_create(const struct prestera_switch *sw, u16 *vr_id)
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_vr_delete(const struct prestera_switch *sw, u16 vr_id)
++int prestera_hw_vr_delete(const struct prestera_switch *sw, u16 vr_id)
+ {
+-	struct mvsw_msg_vr_cmd req = {
++	struct prestera_msg_vr_req req = {
+ 		.vr_id = vr_id,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_VR_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_VR_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_vr_abort(const struct prestera_switch *sw, u16 vr_id)
++int prestera_hw_vr_abort(const struct prestera_switch *sw, u16 vr_id)
+ {
+-	struct mvsw_msg_vr_cmd req = {
++	struct prestera_msg_vr_req req = {
+ 		.vr_id = vr_id,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_VR_ABORT, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_VR_ABORT, &req);
+ }
+ 
+-int mvsw_pr_hw_lpm_add(const struct prestera_switch *sw, u16 vr_id,
+-		       __be32 dst, u32 dst_len, u32 grp_id)
++int prestera_hw_lpm_add(const struct prestera_switch *sw, u16 vr_id,
++			__be32 dst, u32 dst_len, u32 grp_id)
+ {
+-	struct mvsw_msg_lpm_cmd req = {
+-		.dst = dst,
++	struct prestera_msg_lpm_req req = {
++		.dst.v = PRESTERA_IPV4,
++		.dst.u.ipv4 = dst,
+ 		.dst_len = dst_len,
+ 		.vr_id = vr_id,
+ 		.grp_id = grp_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_LPM_ADD, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_LPM_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_lpm_del(const struct prestera_switch *sw, u16 vr_id, __be32 dst,
+-		       u32 dst_len)
++int prestera_hw_lpm_del(const struct prestera_switch *sw, u16 vr_id, __be32 dst,
++			u32 dst_len)
+ {
+-	struct mvsw_msg_lpm_cmd req = {
+-		.dst = dst,
++	struct prestera_msg_lpm_req req = {
++		.dst.v = PRESTERA_IPV4,
++		.dst.u.ipv4 = dst,
+ 		.dst_len = dst_len,
+ 		.vr_id = vr_id,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_LPM_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_LPM_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_nh_entries_set(const struct prestera_switch *sw, int count,
+-			      struct prestera_neigh_info *nhs, u32 grp_id)
++int prestera_hw_nh_entries_set(const struct prestera_switch *sw, int count,
++			       struct prestera_neigh_info *nhs, u32 grp_id)
+ {
+-	struct mvsw_msg_nh_cmd req = { .size = count, .grp_id = grp_id };
++	struct prestera_msg_nh_req req = { .size = count, .grp_id = grp_id };
+ 	int i, err;
+ 
+ 	for (i = 0; i < count; i++) {
+ 		req.nh[i].is_active = nhs[i].connected;
+ 		memcpy(&req.nh[i].mac, nhs[i].ha, ETH_ALEN);
+-		err = mvsw_pr_iface_to_msg(&nhs[i].iface, &req.nh[i].oif);
++		err = prestera_iface_to_msg(&nhs[i].iface, &req.nh[i].oif);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_NH_GRP_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_NH_GRP_SET, &req);
+ }
+ 
+ /* TODO: more than one nh */
+ /* For now "count = 1" supported only */
+-int mvsw_pr_hw_nh_entries_get(const struct prestera_switch *sw, int count,
+-			      struct prestera_neigh_info *nhs, u32 grp_id)
++int prestera_hw_nh_entries_get(const struct prestera_switch *sw, int count,
++			       struct prestera_neigh_info *nhs, u32 grp_id)
+ {
+-	struct mvsw_msg_nh_cmd req = { .size = count, .grp_id = grp_id };
+-	struct mvsw_msg_nh_ret resp;
++	struct prestera_msg_nh_req req = { .size = count, .grp_id = grp_id };
++	struct prestera_msg_nh_resp resp;
+ 	int err, i;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_NH_GRP_GET,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_ROUTER_NH_GRP_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -2022,11 +2004,11 @@ int mvsw_pr_hw_nh_entries_get(const struct prestera_switch *sw, int count,
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_nhgrp_blk_get(const struct prestera_switch *sw,
+-			     u8 *hw_state, u32 buf_size /* Buffer in bytes */)
++int prestera_hw_nhgrp_blk_get(const struct prestera_switch *sw,
++			      u8 *hw_state, u32 buf_size /* Buffer in bytes */)
+ {
+-	struct mvsw_msg_nh_chunk_cmd req;
+-	static struct mvsw_msg_nh_chunk_ret resp;
++	struct prestera_msg_nh_chunk_req req;
++	static struct prestera_msg_nh_chunk_resp resp;
+ 	int err;
+ 	u32 buf_offset;
+ 
+@@ -2038,7 +2020,8 @@ int mvsw_pr_hw_nhgrp_blk_get(const struct prestera_switch *sw,
+ 
+ 		memset(&req, 0, sizeof(req));
+ 		req.offset = buf_offset * 8; /* 8 bits in u8 */
+-		err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_NH_GRP_BLK_GET,
++		err = fw_send_req_resp(sw,
++				       PRESTERA_CMD_TYPE_ROUTER_NH_GRP_BLK_GET,
+ 				       &req, &resp);
+ 		if (err)
+ 			return err;
+@@ -2052,14 +2035,14 @@ int mvsw_pr_hw_nhgrp_blk_get(const struct prestera_switch *sw,
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
+-			       u32 *grp_id)
++int prestera_hw_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
++				u32 *grp_id)
+ {
+-	struct mvsw_msg_nh_grp_cmd req = { .size = nh_count };
+-	struct mvsw_msg_nh_grp_ret resp;
++	struct prestera_msg_nh_grp_req req = { .size = nh_count };
++	struct prestera_msg_nh_grp_resp resp;
+ 	int err;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_ROUTER_NH_GRP_ADD, &req,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_ROUTER_NH_GRP_ADD, &req,
+ 			       &resp);
+ 	if (err)
+ 		return err;
+@@ -2068,34 +2051,34 @@ int mvsw_pr_hw_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
+ 	return err;
+ }
+ 
+-int mvsw_pr_hw_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
+-			       u32 grp_id)
++int prestera_hw_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
++				u32 grp_id)
+ {
+-	struct mvsw_msg_nh_grp_cmd req = {
++	struct prestera_msg_nh_grp_req req = {
+ 	    .grp_id = grp_id,
+ 	    .size = nh_count
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_NH_GRP_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_NH_GRP_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_mp4_hash_set(const struct prestera_switch *sw, u8 hash_policy)
++int prestera_hw_mp4_hash_set(const struct prestera_switch *sw, u8 hash_policy)
+ {
+-	struct mvsw_msg_mp_cmd req = { .hash_policy = hash_policy};
++	struct prestera_msg_mp_req req = { .hash_policy = hash_policy};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_ROUTER_MP_HASH_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_ROUTER_MP_HASH_SET, &req);
+ }
+ 
+-int mvsw_pr_hw_rxtx_init(const struct prestera_switch *sw, bool use_sdma,
+-			 u32 *map_addr)
++int prestera_hw_rxtx_init(const struct prestera_switch *sw, bool use_sdma,
++			  u32 *map_addr)
+ {
+-	struct mvsw_msg_rxtx_ret resp;
+-	struct mvsw_msg_rxtx_cmd req;
++	struct prestera_msg_rxtx_resp resp;
++	struct prestera_msg_rxtx_req req;
+ 	int err;
+ 
+ 	req.use_sdma = use_sdma;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_RXTX_INIT, &req, &resp);
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_RXTX_INIT, &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -2105,49 +2088,49 @@ int mvsw_pr_hw_rxtx_init(const struct prestera_switch *sw, bool use_sdma,
+ 	return 0;
+ }
+ 
+-int mvsw_pr_hw_port_autoneg_restart(struct prestera_port *port)
++int prestera_hw_port_autoneg_restart(struct prestera_port *port)
+ {
+-	struct mvsw_msg_port_attr_cmd req = {
+-		.attr = MVSW_MSG_PORT_ATTR_AUTONEG_RESTART,
++	struct prestera_msg_port_attr_req req = {
++		.attr = PRESTERA_CMD_PORT_ATTR_PHY_AUTONEG_RESTART,
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_PORT_ATTR_SET, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_PORT_ATTR_SET, &req);
+ }
+ 
+ /* ACL API */
+-static int acl_rule_add_put_action(struct mvsw_msg_acl_action *action,
++static int acl_rule_add_put_action(struct prestera_msg_acl_action *action,
+ 				   struct prestera_acl_hw_action_info *info)
+ {
+ 	action->id = info->id;
+ 
+ 	switch (info->id) {
+-	case MVSW_ACL_RULE_ACTION_ACCEPT:
+-	case MVSW_ACL_RULE_ACTION_DROP:
++	case PRESTERA_ACL_RULE_ACTION_ACCEPT:
++	case PRESTERA_ACL_RULE_ACTION_DROP:
+ 		/* just rule action id, no specific data */
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_TRAP:
++	case PRESTERA_ACL_RULE_ACTION_TRAP:
+ 		action->trap.hw_tc = info->trap.hw_tc;
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_JUMP:
++	case PRESTERA_ACL_RULE_ACTION_JUMP:
+ 		action->jump.index = info->jump.index;
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_POLICE:
++	case PRESTERA_ACL_RULE_ACTION_POLICE:
+ 		action->police.rate = info->police.rate;
+ 		action->police.burst = info->police.burst;
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_NH:
++	case PRESTERA_ACL_RULE_ACTION_NH:
+ 		action->nh.nh_id = info->nh;
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_NAT:
++	case PRESTERA_ACL_RULE_ACTION_NAT:
+ 		action->nat.old_addr = info->nat.old_addr;
+ 		action->nat.new_addr = info->nat.new_addr;
+ 		action->nat.flags = info->nat.flags;
+ 		action->nat.port = info->nat.port;
+ 		action->nat.dev = info->nat.dev;
+ 		break;
+-	case MVSW_ACL_RULE_ACTION_COUNT:
++	case PRESTERA_ACL_RULE_ACTION_COUNT:
+ 		action->count.id = info->count.id;
+ 		break;
+ 	default:
+@@ -2159,26 +2142,26 @@ static int acl_rule_add_put_action(struct mvsw_msg_acl_action *action,
+ 
+ int prestera_hw_counter_trigger(const struct prestera_switch *sw, u32 block_id)
+ {
+-	struct mvsw_msg_counter_cmd req = {
++	struct prestera_msg_counter_req req = {
+ 		.block_id = block_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_COUNTER_TRIGGER, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_COUNTER_TRIGGER, &req);
+ }
+ 
+ int prestera_hw_counter_abort(const struct prestera_switch *sw)
+ {
+-	struct mvsw_msg_counter_cmd req;
++	struct prestera_msg_counter_req req;
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_COUNTER_ABORT, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_COUNTER_ABORT, &req);
+ }
+ 
+ int prestera_hw_counters_get(const struct prestera_switch *sw, u32 idx,
+ 			     u32 *len, bool *done,
+ 			     struct prestera_counter_stats *stats)
+ {
+-	struct mvsw_msg_counter_ret *resp;
+-	struct mvsw_msg_counter_cmd req = {
++	struct prestera_msg_counter_resp *resp;
++	struct prestera_msg_counter_req req = {
+ 		.block_id = idx,
+ 		.num_counters = *len,
+ 	};
+@@ -2189,7 +2172,7 @@ int prestera_hw_counters_get(const struct prestera_switch *sw, u32 idx,
+ 	if (!resp)
+ 		return -ENOMEM;
+ 
+-	err = fw_send_nreq_nresp(sw, MVSW_MSG_TYPE_COUNTER_GET,
++	err = fw_send_nreq_nresp(sw, PRESTERA_CMD_TYPE_COUNTER_GET,
+ 				 &req, sizeof(req), resp, size);
+ 	if (err)
+ 		goto free_buff;
+@@ -2211,11 +2194,11 @@ static u32 prestera_client_to_agent(enum prestera_counter_client client)
+ {
+ 	switch (client) {
+ 	case PRESTERA_COUNTER_CLIENT_LOOKUP_0:
+-		return MVSW_COUNTER_CLIENT_LOOKUP_0;
++		return PRESTERA_HW_COUNTER_CLIENT_LOOKUP_0;
+ 	case PRESTERA_COUNTER_CLIENT_LOOKUP_1:
+-		return MVSW_COUNTER_CLIENT_LOOKUP_1;
++		return PRESTERA_HW_COUNTER_CLIENT_LOOKUP_1;
+ 	case PRESTERA_COUNTER_CLIENT_LOOKUP_2:
+-		return MVSW_COUNTER_CLIENT_LOOKUP_2;
++		return PRESTERA_HW_COUNTER_CLIENT_LOOKUP_2;
+ 	case PRESTERA_COUNTER_CLIENT_LOOKUP_LAST:
+ 	default:
+ 		return -ENOTSUPP;
+@@ -2227,8 +2210,8 @@ int prestera_hw_counter_block_get(const struct prestera_switch *sw,
+ 				  u32 *block_id, u32 *offset,
+ 				  u32 *num_counters)
+ {
+-	struct mvsw_msg_counter_ret resp;
+-	struct mvsw_msg_counter_cmd req = {
++	struct prestera_msg_counter_resp resp;
++	struct prestera_msg_counter_req req = {
+ 		.client = prestera_client_to_agent(client)
+ 	};
+ 	int err = 0;
+@@ -2236,7 +2219,7 @@ int prestera_hw_counter_block_get(const struct prestera_switch *sw,
+ 	if (req.client == -ENOTSUPP)
+ 		return -ENOTSUPP;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_COUNTER_BLOCK_GET,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_COUNTER_BLOCK_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -2251,45 +2234,45 @@ int prestera_hw_counter_block_get(const struct prestera_switch *sw,
+ int prestera_hw_counter_block_release(const struct prestera_switch *sw,
+ 				      u32 block_id)
+ {
+-	struct mvsw_msg_counter_cmd req = {
++	struct prestera_msg_counter_req req = {
+ 		.block_id = block_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_COUNTER_BLOCK_RELEASE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_COUNTER_BLOCK_RELEASE, &req);
+ }
+ 
+ int prestera_hw_counter_clear(const struct prestera_switch *sw, u32 block_id,
+ 			      u32 counter_id)
+ {
+-	struct mvsw_msg_counter_cmd req = {
++	struct prestera_msg_counter_req req = {
+ 		.block_id = block_id,
+ 		.num_counters = counter_id,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_COUNTER_CLEAR, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_COUNTER_CLEAR, &req);
+ }
+ 
+ int prestera_hw_nat_port_neigh_update(const struct prestera_port *port,
+ 				      unsigned char *mac)
+ {
+-	struct mvsw_msg_nat_port_cmd req = {
++	struct prestera_msg_nat_port_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 	};
+ 	memcpy(req.neigh_mac, mac, sizeof(req.neigh_mac));
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_NAT_PORT_NEIGH_UPDATE,
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_NAT_PORT_NEIGH_UPDATE,
+ 			   &req);
+ }
+ 
+ int prestera_hw_nh_mangle_add(const struct prestera_switch *sw, u32 *nh_id)
+ {
+-	struct mvsw_msg_nh_mangle_cmd req;
+-	struct mvsw_msg_nh_mangle_ret resp;
++	struct prestera_msg_nh_mangle_req req;
++	struct prestera_msg_nh_mangle_resp resp;
+ 	int err;
+ 
+ 	memset(&req, 0, sizeof(req));
+ 	memset(&resp, 0, sizeof(resp));
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_NAT_NH_MANGLE_ADD, &req,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_NAT_NH_MANGLE_ADD, &req,
+ 			       &resp);
+ 	if (err)
+ 		return err;
+@@ -2300,11 +2283,11 @@ int prestera_hw_nh_mangle_add(const struct prestera_switch *sw, u32 *nh_id)
+ 
+ int prestera_hw_nh_mangle_del(const struct prestera_switch *sw, u32 nh_id)
+ {
+-	struct mvsw_msg_nh_mangle_cmd req;
++	struct prestera_msg_nh_mangle_req req;
+ 
+ 	memset(&req, 0, sizeof(req));
+ 	req.nh_id = nh_id;
+-	return fw_send_req(sw, MVSW_MSG_TYPE_NAT_NH_MANGLE_DEL, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_NAT_NH_MANGLE_DEL, &req);
+ }
+ 
+ int prestera_hw_nh_mangle_set(const struct prestera_switch *sw, u32 nh_id,
+@@ -2314,10 +2297,10 @@ int prestera_hw_nh_mangle_set(const struct prestera_switch *sw, u32 nh_id,
+ 			      bool dip_valid, struct prestera_ip_addr dip,
+ 			      struct prestera_neigh_info nh)
+ {
+-	struct mvsw_msg_nh_mangle_cmd req;
++	struct prestera_msg_nh_mangle_req req;
+ 	int err;
+ 
+-	if (sip.v != MVSW_PR_IPV4 || dip.v != MVSW_PR_IPV4)
++	if (sip.v != PRESTERA_IPV4 || dip.v != PRESTERA_IPV4)
+ 		return -EINVAL;
+ 
+ 	memset(&req, 0, sizeof(req));
+@@ -2332,24 +2315,24 @@ int prestera_hw_nh_mangle_set(const struct prestera_switch *sw, u32 nh_id,
+ 	req.info.dip = dip.u.ipv4;
+ 	req.info.nh.is_active = nh.connected;
+ 	memcpy(&req.info.nh.mac, nh.ha, ETH_ALEN);
+-	err = mvsw_pr_iface_to_msg(&nh.iface, &req.info.nh.oif);
++	err = prestera_iface_to_msg(&nh.iface, &req.info.nh.oif);
+ 	if (err)
+ 		return err;
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_NAT_NH_MANGLE_SET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_NAT_NH_MANGLE_SET, &req);
+ }
+ 
+ int prestera_hw_nh_mangle_get(const struct prestera_switch *sw, u32 nh_id,
+ 			      bool *is_active)
+ {
+-	struct mvsw_msg_nh_mangle_cmd req;
+-	struct mvsw_msg_nh_mangle_ret resp;
++	struct prestera_msg_nh_mangle_req req;
++	struct prestera_msg_nh_mangle_resp resp;
+ 	int err;
+ 
+ 	memset(&req, 0, sizeof(req));
+ 	req.nh_id = nh_id;
+ 	memset(&resp, 0, sizeof(resp));
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_NAT_NH_MANGLE_GET, &req,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_NAT_NH_MANGLE_GET, &req,
+ 			       &resp);
+ 	if (err)
+ 		return err;
+@@ -2361,13 +2344,14 @@ int prestera_hw_nh_mangle_get(const struct prestera_switch *sw, u32 nh_id,
+ int prestera_hw_span_get(const struct prestera_port *port, u8 *span_id)
+ {
+ 	int err;
+-	struct mvsw_msg_span_ret resp;
+-	struct mvsw_msg_span_cmd req = {
++	struct prestera_msg_span_resp resp;
++	struct prestera_msg_span_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 	};
+ 
+-	err = fw_send_req_resp(port->sw, MVSW_MSG_TYPE_SPAN_GET, &req, &resp);
++	err = fw_send_req_resp(port->sw, PRESTERA_CMD_TYPE_SPAN_GET,
++			       &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -2378,81 +2362,82 @@ int prestera_hw_span_get(const struct prestera_port *port, u8 *span_id)
+ 
+ int prestera_hw_span_bind(const struct prestera_port *port, u8 span_id)
+ {
+-	struct mvsw_msg_span_cmd req = {
++	struct prestera_msg_span_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.id = span_id,
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_SPAN_BIND, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_SPAN_BIND, &req);
+ }
+ 
+ int prestera_hw_span_unbind(const struct prestera_port *port)
+ {
+-	struct mvsw_msg_span_cmd req = {
++	struct prestera_msg_span_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_SPAN_UNBIND, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_SPAN_UNBIND, &req);
+ }
+ 
+ int prestera_hw_span_release(const struct prestera_switch *sw, u8 span_id)
+ {
+-	struct mvsw_msg_span_cmd req = {
++	struct prestera_msg_span_req req = {
+ 		.id = span_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_SPAN_RELEASE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_SPAN_RELEASE, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_member_add(struct prestera_port *port, u16 lag_id)
++int prestera_hw_lag_member_add(struct prestera_port *port, u16 lag_id)
+ {
+-	struct mvsw_msg_lag_cmd req = {
++	struct prestera_msg_lag_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.lag_id = lag_id
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_LAG_ADD, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_LAG_ADD, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_member_del(struct prestera_port *port, u16 lag_id)
++int prestera_hw_lag_member_del(struct prestera_port *port, u16 lag_id)
+ {
+-	struct mvsw_msg_lag_cmd req = {
++	struct prestera_msg_lag_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.lag_id = lag_id
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_LAG_DELETE, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_LAG_DELETE, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_member_enable(struct prestera_port *port, u16 lag_id,
+-				 bool enable)
++int prestera_hw_lag_member_enable(struct prestera_port *port, u16 lag_id,
++				  bool enable)
+ {
+ 	u32 cmd;
+-	struct mvsw_msg_lag_cmd req = {
++	struct prestera_msg_lag_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.lag_id = lag_id
+ 	};
+ 
+-	cmd = enable ? MVSW_MSG_TYPE_LAG_ENABLE : MVSW_MSG_TYPE_LAG_DISABLE;
++	cmd = enable ? PRESTERA_CMD_TYPE_LAG_ENABLE :
++			PRESTERA_CMD_TYPE_LAG_DISABLE;
+ 	return fw_send_req(port->sw, cmd, &req);
+ }
+ 
+-int mvsw_pr_hw_lag_member_rif_leave(const struct prestera_port *port,
+-				    u16 lag_id, u16 vr_id)
++int prestera_hw_lag_member_rif_leave(const struct prestera_port *port,
++				     u16 lag_id, u16 vr_id)
+ {
+-	struct mvsw_msg_lag_cmd req = {
++	struct prestera_msg_lag_req req = {
+ 		.port = port->hw_id,
+ 		.dev = port->dev_id,
+ 		.lag_id = lag_id,
+ 		.vr_id = vr_id
+ 	};
+ 
+-	return fw_send_req(port->sw, MVSW_MSG_TYPE_LAG_ROUTER_LEAVE, &req);
++	return fw_send_req(port->sw, PRESTERA_CMD_TYPE_LAG_ROUTER_LEAVE, &req);
+ }
+ 
+ int
+@@ -2460,14 +2445,14 @@ prestera_hw_cpu_code_counters_get(const struct prestera_switch *sw, u8 code,
+ 				  enum prestera_hw_cpu_code_cnt_t counter_type,
+ 				  u64 *packet_count)
+ {
+-	struct mvsw_msg_cpu_code_counter_cmd req = {
++	struct prestera_msg_cpu_code_counter_req req = {
+ 		.counter_type = counter_type,
+ 		.code = code,
+ 	};
+-	struct mvsw_msg_cpu_code_counter_ret resp;
++	struct prestera_msg_cpu_code_counter_resp resp;
+ 	int err;
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_CPU_CODE_COUNTERS_GET,
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_CPU_CODE_COUNTERS_GET,
+ 			       &req, &resp);
+ 	if (err)
+ 		return err;
+@@ -2478,12 +2463,14 @@ prestera_hw_cpu_code_counters_get(const struct prestera_switch *sw, u8 code,
+ }
+ 
+ int prestera_hw_vtcam_create(const struct prestera_switch *sw,
+-			     u8 lookup, const u32 *keymask, u32 *vtcam_id)
++			     u8 lookup, const u32 *keymask, u32 *vtcam_id,
++			     enum prestera_hw_vtcam_direction_t dir)
+ {
+ 	int err;
+-	struct mvsw_msg_vtcam_ret resp;
+-	struct mvsw_msg_vtcam_create_cmd req = {
++	struct prestera_msg_vtcam_resp resp;
++	struct prestera_msg_vtcam_create_req req = {
+ 		.lookup = lookup,
++		.direction = dir,
+ 	};
+ 
+ 	if (keymask)
+@@ -2491,7 +2478,7 @@ int prestera_hw_vtcam_create(const struct prestera_switch *sw,
+ 	else
+ 		memset(req.keymask, 0, sizeof(req.keymask));
+ 
+-	err = fw_send_req_resp(sw, MVSW_MSG_TYPE_VTCAM_CREATE, &req, &resp);
++	err = fw_send_req_resp(sw, PRESTERA_CMD_TYPE_VTCAM_CREATE, &req, &resp);
+ 	if (err)
+ 		return err;
+ 
+@@ -2501,11 +2488,11 @@ int prestera_hw_vtcam_create(const struct prestera_switch *sw,
+ 
+ int prestera_hw_vtcam_destroy(const struct prestera_switch *sw, u32 vtcam_id)
+ {
+-	struct mvsw_msg_vtcam_destroy_cmd req = {
++	struct prestera_msg_vtcam_destroy_req req = {
+ 		.vtcam_id = vtcam_id,
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VTCAM_DESTROY, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VTCAM_DESTROY, &req);
+ }
+ 
+ int prestera_hw_vtcam_rule_add(const struct prestera_switch *sw,
+@@ -2513,9 +2500,9 @@ int prestera_hw_vtcam_rule_add(const struct prestera_switch *sw,
+ 			       struct prestera_acl_hw_action_info *act,
+ 			       u8 n_act, u32 *rule_id)
+ {
+-	struct mvsw_msg_acl_action *actions_msg;
+-	struct mvsw_msg_vtcam_rule_add_cmd *req;
+-	struct mvsw_msg_vtcam_ret resp;
++	struct prestera_msg_acl_action *actions_msg;
++	struct prestera_msg_vtcam_rule_add_req *req;
++	struct prestera_msg_vtcam_resp resp;
+ 	void *buff;
+ 	u32 size;
+ 	int err;
+@@ -2545,7 +2532,7 @@ int prestera_hw_vtcam_rule_add(const struct prestera_switch *sw,
+ 	req->vtcam_id = vtcam_id;
+ 	req->prio = prio;
+ 
+-	err = fw_send_nreq_resp(sw, MVSW_MSG_TYPE_VTCAM_RULE_ADD, req,
++	err = fw_send_nreq_resp(sw, PRESTERA_CMD_TYPE_VTCAM_RULE_ADD, req,
+ 				size, &resp);
+ 	if (err)
+ 		goto free_buff;
+@@ -2559,19 +2546,19 @@ int prestera_hw_vtcam_rule_add(const struct prestera_switch *sw,
+ int prestera_hw_vtcam_rule_del(const struct prestera_switch *sw,
+ 			       u32 vtcam_id, u32 rule_id)
+ {
+-	struct mvsw_msg_vtcam_rule_del_cmd req = {
++	struct prestera_msg_vtcam_rule_del_req req = {
+ 		.vtcam_id = vtcam_id,
+ 		.id = rule_id
+ 	};
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VTCAM_RULE_DELETE, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VTCAM_RULE_DELETE, &req);
+ }
+ 
+ int prestera_hw_vtcam_iface_bind(const struct prestera_switch *sw,
+ 				 struct prestera_acl_iface *iface,
+ 				 u32 vtcam_id, u16 pcl_id)
+ {
+-	struct mvsw_msg_vtcam_bind_cmd req = {
++	struct prestera_msg_vtcam_bind_req req = {
+ 		.vtcam_id = vtcam_id,
+ 		.type = iface->type,
+ 		.pcl_id = pcl_id
+@@ -2584,14 +2571,14 @@ int prestera_hw_vtcam_iface_bind(const struct prestera_switch *sw,
+ 		req.index = iface->index;
+ 	}
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VTCAM_IFACE_BIND, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VTCAM_IFACE_BIND, &req);
+ }
+ 
+ int prestera_hw_vtcam_iface_unbind(const struct prestera_switch *sw,
+ 				   struct prestera_acl_iface *iface,
+ 				   u32 vtcam_id)
+ {
+-	struct mvsw_msg_vtcam_bind_cmd req = {
++	struct prestera_msg_vtcam_bind_req req = {
+ 		.vtcam_id = vtcam_id,
+ 		.type = iface->type,
+ 	};
+@@ -2603,12 +2590,12 @@ int prestera_hw_vtcam_iface_unbind(const struct prestera_switch *sw,
+ 		req.index = iface->index;
+ 	}
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_VTCAM_IFACE_UNBIND, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_VTCAM_IFACE_UNBIND, &req);
+ }
+ 
+ int prestera_hw_switch_reset(struct prestera_switch *sw)
+ {
+-	struct mvsw_msg_common_request req;
++	struct prestera_msg_common_req req;
+ 
+-	return fw_send_req(sw, MVSW_MSG_TYPE_SWITCH_RESET, &req);
++	return fw_send_req(sw, PRESTERA_CMD_TYPE_SWITCH_RESET, &req);
+ }
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_hw.h b/drivers/net/ethernet/marvell/prestera/prestera_hw.h
+index be6636a..c99c2f4 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_hw.h
++++ b/drivers/net/ethernet/marvell/prestera/prestera_hw.h
+@@ -1,15 +1,15 @@
+ /* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
+ /* Copyright (c) 2019-2021 Marvell International Ltd. All rights reserved. */
+ 
+-#ifndef _MVSW_PRESTERA_HW_H_
+-#define _MVSW_PRESTERA_HW_H_
++#ifndef _PRESTERA_HW_H_
++#define _PRESTERA_HW_H_
+ 
+ #include <linux/types.h>
+ 
+-enum mvsw_pr_accept_frame_type {
+-	MVSW_ACCEPT_FRAME_TYPE_TAGGED,
+-	MVSW_ACCEPT_FRAME_TYPE_UNTAGGED,
+-	MVSW_ACCEPT_FRAME_TYPE_ALL
++enum prestera_accept_frame_type {
++	PRESTERA_ACCEPT_FRAME_TYPE_TAGGED,
++	PRESTERA_ACCEPT_FRAME_TYPE_UNTAGGED,
++	PRESTERA_ACCEPT_FRAME_TYPE_ALL
+ };
+ 
+ enum {
+@@ -29,147 +29,147 @@ enum {
+ };
+ 
+ enum {
+-	MVSW_LINK_MODE_10baseT_Half_BIT,
+-	MVSW_LINK_MODE_10baseT_Full_BIT,
+-	MVSW_LINK_MODE_100baseT_Half_BIT,
+-	MVSW_LINK_MODE_100baseT_Full_BIT,
+-	MVSW_LINK_MODE_1000baseT_Half_BIT,
+-	MVSW_LINK_MODE_1000baseT_Full_BIT,
+-	MVSW_LINK_MODE_1000baseX_Full_BIT,
+-	MVSW_LINK_MODE_1000baseKX_Full_BIT,
+-	MVSW_LINK_MODE_2500baseX_Full_BIT,
+-	MVSW_LINK_MODE_10GbaseKR_Full_BIT,
+-	MVSW_LINK_MODE_10GbaseSR_Full_BIT,
+-	MVSW_LINK_MODE_10GbaseLR_Full_BIT,
+-	MVSW_LINK_MODE_20GbaseKR2_Full_BIT,
+-	MVSW_LINK_MODE_25GbaseCR_Full_BIT,
+-	MVSW_LINK_MODE_25GbaseKR_Full_BIT,
+-	MVSW_LINK_MODE_25GbaseSR_Full_BIT,
+-	MVSW_LINK_MODE_40GbaseKR4_Full_BIT,
+-	MVSW_LINK_MODE_40GbaseCR4_Full_BIT,
+-	MVSW_LINK_MODE_40GbaseSR4_Full_BIT,
+-	MVSW_LINK_MODE_50GbaseCR2_Full_BIT,
+-	MVSW_LINK_MODE_50GbaseKR2_Full_BIT,
+-	MVSW_LINK_MODE_50GbaseSR2_Full_BIT,
+-	MVSW_LINK_MODE_100GbaseKR4_Full_BIT,
+-	MVSW_LINK_MODE_100GbaseSR4_Full_BIT,
+-	MVSW_LINK_MODE_100GbaseCR4_Full_BIT,
+-	MVSW_LINK_MODE_MAX,
++	PRESTERA_LINK_MODE_10baseT_Half,
++	PRESTERA_LINK_MODE_10baseT_Full,
++	PRESTERA_LINK_MODE_100baseT_Half,
++	PRESTERA_LINK_MODE_100baseT_Full,
++	PRESTERA_LINK_MODE_1000baseT_Half,
++	PRESTERA_LINK_MODE_1000baseT_Full,
++	PRESTERA_LINK_MODE_1000baseX_Full,
++	PRESTERA_LINK_MODE_1000baseKX_Full,
++	PRESTERA_LINK_MODE_2500baseX_Full,
++	PRESTERA_LINK_MODE_10GbaseKR_Full,
++	PRESTERA_LINK_MODE_10GbaseSR_Full,
++	PRESTERA_LINK_MODE_10GbaseLR_Full,
++	PRESTERA_LINK_MODE_20GbaseKR2_Full,
++	PRESTERA_LINK_MODE_25GbaseCR_Full,
++	PRESTERA_LINK_MODE_25GbaseKR_Full,
++	PRESTERA_LINK_MODE_25GbaseSR_Full,
++	PRESTERA_LINK_MODE_40GbaseKR4_Full,
++	PRESTERA_LINK_MODE_40GbaseCR4_Full,
++	PRESTERA_LINK_MODE_40GbaseSR4_Full,
++	PRESTERA_LINK_MODE_50GbaseCR2_Full,
++	PRESTERA_LINK_MODE_50GbaseKR2_Full,
++	PRESTERA_LINK_MODE_50GbaseSR2_Full,
++	PRESTERA_LINK_MODE_100GbaseKR4_Full,
++	PRESTERA_LINK_MODE_100GbaseSR4_Full,
++	PRESTERA_LINK_MODE_100GbaseCR4_Full,
++	PRESTERA_LINK_MODE_MAX,
+ };
+ 
+ enum {
+-	MVSW_PORT_TYPE_NONE,
+-	MVSW_PORT_TYPE_TP,
+-	MVSW_PORT_TYPE_AUI,
+-	MVSW_PORT_TYPE_MII,
+-	MVSW_PORT_TYPE_FIBRE,
+-	MVSW_PORT_TYPE_BNC,
+-	MVSW_PORT_TYPE_DA,
+-	MVSW_PORT_TYPE_OTHER,
+-	MVSW_PORT_TYPE_MAX,
++	PRESTERA_PORT_TYPE_NONE,
++	PRESTERA_PORT_TYPE_TP,
++	PRESTERA_PORT_TYPE_AUI,
++	PRESTERA_PORT_TYPE_MII,
++	PRESTERA_PORT_TYPE_FIBRE,
++	PRESTERA_PORT_TYPE_BNC,
++	PRESTERA_PORT_TYPE_DA,
++	PRESTERA_PORT_TYPE_OTHER,
++	PRESTERA_PORT_TYPE_MAX,
+ };
+ 
+ enum {
+-	MVSW_PORT_TRANSCEIVER_COPPER,
+-	MVSW_PORT_TRANSCEIVER_SFP,
+-	MVSW_PORT_TRANSCEIVER_MAX,
++	PRESTERA_PORT_TCVR_COPPER,
++	PRESTERA_PORT_TCVR_SFP,
++	PRESTERA_PORT_TCVR_MAX,
+ };
+ 
+ enum {
+-	MVSW_PORT_FEC_OFF_BIT,
+-	MVSW_PORT_FEC_BASER_BIT,
+-	MVSW_PORT_FEC_RS_BIT,
+-	MVSW_PORT_FEC_MAX,
++	PRESTERA_PORT_FEC_OFF,
++	PRESTERA_PORT_FEC_BASER,
++	PRESTERA_PORT_FEC_RS,
++	PRESTERA_PORT_FEC_MAX,
+ };
+ 
+ enum {
+-	MVSW_PORT_DUPLEX_HALF,
+-	MVSW_PORT_DUPLEX_FULL,
+-	MVSW_PORT_DUPLEX_MAX
++	PRESTERA_PORT_DUPLEX_HALF,
++	PRESTERA_PORT_DUPLEX_FULL,
++	PRESTERA_PORT_DUPLEX_MAX
+ };
+ 
+ enum {
+-	MVSW_STP_DISABLED,
+-	MVSW_STP_BLOCK_LISTEN,
+-	MVSW_STP_LEARN,
+-	MVSW_STP_FORWARD
++	PRESTERA_STP_DISABLED,
++	PRESTERA_STP_BLOCK_LISTEN,
++	PRESTERA_STP_LEARN,
++	PRESTERA_STP_FORWARD
+ };
+ 
+ enum {
+-	MVSW_FW_LOG_LIB_BRIDGE = 0,
+-	MVSW_FW_LOG_LIB_CNC,
+-	MVSW_FW_LOG_LIB_CONFIG,
+-	MVSW_FW_LOG_LIB_COS,
+-	MVSW_FW_LOG_LIB_HW_INIT,
+-	MVSW_FW_LOG_LIB_CSCD,
+-	MVSW_FW_LOG_LIB_CUT_THROUGH,
+-	MVSW_FW_LOG_LIB_DIAG,
+-	MVSW_FW_LOG_LIB_FABRIC,
+-	MVSW_FW_LOG_LIB_IP,
+-	MVSW_FW_LOG_LIB_IPFIX,
+-	MVSW_FW_LOG_LIB_IP_LPM,
+-	MVSW_FW_LOG_LIB_L2_MLL,
+-	MVSW_FW_LOG_LIB_LOGICAL_TARGET,
+-	MVSW_FW_LOG_LIB_LPM,
+-	MVSW_FW_LOG_LIB_MIRROR,
+-	MVSW_FW_LOG_LIB_MULTI_PORT_GROUP,
+-	MVSW_FW_LOG_LIB_NETWORK_IF,
+-	MVSW_FW_LOG_LIB_NST,
+-	MVSW_FW_LOG_LIB_OAM,
+-	MVSW_FW_LOG_LIB_PCL,
+-	MVSW_FW_LOG_LIB_PHY,
+-	MVSW_FW_LOG_LIB_POLICER,
+-	MVSW_FW_LOG_LIB_PORT,
+-	MVSW_FW_LOG_LIB_PROTECTION,
+-	MVSW_FW_LOG_LIB_PTP,
+-	MVSW_FW_LOG_LIB_SYSTEM_RECOVERY,
+-	MVSW_FW_LOG_LIB_TCAM,
+-	MVSW_FW_LOG_LIB_TM_GLUE,
+-	MVSW_FW_LOG_LIB_TRUNK,
+-	MVSW_FW_LOG_LIB_TTI,
+-	MVSW_FW_LOG_LIB_TUNNEL,
+-	MVSW_FW_LOG_LIB_VNT,
+-	MVSW_FW_LOG_LIB_RESOURCE_MANAGER,
+-	MVSW_FW_LOG_LIB_VERSION,
+-	MVSW_FW_LOG_LIB_TM,
+-	MVSW_FW_LOG_LIB_SMI,
+-	MVSW_FW_LOG_LIB_INIT,
+-	MVSW_FW_LOG_LIB_DRAGONITE,
+-	MVSW_FW_LOG_LIB_VIRTUAL_TCAM,
+-	MVSW_FW_LOG_LIB_INGRESS,
+-	MVSW_FW_LOG_LIB_EGRESS,
+-	MVSW_FW_LOG_LIB_LATENCY_MONITORING,
+-	MVSW_FW_LOG_LIB_TAM,
+-	MVSW_FW_LOG_LIB_EXACT_MATCH,
+-	MVSW_FW_LOG_LIB_PHA,
+-	MVSW_FW_LOG_LIB_PACKET_ANALYZER,
+-	MVSW_FW_LOG_LIB_FLOW_MANAGER,
+-	MVSW_FW_LOG_LIB_BRIDGE_FDB_MANAGER,
+-	MVSW_FW_LOG_LIB_I2C,
+-	MVSW_FW_LOG_LIB_PPU,
+-	MVSW_FW_LOG_LIB_EXACT_MATCH_MANAGER,
+-	MVSW_FW_LOG_LIB_MAC_SEC,
+-	MVSW_FW_LOG_LIB_PTP_MANAGER,
+-	MVSW_FW_LOG_LIB_HSR_PRP,
+-	MVSW_FW_LOG_LIB_ALL,
+-
+-	MVSW_FW_LOG_LIB_MAX
++	PRESTERA_FW_LOG_LIB_BRIDGE = 0,
++	PRESTERA_FW_LOG_LIB_CNC,
++	PRESTERA_FW_LOG_LIB_CONFIG,
++	PRESTERA_FW_LOG_LIB_COS,
++	PRESTERA_FW_LOG_LIB_HW_INIT,
++	PRESTERA_FW_LOG_LIB_CSCD,
++	PRESTERA_FW_LOG_LIB_CUT_THROUGH,
++	PRESTERA_FW_LOG_LIB_DIAG,
++	PRESTERA_FW_LOG_LIB_FABRIC,
++	PRESTERA_FW_LOG_LIB_IP,
++	PRESTERA_FW_LOG_LIB_IPFIX,
++	PRESTERA_FW_LOG_LIB_IP_LPM,
++	PRESTERA_FW_LOG_LIB_L2_MLL,
++	PRESTERA_FW_LOG_LIB_LOGICAL_TARGET,
++	PRESTERA_FW_LOG_LIB_LPM,
++	PRESTERA_FW_LOG_LIB_MIRROR,
++	PRESTERA_FW_LOG_LIB_MULTI_PORT_GROUP,
++	PRESTERA_FW_LOG_LIB_NETWORK_IF,
++	PRESTERA_FW_LOG_LIB_NST,
++	PRESTERA_FW_LOG_LIB_OAM,
++	PRESTERA_FW_LOG_LIB_PCL,
++	PRESTERA_FW_LOG_LIB_PHY,
++	PRESTERA_FW_LOG_LIB_POLICER,
++	PRESTERA_FW_LOG_LIB_PORT,
++	PRESTERA_FW_LOG_LIB_PROTECTION,
++	PRESTERA_FW_LOG_LIB_PTP,
++	PRESTERA_FW_LOG_LIB_SYSTEM_RECOVERY,
++	PRESTERA_FW_LOG_LIB_TCAM,
++	PRESTERA_FW_LOG_LIB_TM_GLUE,
++	PRESTERA_FW_LOG_LIB_TRUNK,
++	PRESTERA_FW_LOG_LIB_TTI,
++	PRESTERA_FW_LOG_LIB_TUNNEL,
++	PRESTERA_FW_LOG_LIB_VNT,
++	PRESTERA_FW_LOG_LIB_RESOURCE_MANAGER,
++	PRESTERA_FW_LOG_LIB_VERSION,
++	PRESTERA_FW_LOG_LIB_TM,
++	PRESTERA_FW_LOG_LIB_SMI,
++	PRESTERA_FW_LOG_LIB_INIT,
++	PRESTERA_FW_LOG_LIB_DRAGONITE,
++	PRESTERA_FW_LOG_LIB_VIRTUAL_TCAM,
++	PRESTERA_FW_LOG_LIB_INGRESS,
++	PRESTERA_FW_LOG_LIB_EGRESS,
++	PRESTERA_FW_LOG_LIB_LATENCY_MONITORING,
++	PRESTERA_FW_LOG_LIB_TAM,
++	PRESTERA_FW_LOG_LIB_EXACT_MATCH,
++	PRESTERA_FW_LOG_LIB_PHA,
++	PRESTERA_FW_LOG_LIB_PACKET_ANALYZER,
++	PRESTERA_FW_LOG_LIB_FLOW_MANAGER,
++	PRESTERA_FW_LOG_LIB_BRIDGE_FDB_MANAGER,
++	PRESTERA_FW_LOG_LIB_I2C,
++	PRESTERA_FW_LOG_LIB_PPU,
++	PRESTERA_FW_LOG_LIB_EXACT_MATCH_MANAGER,
++	PRESTERA_FW_LOG_LIB_MAC_SEC,
++	PRESTERA_FW_LOG_LIB_PTP_MANAGER,
++	PRESTERA_FW_LOG_LIB_HSR_PRP,
++	PRESTERA_FW_LOG_LIB_ALL,
++
++	PRESTERA_FW_LOG_LIB_MAX
+ };
+ 
+ enum {
+-	MVSW_FW_LOG_TYPE_INFO = 0,
+-	MVSW_FW_LOG_TYPE_ENTRY_LEVEL_FUNCTION,
+-	MVSW_FW_LOG_TYPE_ERROR,
+-	MVSW_FW_LOG_TYPE_ALL,
+-	MVSW_FW_LOG_TYPE_NONE,
++	PRESTERA_FW_LOG_TYPE_INFO = 0,
++	PRESTERA_FW_LOG_TYPE_ENTRY_LEVEL_FUNCTION,
++	PRESTERA_FW_LOG_TYPE_ERROR,
++	PRESTERA_FW_LOG_TYPE_ALL,
++	PRESTERA_FW_LOG_TYPE_NONE,
+ 
+-	MVSW_FW_LOG_TYPE_MAX
++	PRESTERA_FW_LOG_TYPE_MAX
+ };
+ 
+ enum {
+-	MVSW_PORT_STORM_CTL_TYPE_BC = 0,
+-	MVSW_PORT_STORM_CTL_TYPE_UC_UNK = 1,
+-	MVSW_PORT_STORM_CTL_TYPE_MC = 2
++	PRESTERA_PORT_STORM_CTL_TYPE_BC = 0,
++	PRESTERA_PORT_STORM_CTL_TYPE_UC_UNK = 1,
++	PRESTERA_PORT_STORM_CTL_TYPE_MC = 2
+ };
+ 
+ enum prestera_hw_cpu_code_cnt_t {
+@@ -177,6 +177,11 @@ enum prestera_hw_cpu_code_cnt_t {
+ 	PRESTERA_HW_CPU_CODE_CNT_TYPE_TRAP = 1,
+ };
+ 
++enum prestera_hw_vtcam_direction_t {
++	PRESTERA_HW_VTCAM_DIR_INGRESS = 0,
++	PRESTERA_HW_VTCAM_DIR_EGRESS = 1,
++};
++
+ struct prestera_switch;
+ struct prestera_port;
+ struct prestera_port_stats;
+@@ -193,85 +198,85 @@ enum prestera_event_type;
+ struct prestera_event;
+ 
+ /* Switch API */
+-int mvsw_pr_hw_switch_init(struct prestera_switch *sw);
++int prestera_hw_switch_init(struct prestera_switch *sw);
+ int prestera_hw_switch_reset(struct prestera_switch *sw);
+-int mvsw_pr_hw_switch_ageing_set(const struct prestera_switch *sw,
+-				 u32 ageing_time);
+-int mvsw_pr_hw_switch_mac_set(const struct prestera_switch *sw, const u8 *mac);
+-int mvsw_pr_hw_switch_trap_policer_set(const struct prestera_switch *sw,
+-				       u8 profile);
++int prestera_hw_switch_ageing_set(const struct prestera_switch *sw,
++				  u32 ageing_time);
++int prestera_hw_switch_mac_set(const struct prestera_switch *sw, const u8 *mac);
++int prestera_hw_switch_trap_policer_set(const struct prestera_switch *sw,
++					u8 profile);
+ 
+ /* Port API */
+-int mvsw_pr_hw_port_info_get(const struct prestera_port *port,
+-			     u16 *fp_id, u32 *hw_id, u32 *dev_id);
+-int mvsw_pr_hw_port_mtu_set(const struct prestera_port *port, u32 mtu);
+-int mvsw_pr_hw_port_mtu_get(const struct prestera_port *port, u32 *mtu);
+-int mvsw_pr_hw_port_mac_set(const struct prestera_port *port, char *mac);
+-int mvsw_pr_hw_port_mac_get(const struct prestera_port *port, char *mac);
+-int mvsw_pr_hw_port_accept_frame_type_set(const struct prestera_port *port,
+-					  enum mvsw_pr_accept_frame_type type);
+-int mvsw_pr_hw_port_learning_set(const struct prestera_port *port, bool enable);
+-int mvsw_pr_hw_port_uc_flood_set(const struct prestera_port *port, bool flood);
+-int mvsw_pr_hw_port_mc_flood_set(const struct prestera_port *port, bool flood);
++int prestera_hw_port_info_get(const struct prestera_port *port,
++			      u16 *fp_id, u32 *hw_id, u32 *dev_id);
++int prestera_hw_port_mtu_set(const struct prestera_port *port, u32 mtu);
++int prestera_hw_port_mtu_get(const struct prestera_port *port, u32 *mtu);
++int prestera_hw_port_mac_set(const struct prestera_port *port, char *mac);
++int prestera_hw_port_mac_get(const struct prestera_port *port, char *mac);
++int prestera_hw_port_accept_frame_type_set(const struct prestera_port *port,
++					   enum prestera_accept_frame_type type);
++int prestera_hw_port_learning_set(const struct prestera_port *port,
++				  bool enable);
++int prestera_hw_port_uc_flood_set(const struct prestera_port *port, bool flood);
++int prestera_hw_port_mc_flood_set(const struct prestera_port *port, bool flood);
+ int prestera_hw_port_srcid_default_set(const struct prestera_port *port,
+ 				       u32 sourceid);
+ int prestera_hw_port_srcid_filter_set(const struct prestera_port *port,
+ 				      u32 sourceid);
+-int mvsw_pr_hw_port_cap_get(const struct prestera_port *port,
+-			    struct prestera_port_caps *caps);
+-int mvsw_pr_hw_port_remote_cap_get(const struct prestera_port *port,
+-				   u64 *link_mode_bitmap,
+-				   bool *pause, bool *asym_pause);
+-int mvsw_pr_hw_port_type_get(const struct prestera_port *port, u8 *type);
+-int mvsw_pr_hw_port_stats_get(const struct prestera_port *port,
+-			      struct prestera_port_stats *stats);
+-int mvsw_pr_hw_port_mac_mode_get(const struct prestera_port *port,
+-				 u32 *mode, u32 *speed, u8 *duplex, u8 *fec);
+-int mvsw_pr_hw_port_mac_mode_set(const struct prestera_port *port,
+-				 bool admin, u32 mode, u8 inband,
+-				 u32 speed, u8 duplex, u8 fec);
+-int mvsw_pr_hw_port_phy_mode_set(const struct prestera_port *port,
+-				 bool admin, bool adv, u32 mode, u64 modes);
+-int mvsw_pr_hw_port_mdix_get(const struct prestera_port *port, u8 *status,
+-			     u8 *admin_mode);
+-int mvsw_pr_hw_port_mdix_set(const struct prestera_port *port, u8 mode);
+-int mvsw_pr_hw_port_autoneg_restart(struct prestera_port *port);
+-
+-int mvsw_pr_hw_port_storm_control_cfg_set(const struct prestera_port *port,
+-					  u32 storm_type,
+-					  u32 kbyte_per_sec_rate);
++int prestera_hw_port_cap_get(const struct prestera_port *port,
++			     struct prestera_port_caps *caps);
++int prestera_hw_port_type_get(const struct prestera_port *port, u8 *type);
++int prestera_hw_port_stats_get(const struct prestera_port *port,
++			       struct prestera_port_stats *stats);
++int prestera_hw_port_mac_mode_get(const struct prestera_port *port,
++				  u32 *mode, u32 *speed, u8 *duplex, u8 *fec);
++int prestera_hw_port_mac_mode_set(const struct prestera_port *port,
++				  bool admin, u32 mode, u8 inband,
++				  u32 speed, u8 duplex, u8 fec);
++int prestera_hw_port_phy_mode_get(const struct prestera_port *port,
++				  u8 *mdix, u64 *lmode_bmap,
++				  bool *fc_pause, bool *fc_asym);
++int prestera_hw_port_phy_mode_set(const struct prestera_port *port,
++				  bool admin, bool adv, u32 mode, u64 modes,
++				  u8 mdix);
++int prestera_hw_port_autoneg_restart(struct prestera_port *port);
++
++int prestera_hw_port_storm_control_cfg_set(const struct prestera_port *port,
++					   u32 storm_type,
++					   u32 kbyte_per_sec_rate);
+ 
+ /* Vlan API */
+-int mvsw_pr_hw_vlan_create(const struct prestera_switch *sw, u16 vid);
+-int mvsw_pr_hw_vlan_delete(const struct prestera_switch *sw, u16 vid);
+-int mvsw_pr_hw_vlan_port_set(const struct prestera_port *port,
+-			     u16 vid, bool is_member, bool untagged);
+-int mvsw_pr_hw_vlan_port_vid_set(const struct prestera_port *port, u16 vid);
++int prestera_hw_vlan_create(const struct prestera_switch *sw, u16 vid);
++int prestera_hw_vlan_delete(const struct prestera_switch *sw, u16 vid);
++int prestera_hw_vlan_port_set(const struct prestera_port *port,
++			      u16 vid, bool is_member, bool untagged);
++int prestera_hw_vlan_port_vid_set(const struct prestera_port *port, u16 vid);
+ 
+ /* FDB API */
+-int mvsw_pr_hw_fdb_add(const struct prestera_port *port,
+-		       const unsigned char *mac, u16 vid, bool dynamic);
+-int mvsw_pr_hw_fdb_del(const struct prestera_port *port,
+-		       const unsigned char *mac, u16 vid);
+-int mvsw_pr_hw_fdb_flush_port(const struct prestera_port *port, u32 mode);
+-int mvsw_pr_hw_fdb_flush_vlan(const struct prestera_switch *sw, u16 vid,
+-			      u32 mode);
+-int mvsw_pr_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
+-				   u32 mode);
+-int mvsw_pr_hw_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
+-			   const u8 *mac, u16 vid);
+-int mvsw_pr_hw_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
+-			   const u8 *mac, u16 vid);
++int prestera_hw_fdb_add(const struct prestera_port *port,
++			const unsigned char *mac, u16 vid, bool dynamic);
++int prestera_hw_fdb_del(const struct prestera_port *port,
++			const unsigned char *mac, u16 vid);
++int prestera_hw_fdb_flush_port(const struct prestera_port *port, u32 mode);
++int prestera_hw_fdb_flush_vlan(const struct prestera_switch *sw, u16 vid,
++			       u32 mode);
++int prestera_hw_fdb_flush_port_vlan(const struct prestera_port *port, u16 vid,
++				    u32 mode);
++int prestera_hw_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
++			    const u8 *mac, u16 vid);
++int prestera_hw_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
++			    const u8 *mac, u16 vid);
+ 
+ /* Bridge API */
+-int mvsw_pr_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id);
+-int mvsw_pr_hw_bridge_delete(const struct prestera_switch *sw, u16 bridge_id);
+-int mvsw_pr_hw_bridge_port_add(const struct prestera_port *port, u16 bridge_id);
+-int mvsw_pr_hw_bridge_port_delete(const struct prestera_port *port,
+-				  u16 bridge_id);
++int prestera_hw_bridge_create(const struct prestera_switch *sw, u16 *bridge_id);
++int prestera_hw_bridge_delete(const struct prestera_switch *sw, u16 bridge_id);
++int prestera_hw_bridge_port_add(const struct prestera_port *port,
++				u16 bridge_id);
++int prestera_hw_bridge_port_delete(const struct prestera_port *port,
++				   u16 bridge_id);
+ 
+ /* STP API */
+-int mvsw_pr_hw_port_vid_stp_set(struct prestera_port *port, u16 vid, u8 state);
++int prestera_hw_port_vid_stp_set(struct prestera_port *port, u16 vid, u8 state);
+ 
+ /* Counter API */
+ int prestera_hw_counter_trigger(const struct prestera_switch *sw, u32 block_id);
+@@ -290,7 +295,8 @@ int prestera_hw_counter_clear(const struct prestera_switch *sw, u32 block_id,
+ 
+ /* vTCAM API */
+ int prestera_hw_vtcam_create(const struct prestera_switch *sw,
+-			     u8 lookup, const u32 *keymask, u32 *vtcam_id);
++			     u8 lookup, const u32 *keymask, u32 *vtcam_id,
++			     enum prestera_hw_vtcam_direction_t direction);
+ int prestera_hw_vtcam_rule_add(const struct prestera_switch *sw, u32 vtcam_id,
+ 			       u32 prio, void *key, void *keymask,
+ 			       struct prestera_acl_hw_action_info *act,
+@@ -326,75 +332,75 @@ int prestera_hw_span_unbind(const struct prestera_port *port);
+ int prestera_hw_span_release(const struct prestera_switch *sw, u8 span_id);
+ 
+ /* Router API */
+-int mvsw_pr_hw_rif_create(const struct prestera_switch *sw,
+-			  struct prestera_iface *iif, u8 *mac, u16 *rif_id);
+-int mvsw_pr_hw_rif_delete(const struct prestera_switch *sw, u16 rif_id,
+-			  struct prestera_iface *iif);
+-int mvsw_pr_hw_rif_set(const struct prestera_switch *sw, u16 *rif_id,
+-		       struct prestera_iface *iif, u8 *mac);
++int prestera_hw_rif_create(const struct prestera_switch *sw,
++			   struct prestera_iface *iif, u8 *mac, u16 *rif_id);
++int prestera_hw_rif_delete(const struct prestera_switch *sw, u16 rif_id,
++			   struct prestera_iface *iif);
++int prestera_hw_rif_set(const struct prestera_switch *sw, u16 *rif_id,
++			struct prestera_iface *iif, u8 *mac);
+ 
+ /* Virtual Router API */
+-int mvsw_pr_hw_vr_create(const struct prestera_switch *sw, u16 *vr_id);
+-int mvsw_pr_hw_vr_delete(const struct prestera_switch *sw, u16 vr_id);
+-int mvsw_pr_hw_vr_abort(const struct prestera_switch *sw, u16 vr_id);
++int prestera_hw_vr_create(const struct prestera_switch *sw, u16 *vr_id);
++int prestera_hw_vr_delete(const struct prestera_switch *sw, u16 vr_id);
++int prestera_hw_vr_abort(const struct prestera_switch *sw, u16 vr_id);
+ 
+ /* LPM API */
+-int mvsw_pr_hw_lpm_add(const struct prestera_switch *sw, u16 vr_id,
+-		       __be32 dst, u32 dst_len, u32 grp_id);
+-int mvsw_pr_hw_lpm_del(const struct prestera_switch *sw, u16 vr_id, __be32 dst,
+-		       u32 dst_len);
++int prestera_hw_lpm_add(const struct prestera_switch *sw, u16 vr_id,
++			__be32 dst, u32 dst_len, u32 grp_id);
++int prestera_hw_lpm_del(const struct prestera_switch *sw, u16 vr_id, __be32 dst,
++			u32 dst_len);
+ 
+ /* NH API */
+-int mvsw_pr_hw_nh_entries_set(const struct prestera_switch *sw, int count,
+-			      struct prestera_neigh_info *nhs, u32 grp_id);
+-int mvsw_pr_hw_nh_entries_get(const struct prestera_switch *sw, int count,
+-			      struct prestera_neigh_info *nhs, u32 grp_id);
+-int mvsw_pr_hw_nhgrp_blk_get(const struct prestera_switch *sw,
+-			     u8 *hw_state, u32 buf_size /* Buffer in bytes */);
+-int mvsw_pr_hw_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
+-			       u32 *grp_id);
+-int mvsw_pr_hw_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
+-			       u32 grp_id);
++int prestera_hw_nh_entries_set(const struct prestera_switch *sw, int count,
++			       struct prestera_neigh_info *nhs, u32 grp_id);
++int prestera_hw_nh_entries_get(const struct prestera_switch *sw, int count,
++			       struct prestera_neigh_info *nhs, u32 grp_id);
++int prestera_hw_nhgrp_blk_get(const struct prestera_switch *sw,
++			      u8 *hw_state, u32 buf_size /* Buffer in bytes */);
++int prestera_hw_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
++				u32 *grp_id);
++int prestera_hw_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
++				u32 grp_id);
+ 
+ /* MP API */
+-int mvsw_pr_hw_mp4_hash_set(const struct prestera_switch *sw, u8 hash_policy);
++int prestera_hw_mp4_hash_set(const struct prestera_switch *sw, u8 hash_policy);
+ 
+ /* LAG API */
+-int mvsw_pr_hw_lag_member_add(struct prestera_port *port, u16 lag_id);
+-int mvsw_pr_hw_lag_member_del(struct prestera_port *port, u16 lag_id);
+-int mvsw_pr_hw_lag_member_enable(struct prestera_port *port, u16 lag_id,
+-				 bool enable);
+-int mvsw_pr_hw_lag_fdb_add(const struct prestera_switch *sw, u16 lag_id,
+-			   const unsigned char *mac, u16 vid, bool dynamic);
+-int mvsw_pr_hw_lag_fdb_del(const struct prestera_switch *sw, u16 lag_id,
+-			   const unsigned char *mac, u16 vid);
+-int mvsw_pr_hw_fdb_flush_lag(const struct prestera_switch *sw, u16 lag_id,
+-			     u32 mode);
+-int mvsw_pr_hw_fdb_flush_lag_vlan(const struct prestera_switch *sw,
+-				  u16 lag_id, u16 vid, u32 mode);
+-int mvsw_pr_hw_lag_member_rif_leave(const struct prestera_port *port,
+-				    u16 lag_id, u16 vr_id);
++int prestera_hw_lag_member_add(struct prestera_port *port, u16 lag_id);
++int prestera_hw_lag_member_del(struct prestera_port *port, u16 lag_id);
++int prestera_hw_lag_member_enable(struct prestera_port *port, u16 lag_id,
++				  bool enable);
++int prestera_hw_lag_fdb_add(const struct prestera_switch *sw, u16 lag_id,
++			    const unsigned char *mac, u16 vid, bool dynamic);
++int prestera_hw_lag_fdb_del(const struct prestera_switch *sw, u16 lag_id,
++			    const unsigned char *mac, u16 vid);
++int prestera_hw_fdb_flush_lag(const struct prestera_switch *sw, u16 lag_id,
++			      u32 mode);
++int prestera_hw_fdb_flush_lag_vlan(const struct prestera_switch *sw,
++				   u16 lag_id, u16 vid, u32 mode);
++int prestera_hw_lag_member_rif_leave(const struct prestera_port *port,
++				     u16 lag_id, u16 vr_id);
+ 
+ /* Event handlers */
+-int mvsw_pr_hw_event_handler_register(struct prestera_switch *sw,
+-				      enum prestera_event_type type,
+-				      void (*cb)(struct prestera_switch *sw,
+-						 struct prestera_event *evt,
+-						 void *arg),
+-				      void *arg);
++int prestera_hw_event_handler_register(struct prestera_switch *sw,
++				       enum prestera_event_type type,
++				       void (*cb)(struct prestera_switch *sw,
++						  struct prestera_event *evt,
++						  void *arg),
++				       void *arg);
+ 
+-void mvsw_pr_hw_event_handler_unregister(struct prestera_switch *sw,
+-					 enum prestera_event_type type);
++void prestera_hw_event_handler_unregister(struct prestera_switch *sw,
++					  enum prestera_event_type type);
+ 
+ /* FW Log API */
+-int mvsw_pr_hw_fw_log_level_set(const struct prestera_switch *sw, u32 lib,
+-				u32 type);
++int prestera_hw_fw_log_level_set(const struct prestera_switch *sw, u32 lib,
++				 u32 type);
+ 
+-int mvsw_pr_hw_rxtx_init(const struct prestera_switch *sw, bool use_sdma,
+-			 u32 *map_addr);
++int prestera_hw_rxtx_init(const struct prestera_switch *sw, bool use_sdma,
++			  u32 *map_addr);
+ 
+ /* FW Keepalive/ Watchdog API */
+-void mvsw_pr_hw_keepalive_fini(const struct prestera_switch *sw);
++void prestera_hw_keepalive_fini(const struct prestera_switch *sw);
+ 
+ /* HW trap/drop counters API */
+ int
+@@ -402,4 +408,4 @@ prestera_hw_cpu_code_counters_get(const struct prestera_switch *sw, u8 code,
+ 				  enum prestera_hw_cpu_code_cnt_t counter_type,
+ 				  u64 *packet_count);
+ 
+-#endif /* _MVSW_PRESTERA_HW_H_ */
++#endif /* _PRESTERA_HW_H_ */
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_main.c b/drivers/net/ethernet/marvell/prestera/prestera_main.c
+index 75cd8c3..e6f081a 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_main.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_main.c
+@@ -27,6 +27,7 @@
+ #include "prestera_rxtx.h"
+ #include "prestera_drv_ver.h"
+ #include "prestera_counter.h"
++#include "prestera_switchdev.h"
+ 
+ static u8 trap_policer_profile = 1;
+ 
+@@ -79,21 +80,28 @@ static struct prestera_port *__find_pr_port(const struct prestera_switch *sw,
+ 
+ static int prestera_port_open(struct net_device *dev)
+ {
+-	int err = 0;
+-#ifdef CONFIG_PHYLINK
+ 	struct prestera_port *port = netdev_priv(dev);
++	struct prestera_port_mac_config cfg_mac;
++	int err = 0;
+ 
++#ifdef CONFIG_PHYLINK
+ 	if (port->phy_link) {
+ 		phylink_start(port->phy_link);
+-		/* port became up once mac_config called */
+ 	} else {
+-		port->cfg_phy.admin = true;
+-		err = mvsw_pr_hw_port_phy_mode_set(port, true, port->autoneg,
+-						   port->cfg_phy.mode,
+-						   port->adver_link_modes);
++#endif
++		if (port->caps.transceiver == PRESTERA_PORT_TCVR_SFP) {
++			prestera_port_cfg_mac_read(port, &cfg_mac);
++			cfg_mac.admin = true;
++			prestera_port_cfg_mac_write(port, &cfg_mac);
++		} else {
++			port->cfg_phy.admin = true;
++			err = prestera_hw_port_phy_mode_set(port, true, port->autoneg,
++							    port->cfg_phy.mode,
++							    port->adver_link_modes,
++							    port->cfg_phy.mdix);
++		}
++#ifdef CONFIG_PHYLINK
+ 	}
+-#else
+-	pr_err("Can't operate without phylink");
+ #endif
+ 
+ 	netif_start_queue(dev);
+@@ -102,14 +110,17 @@ static int prestera_port_open(struct net_device *dev)
+ 
+ static int prestera_port_close(struct net_device *dev)
+ {
+-	int err = 0;
+ 	struct prestera_port *port = netdev_priv(dev);
+-#ifdef CONFIG_PHYLINK
+ 	struct prestera_port_mac_config cfg_mac;
++	int err = 0;
+ 
++#ifdef CONFIG_PHYLINK
+ 	if (port->phy_link) {
+ 		phylink_stop(port->phy_link);
+ 		phylink_disconnect_phy(port->phy_link);
++	}
++#endif
++	if (port->caps.transceiver == PRESTERA_PORT_TCVR_SFP) {
+ 		/* TODO: can we use somethink, like phylink callback ? */
+ 		/* ensure, that link is down */
+ 		/* TODO: use macros for operations like admin down-up ? */
+@@ -118,15 +129,15 @@ static int prestera_port_close(struct net_device *dev)
+ 		prestera_port_cfg_mac_write(port, &cfg_mac);
+ 	} else {
+ 		port->cfg_phy.admin = false;
+-		err = mvsw_pr_hw_port_phy_mode_set(port, false, port->autoneg,
+-						   port->cfg_phy.mode,
+-						   port->adver_link_modes);
++		err = prestera_hw_port_phy_mode_set(port, false, port->autoneg,
++						    port->cfg_phy.mode,
++						    port->adver_link_modes,
++						    port->cfg_phy.mdix);
+ 	}
+-#else
+-	pr_err("Can't operate without phylink");
+-#endif
+ 
+-	prestera_fdb_flush_port(port, MVSW_PR_FDB_FLUSH_MODE_DYNAMIC);
++	/* TODO: does it make any sense ? */
++	 /* should not FDB all be cleared */
++	prestera_bridge_port_down(port);
+ 
+ 	netif_stop_queue(dev);
+ 	return err;
+@@ -180,7 +191,7 @@ static int prestera_port_set_mac_address(struct net_device *dev, void *p)
+ 	if (err)
+ 		return err;
+ 
+-	err = mvsw_pr_hw_port_mac_set(port, addr->sa_data);
++	err = prestera_hw_port_mac_set(port, addr->sa_data);
+ 	if (!err)
+ 		memcpy(dev->dev_addr, addr->sa_data, dev->addr_len);
+ 
+@@ -193,7 +204,7 @@ static int prestera_port_change_mtu(struct net_device *dev, int mtu)
+ 	int err;
+ 
+ 	if (port->sw->mtu_min <= mtu && mtu <= port->sw->mtu_max)
+-		err = mvsw_pr_hw_port_mtu_set(port, mtu);
++		err = prestera_hw_port_mtu_set(port, mtu);
+ 	else
+ 		err = -EINVAL;
+ 
+@@ -235,7 +246,7 @@ static void prestera_port_get_stats64(struct net_device *dev,
+ 
+ static void prestera_port_get_hw_stats(struct prestera_port *port)
+ {
+-	mvsw_pr_hw_port_stats_get(port, &port->cached_hw_stats.stats);
++	prestera_hw_port_stats_get(port, &port->cached_hw_stats.stats);
+ }
+ 
+ static void update_stats_cache(struct work_struct *work)
+@@ -432,9 +443,9 @@ int prestera_port_cfg_mac_write(struct prestera_port *port,
+ {
+ 	int err;
+ 
+-	err = mvsw_pr_hw_port_mac_mode_set(port, cfg->admin,
+-					   cfg->mode, cfg->inband, cfg->speed,
+-					   cfg->duplex, cfg->fec);
++	err = prestera_hw_port_mac_mode_set(port, cfg->admin,
++					    cfg->mode, cfg->inband, cfg->speed,
++					    cfg->duplex, cfg->fec);
+ 	if (err)
+ 		return err;
+ 
+@@ -451,31 +462,32 @@ int prestera_port_autoneg_set(struct prestera_port *port, u64 link_modes)
+ 	if (port->autoneg == true && port->adver_link_modes == link_modes)
+ 		return 0;
+ 
+-	if (mvsw_pr_hw_port_phy_mode_set(port, port->cfg_phy.admin,
+-					 true, 0, link_modes))
++	if (prestera_hw_port_phy_mode_set(port, port->cfg_phy.admin,
++					  true, 0, link_modes,
++					  port->cfg_phy.mdix))
+ 		return -EINVAL;
+ 
+ 	/* TODO: move all this parameters to cfg_phy */
+ 	port->autoneg = true;
+ 	port->cfg_phy.mode = 0;
+ 	port->adver_link_modes = link_modes;
+-	port->adver_fec = BIT(MVSW_PORT_FEC_OFF_BIT);
++	port->adver_fec = BIT(PRESTERA_PORT_FEC_OFF);
+ 	return 0;
+ }
+ 
+ int prestera_port_learning_set(struct prestera_port *port, bool learn)
+ {
+-	return mvsw_pr_hw_port_learning_set(port, learn);
++	return prestera_hw_port_learning_set(port, learn);
+ }
+ 
+ int prestera_port_uc_flood_set(struct prestera_port *port, bool flood)
+ {
+-	return mvsw_pr_hw_port_uc_flood_set(port, flood);
++	return prestera_hw_port_uc_flood_set(port, flood);
+ }
+ 
+ int prestera_port_mc_flood_set(struct prestera_port *port, bool flood)
+ {
+-	return mvsw_pr_hw_port_mc_flood_set(port, flood);
++	return prestera_hw_port_mc_flood_set(port, flood);
+ }
+ 
+ /* Isolation group - is set of ports,
+@@ -510,16 +522,16 @@ int prestera_port_pvid_set(struct prestera_port *port, u16 vid)
+ 	int err;
+ 
+ 	if (!vid) {
+-		err = mvsw_pr_hw_port_accept_frame_type_set
+-		    (port, MVSW_ACCEPT_FRAME_TYPE_TAGGED);
++		err = prestera_hw_port_accept_frame_type_set
++		    (port, PRESTERA_ACCEPT_FRAME_TYPE_TAGGED);
+ 		if (err)
+ 			return err;
+ 	} else {
+-		err = mvsw_pr_hw_vlan_port_vid_set(port, vid);
++		err = prestera_hw_vlan_port_vid_set(port, vid);
+ 		if (err)
+ 			return err;
+-		err = mvsw_pr_hw_port_accept_frame_type_set
+-		    (port, MVSW_ACCEPT_FRAME_TYPE_ALL);
++		err = prestera_hw_port_accept_frame_type_set
++		    (port, PRESTERA_ACCEPT_FRAME_TYPE_ALL);
+ 		if (err)
+ 			goto err_port_allow_untagged_set;
+ 	}
+@@ -528,7 +540,7 @@ int prestera_port_pvid_set(struct prestera_port *port, u16 vid)
+ 	return 0;
+ 
+ err_port_allow_untagged_set:
+-	mvsw_pr_hw_vlan_port_vid_set(port, port->pvid);
++	prestera_hw_vlan_port_vid_set(port, port->pvid);
+ 	return err;
+ }
+ 
+@@ -538,27 +550,27 @@ int prestera_port_vid_stp_set(struct prestera_port *port, u16 vid, u8 state)
+ 
+ 	switch (state) {
+ 	case BR_STATE_DISABLED:
+-		hw_state = MVSW_STP_DISABLED;
++		hw_state = PRESTERA_STP_DISABLED;
+ 		break;
+ 
+ 	case BR_STATE_BLOCKING:
+ 	case BR_STATE_LISTENING:
+-		hw_state = MVSW_STP_BLOCK_LISTEN;
++		hw_state = PRESTERA_STP_BLOCK_LISTEN;
+ 		break;
+ 
+ 	case BR_STATE_LEARNING:
+-		hw_state = MVSW_STP_LEARN;
++		hw_state = PRESTERA_STP_LEARN;
+ 		break;
+ 
+ 	case BR_STATE_FORWARDING:
+-		hw_state = MVSW_STP_FORWARD;
++		hw_state = PRESTERA_STP_FORWARD;
+ 		break;
+ 
+ 	default:
+ 		return -EINVAL;
+ 	}
+ 
+-	return mvsw_pr_hw_port_vid_stp_set(port, vid, hw_state);
++	return prestera_hw_port_vid_stp_set(port, vid, hw_state);
+ }
+ 
+ struct prestera_port_vlan*
+@@ -594,7 +606,7 @@ prestera_port_vlan_create(struct prestera_port *port, u16 vid, bool untagged)
+ 		goto err_port_vlan_alloc;
+ 	}
+ 
+-	port_vlan->mvsw_pr_port = port;
++	port_vlan->port = port;
+ 	port_vlan->vid = vid;
+ 
+ 	list_add(&port_vlan->list, &port->vlans_list);
+@@ -615,19 +627,19 @@ prestera_port_vlan_cleanup(struct prestera_port_vlan *port_vlan)
+ 
+ void prestera_port_vlan_destroy(struct prestera_port_vlan *port_vlan)
+ {
+-	struct prestera_port *port = port_vlan->mvsw_pr_port;
++	struct prestera_port *port = port_vlan->port;
+ 	u16 vid = port_vlan->vid;
+ 
+ 	prestera_port_vlan_cleanup(port_vlan);
+ 	list_del(&port_vlan->list);
+ 	kfree(port_vlan);
+-	mvsw_pr_hw_vlan_port_set(port, vid, false, false);
++	prestera_hw_vlan_port_set(port, vid, false, false);
+ }
+ 
+ int prestera_port_vlan_set(struct prestera_port *port, u16 vid,
+ 			   bool is_member, bool untagged)
+ {
+-	return mvsw_pr_hw_vlan_port_set(port, vid, is_member, untagged);
++	return prestera_hw_vlan_port_set(port, vid, is_member, untagged);
+ }
+ 
+ #ifdef CONFIG_PHYLINK
+@@ -707,15 +719,15 @@ static void prestera_mac_pcs_get_state(struct phylink_config *config,
+ 	struct net_device *ndev = to_net_dev(config->dev);
+ 	struct prestera_port *port = netdev_priv(ndev);
+ 
+-	state->link = port->link_params.oper_state;
++	state->link = port->state_mac.oper;
+ 	state->pause = 0;
+ 
+-	if (port->link_params.oper_state) {
++	if (port->state_mac.oper) {
+ 		/* AN is completed, when port is up */
+ 		state->an_complete = port->autoneg;
+ 
+-		state->speed = port->link_params.speed;
+-		state->duplex = port->link_params.duplex;
++		state->speed = port->state_mac.speed;
++		state->duplex = port->state_mac.duplex;
+ 	} else {
+ 		state->an_complete = false;
+ 		state->speed = SPEED_UNKNOWN;
+@@ -737,7 +749,7 @@ static void prestera_mac_config(struct phylink_config *config,
+ 	cfg_mac.inband = false;
+ 	cfg_mac.speed = 0;
+ 	cfg_mac.duplex = DUPLEX_UNKNOWN;
+-	cfg_mac.fec = MVSW_PORT_FEC_OFF_BIT;
++	cfg_mac.fec = PRESTERA_PORT_FEC_OFF;
+ 
+ 	/* See sfp_select_interface... fIt */
+ 	switch (state->interface) {
+@@ -904,8 +916,8 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		port->sw = sw;
+ 		port->lag_id = sw->lag_max;
+ 
+-		err = mvsw_pr_hw_port_info_get(port, &port->fp_id,
+-					       &port->hw_id, &port->dev_id);
++		err = prestera_hw_port_info_get(port, &port->fp_id,
++						&port->hw_id, &port->dev_id);
+ 		if (err) {
+ 			dev_err(prestera_dev(sw),
+ 				"Failed to get port(%u) info\n", id);
+@@ -925,7 +937,7 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		net_dev->min_mtu = sw->mtu_min;
+ 		net_dev->max_mtu = sw->mtu_max;
+ 
+-		err = mvsw_pr_hw_port_mtu_set(port, net_dev->mtu);
++		err = prestera_hw_port_mtu_set(port, net_dev->mtu);
+ 		if (err) {
+ 			dev_err(prestera_dev(sw),
+ 				"Failed to set port(%u) mtu\n", id);
+@@ -943,14 +955,14 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		mac[net_dev->addr_len - 1] += port->fp_id +
+ 					      PRESTERA_MAC_ADDR_OFFSET;
+ 
+-		err = mvsw_pr_hw_port_mac_set(port, mac);
++		err = prestera_hw_port_mac_set(port, mac);
+ 		if (err) {
+ 			dev_err(prestera_dev(sw),
+ 				"Failed to set port(%u) mac addr\n", id);
+ 			goto err_mac_set;
+ 		}
+ 
+-		err = mvsw_pr_hw_port_cap_get(port, &port->caps);
++		err = prestera_hw_port_cap_get(port, &port->caps);
+ 		if (err) {
+ 			dev_err(prestera_dev(sw),
+ 				"Failed to get port(%u) caps\n", id);
+@@ -958,7 +970,7 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		}
+ 
+ #ifdef CONFIG_PHYLINK
+-		if (port->caps.transceiver != MVSW_PORT_TRANSCEIVER_SFP)
++		if (port->caps.transceiver != PRESTERA_PORT_TCVR_SFP)
+ 			netif_carrier_off(net_dev);
+ #else
+ 		netif_carrier_off(net_dev);
+@@ -970,7 +982,7 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		port->autoneg = true;
+ 
+ 		/* initialize config mac */
+-		if (port->caps.transceiver != MVSW_PORT_TRANSCEIVER_SFP) {
++		if (port->caps.transceiver != PRESTERA_PORT_TCVR_SFP) {
+ 			cfg_mac.admin = true;
+ 			cfg_mac.mode = PRESTERA_MAC_MODE_INTERNAL;
+ 		} else {
+@@ -980,7 +992,7 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		cfg_mac.inband = false;
+ 		cfg_mac.speed = 0;
+ 		cfg_mac.duplex = DUPLEX_UNKNOWN;
+-		cfg_mac.fec = MVSW_PORT_FEC_OFF_BIT;
++		cfg_mac.fec = PRESTERA_PORT_FEC_OFF;
+ 
+ 		err = prestera_port_cfg_mac_write(port, &cfg_mac);
+ 		if (err) {
+@@ -990,11 +1002,15 @@ static int __prestera_ports_alloc(struct prestera_switch *sw)
+ 		}
+ 
+ 		/* initialize config phy (if this is inegral) */
+-		if (port->caps.transceiver != MVSW_PORT_TRANSCEIVER_SFP) {
++		if (port->caps.transceiver != PRESTERA_PORT_TCVR_SFP) {
+ 			/* TODO: another parameters init */
++			port->cfg_phy.mdix = ETH_TP_MDI_AUTO;
+ 			port->cfg_phy.admin = false;
+-			err = mvsw_pr_hw_port_phy_mode_set(port, false, false,
+-							   0, 0);
++			err = prestera_hw_port_phy_mode_set(port,
++							    port->cfg_phy.admin,
++							    /* TODO: phy_cfg */
++							    false, 0, 0,
++							    port->cfg_phy.mdix);
+ 			if (err) {
+ 				dev_err(prestera_dev(sw),
+ 					"Failed to set port(%u) phy mode\n",
+@@ -1062,7 +1078,7 @@ static int __prestera_ports_register(struct prestera_switch *sw)
+ 	rtnl_unlock();
+ 
+ 	list_for_each_entry(port, &sw->port_list, list) {
+-		if (port->caps.transceiver == MVSW_PORT_TRANSCEIVER_SFP) {
++		if (port->caps.transceiver == PRESTERA_PORT_TCVR_SFP) {
+ 			err = prestera_port_sfp_bind(port);
+ 			if (err)
+ 				goto err_sfp_bind;
+@@ -1131,31 +1147,6 @@ static void prestera_port_vlan_flush(struct prestera_port *port,
+ 	}
+ }
+ 
+-int prestera_8021d_bridge_create(struct prestera_switch *sw, u16 *bridge_id)
+-{
+-	return mvsw_pr_hw_bridge_create(sw, bridge_id);
+-}
+-
+-int prestera_8021d_bridge_delete(struct prestera_switch *sw, u16 bridge_id)
+-{
+-	return mvsw_pr_hw_bridge_delete(sw, bridge_id);
+-}
+-
+-int prestera_8021d_bridge_port_add(struct prestera_port *port, u16 bridge_id)
+-{
+-	return mvsw_pr_hw_bridge_port_add(port, bridge_id);
+-}
+-
+-int prestera_8021d_bridge_port_delete(struct prestera_port *port, u16 bridge_id)
+-{
+-	return mvsw_pr_hw_bridge_port_delete(port, bridge_id);
+-}
+-
+-int prestera_switch_ageing_set(struct prestera_switch *sw, u32 ageing_time)
+-{
+-	return mvsw_pr_hw_switch_ageing_set(sw, ageing_time / 1000);
+-}
+-
+ struct prestera_port *prestera_port_find_by_fp_id(u32 fp_id)
+ {
+ 	struct prestera_port *port = NULL;
+@@ -1175,17 +1166,17 @@ int prestera_dev_if_type(const struct net_device *dev)
+ 	struct macvlan_dev *vlan;
+ 
+ 	if (is_vlan_dev(dev) && netif_is_bridge_master(vlan_dev_real_dev(dev)))
+-		return MVSW_IF_VID_E;
++		return PRESTERA_IF_VID_E;
+ 	else if (netif_is_bridge_master(dev))
+-		return MVSW_IF_VID_E;
++		return PRESTERA_IF_VID_E;
+ 	else if (netif_is_lag_master(dev))
+-		return MVSW_IF_LAG_E;
++		return PRESTERA_IF_LAG_E;
+ 	else if (netif_is_macvlan(dev)) {
+ 		vlan = netdev_priv(dev);
+ 		return prestera_dev_if_type(vlan->lowerdev);
+ 	}
+ 	else
+-		return MVSW_IF_PORT_E;
++		return PRESTERA_IF_PORT_E;
+ }
+ 
+ int prestera_lpm_add(struct prestera_switch *sw, u16 hw_vr_id,
+@@ -1198,8 +1189,8 @@ int prestera_lpm_add(struct prestera_switch *sw, u16 hw_vr_id,
+ 		return -ENOENT;
+ 
+ 	/* TODO: ipv6 key type check before call designated hw cb */
+-	return mvsw_pr_hw_lpm_add(sw, hw_vr_id, addr->u.ipv4,
+-				  prefix_len, grp_id);
++	return prestera_hw_lpm_add(sw, hw_vr_id, addr->u.ipv4,
++				   prefix_len, grp_id);
+ }
+ 
+ int prestera_lpm_del(struct prestera_switch *sw, u16 hw_vr_id,
+@@ -1212,8 +1203,8 @@ int prestera_lpm_del(struct prestera_switch *sw, u16 hw_vr_id,
+ 		return -ENOENT;
+ 
+ 	/* TODO: ipv6 key type check before call designated hw cb */
+-	return mvsw_pr_hw_lpm_del(sw, hw_vr_id, addr->u.ipv4,
+-				  prefix_len);
++	return prestera_hw_lpm_del(sw, hw_vr_id, addr->u.ipv4,
++				   prefix_len);
+ }
+ 
+ int prestera_nh_entries_set(const struct prestera_switch *sw, int count,
+@@ -1225,7 +1216,7 @@ int prestera_nh_entries_set(const struct prestera_switch *sw, int count,
+ 	if (sw->router->aborted)
+ 		return -ENOENT;
+ 
+-	return mvsw_pr_hw_nh_entries_set(sw, count, nhs, grp_id);
++	return prestera_hw_nh_entries_set(sw, count, nhs, grp_id);
+ }
+ 
+ int prestera_nh_entries_get(const struct prestera_switch *sw, int count,
+@@ -1237,7 +1228,7 @@ int prestera_nh_entries_get(const struct prestera_switch *sw, int count,
+ 	if (sw->router->aborted)
+ 		return -ENOENT;
+ 
+-	return mvsw_pr_hw_nh_entries_get(sw, count, nhs, grp_id);
++	return prestera_hw_nh_entries_get(sw, count, nhs, grp_id);
+ }
+ 
+ int prestera_nhgrp_blk_get(const struct prestera_switch *sw, u8 *hw_state,
+@@ -1249,7 +1240,7 @@ int prestera_nhgrp_blk_get(const struct prestera_switch *sw, u8 *hw_state,
+ 	if (sw->router->aborted)
+ 		return -ENOENT;
+ 
+-	return mvsw_pr_hw_nhgrp_blk_get(sw, hw_state, buf_size);
++	return prestera_hw_nhgrp_blk_get(sw, hw_state, buf_size);
+ }
+ 
+ int prestera_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
+@@ -1261,7 +1252,7 @@ int prestera_nh_group_create(const struct prestera_switch *sw, u16 nh_count,
+ 	if (sw->router->aborted)
+ 		return -ENOENT;
+ 
+-	return mvsw_pr_hw_nh_group_create(sw, nh_count, grp_id);
++	return prestera_hw_nh_group_create(sw, nh_count, grp_id);
+ }
+ 
+ int prestera_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
+@@ -1273,49 +1264,12 @@ int prestera_nh_group_delete(const struct prestera_switch *sw, u16 nh_count,
+ 	if (sw->router->aborted)
+ 		return -ENOENT;
+ 
+-	return mvsw_pr_hw_nh_group_delete(sw, nh_count, grp_id);
++	return prestera_hw_nh_group_delete(sw, nh_count, grp_id);
+ }
+ 
+ int prestera_mp4_hash_set(const struct prestera_switch *sw, u8 hash_policy)
+ {
+-	return mvsw_pr_hw_mp4_hash_set(sw, hash_policy);
+-}
+-
+-int prestera_fdb_flush_vlan(struct prestera_switch *sw, u16 vid,
+-			    enum prestera_fdb_flush_mode mode)
+-{
+-	return mvsw_pr_hw_fdb_flush_vlan(sw, vid, mode);
+-}
+-
+-int prestera_fdb_flush_port_vlan(struct prestera_port *port, u16 vid,
+-				 enum prestera_fdb_flush_mode mode)
+-{
+-	if (prestera_port_is_lag_member(port))
+-		return mvsw_pr_hw_fdb_flush_lag_vlan(port->sw, port->lag_id,
+-						     vid, mode);
+-	else
+-		return mvsw_pr_hw_fdb_flush_port_vlan(port, vid, mode);
+-}
+-
+-int prestera_fdb_flush_port(struct prestera_port *port,
+-			    enum prestera_fdb_flush_mode mode)
+-{
+-	if (prestera_port_is_lag_member(port))
+-		return mvsw_pr_hw_fdb_flush_lag(port->sw, port->lag_id, mode);
+-	else
+-		return mvsw_pr_hw_fdb_flush_port(port, mode);
+-}
+-
+-int prestera_macvlan_add(const struct prestera_switch *sw, u16 vr_id,
+-			 const u8 *mac, u16 vid)
+-{
+-	return mvsw_pr_hw_macvlan_add(sw, vr_id, mac,  vid);
+-}
+-
+-int prestera_macvlan_del(const struct prestera_switch *sw, u16 vr_id,
+-			 const u8 *mac, u16 vid)
+-{
+-	return mvsw_pr_hw_macvlan_del(sw, vr_id, mac,  vid);
++	return prestera_hw_mp4_hash_set(sw, hash_policy);
+ }
+ 
+ struct prestera_lag *prestera_lag_get(struct prestera_switch *sw, u8 id)
+@@ -1355,7 +1309,7 @@ int prestera_lag_member_add(struct prestera_port *port,
+ 	if (!member)
+ 		return -ENOMEM;
+ 
+-	if (mvsw_pr_hw_lag_member_add(port, lag_id)) {
++	if (prestera_hw_lag_member_add(port, lag_id)) {
+ 		kfree(member);
+ 		if (!lag->member_count)
+ 			prestera_port_lag_destroy(sw, lag_id);
+@@ -1382,7 +1336,7 @@ int prestera_lag_member_del(struct prestera_port *port)
+ 	if (!lag || !lag->member_count)
+ 		return -EINVAL;
+ 
+-	err = mvsw_pr_hw_lag_member_del(port, lag_id);
++	err = prestera_hw_lag_member_del(port, lag_id);
+ 	if (err)
+ 		return err;
+ 
+@@ -1408,7 +1362,7 @@ int prestera_lag_member_del(struct prestera_port *port)
+ 
+ int prestera_lag_member_enable(struct prestera_port *port, bool enable)
+ {
+-	return mvsw_pr_hw_lag_member_enable(port, port->lag_id, enable);
++	return prestera_hw_lag_member_enable(port, port->lag_id, enable);
+ }
+ 
+ bool prestera_port_is_lag_member(const struct prestera_port *port)
+@@ -1443,7 +1397,7 @@ int prestera_lag_id_find(struct prestera_switch *sw, struct net_device *lag_dev,
+ void prestera_lag_member_rif_leave(const struct prestera_port *port,
+ 				   u16 lag_id, u16 vr_id)
+ {
+-	mvsw_pr_hw_lag_member_rif_leave(port, lag_id, vr_id);
++	prestera_hw_lag_member_rif_leave(port, lag_id, vr_id);
+ }
+ 
+ static int prestera_lag_init(struct prestera_switch *sw)
+@@ -1654,9 +1608,9 @@ static void prestera_port_handle_event(struct prestera_switch *sw,
+ 	prestera_ethtool_port_state_changed(port, &evt->port_evt);
+ 
+ 	switch (evt->id) {
+-	case MVSW_PORT_EVENT_STATE_CHANGED:
++	case PRESTERA_PORT_EVENT_MAC_STATE_CHANGED:
+ 
+-		if (port->link_params.oper_state) {
++		if (port->state_mac.oper) {
+ #ifdef CONFIG_PHYLINK
+ 			if (port->phy_link)
+ 				phylink_mac_change(port->phy_link, true);
+@@ -1700,12 +1654,12 @@ static void prestera_fdb_handle_event(struct prestera_switch *sw,
+ 	u16 lag_id;
+ 
+ 	switch (evt->fdb_evt.type) {
+-	case MVSW_PR_FDB_ENTRY_TYPE_REG_PORT:
++	case PRESTERA_FDB_ENTRY_TYPE_REG_PORT:
+ 		port = __find_pr_port(sw, evt->fdb_evt.dest.port_id);
+ 		if (port)
+ 			dev = port->net_dev;
+ 		break;
+-	case MVSW_PR_FDB_ENTRY_TYPE_LAG:
++	case PRESTERA_FDB_ENTRY_TYPE_LAG:
+ 		lag_id = evt->fdb_evt.dest.lag_id;
+ 		if (prestera_lag_exists(sw, lag_id))
+ 			dev = sw->lags[lag_id].dev;
+@@ -1723,11 +1677,11 @@ static void prestera_fdb_handle_event(struct prestera_switch *sw,
+ 
+ 	rtnl_lock();
+ 	switch (evt->id) {
+-	case MVSW_FDB_EVENT_LEARNED:
++	case PRESTERA_FDB_EVENT_LEARNED:
+ 		call_switchdev_notifiers(SWITCHDEV_FDB_ADD_TO_BRIDGE,
+ 					 dev, &info.info, NULL);
+ 		break;
+-	case MVSW_FDB_EVENT_AGED:
++	case PRESTERA_FDB_EVENT_AGED:
+ 		call_switchdev_notifiers(SWITCHDEV_FDB_DEL_TO_BRIDGE,
+ 					 dev, &info.info, NULL);
+ 		break;
+@@ -1735,34 +1689,14 @@ static void prestera_fdb_handle_event(struct prestera_switch *sw,
+ 	rtnl_unlock();
+ }
+ 
+-int prestera_fdb_add(struct prestera_port *port, const unsigned char *mac,
+-		     u16 vid, bool dynamic)
+-{
+-	if (prestera_port_is_lag_member(port))
+-		return mvsw_pr_hw_lag_fdb_add(port->sw, port->lag_id,
+-					      mac, vid, dynamic);
+-	else
+-		return mvsw_pr_hw_fdb_add(port, mac, vid, dynamic);
+-}
+-
+-int prestera_fdb_del(struct prestera_port *port, const unsigned char *mac,
+-		     u16 vid)
+-{
+-	if (prestera_port_is_lag_member(port))
+-		return mvsw_pr_hw_lag_fdb_del(port->sw, port->lag_id,
+-					      mac, vid);
+-	else
+-		return mvsw_pr_hw_fdb_del(port, mac, vid);
+-}
+-
+ static void prestera_fdb_event_handler_unregister(struct prestera_switch *sw)
+ {
+-	mvsw_pr_hw_event_handler_unregister(sw, MVSW_EVENT_TYPE_FDB);
++	prestera_hw_event_handler_unregister(sw, PRESTERA_EVENT_TYPE_FDB);
+ }
+ 
+ static void prestera_port_event_handler_unregister(struct prestera_switch *sw)
+ {
+-	mvsw_pr_hw_event_handler_unregister(sw, MVSW_EVENT_TYPE_PORT);
++	prestera_hw_event_handler_unregister(sw, PRESTERA_EVENT_TYPE_PORT);
+ }
+ 
+ static void prestera_event_handlers_unregister(struct prestera_switch *sw)
+@@ -1773,16 +1707,16 @@ static void prestera_event_handlers_unregister(struct prestera_switch *sw)
+ 
+ static int prestera_fdb_event_handler_register(struct prestera_switch *sw)
+ {
+-	return mvsw_pr_hw_event_handler_register(sw, MVSW_EVENT_TYPE_FDB,
+-						 prestera_fdb_handle_event,
+-						 NULL);
++	return prestera_hw_event_handler_register(sw, PRESTERA_EVENT_TYPE_FDB,
++						  prestera_fdb_handle_event,
++						  NULL);
+ }
+ 
+ static int prestera_port_event_handler_register(struct prestera_switch *sw)
+ {
+-	return mvsw_pr_hw_event_handler_register(sw, MVSW_EVENT_TYPE_PORT,
+-						 prestera_port_handle_event,
+-						 NULL);
++	return prestera_hw_event_handler_register(sw, PRESTERA_EVENT_TYPE_PORT,
++						  prestera_port_handle_event,
++						  NULL);
+ }
+ 
+ static int prestera_event_handlers_register(struct prestera_switch *sw)
+@@ -1843,26 +1777,377 @@ static int prestera_sw_init_base_mac(struct prestera_switch *sw)
+ 	if (lsb + sw->port_count + PRESTERA_MAC_ADDR_OFFSET > 0xFF)
+ 		sw->base_mac[ETH_ALEN - 1] = 0;
+ 
+-	err = mvsw_pr_hw_switch_mac_set(sw, sw->base_mac);
++	err = prestera_hw_switch_mac_set(sw, sw->base_mac);
+ 	if (err)
+ 		return err;
+ 
+ 	return 0;
+ }
+ 
++static bool prestera_is_vrf_event(unsigned long event, void *ptr)
++{
++	struct netdev_notifier_changeupper_info *info = ptr;
++
++	if (event != NETDEV_PRECHANGEUPPER && event != NETDEV_CHANGEUPPER)
++		return false;
++
++	return netif_is_l3_master(info->upper_dev);
++}
++
++static bool
++prestera_lag_master_check(struct prestera_switch *sw,
++			  struct net_device *lag_dev,
++			  struct netdev_lag_upper_info *upper_info,
++			  struct netlink_ext_ack *ext_ack)
++{
++	u16 lag_id;
++
++	if (prestera_lag_id_find(sw, lag_dev, &lag_id)) {
++		NL_SET_ERR_MSG_MOD(ext_ack,
++				   "Exceeded max supported LAG devices");
++		return false;
++	}
++	if (upper_info->tx_type != NETDEV_LAG_TX_TYPE_HASH) {
++		NL_SET_ERR_MSG_MOD(ext_ack, "Unsupported LAG Tx type");
++		return false;
++	}
++	return true;
++}
++
++static void prestera_port_lag_clean(struct prestera_port *port,
++				    struct net_device *lag_dev)
++{
++	struct net_device *br_dev = netdev_master_upper_dev_get(lag_dev);
++	struct prestera_port_vlan *port_vlan, *tmp;
++	struct net_device *upper_dev;
++	struct list_head *iter;
++
++	list_for_each_entry_safe(port_vlan, tmp, &port->vlans_list, list) {
++		prestera_port_vlan_bridge_leave(port_vlan);
++		prestera_port_vlan_destroy(port_vlan);
++	}
++
++	if (netif_is_bridge_port(lag_dev))
++		prestera_port_bridge_leave(port, lag_dev, br_dev);
++
++	netdev_for_each_upper_dev_rcu(lag_dev, upper_dev, iter) {
++		if (!netif_is_bridge_port(upper_dev))
++			continue;
++		br_dev = netdev_master_upper_dev_get(upper_dev);
++		prestera_port_bridge_leave(port, upper_dev, br_dev);
++	}
++
++	prestera_port_pvid_set(port, PRESTERA_DEFAULT_VID);
++}
++
++static int prestera_port_lag_join(struct prestera_port *port,
++				  struct net_device *lag_dev)
++{
++	u16 lag_id;
++	int err;
++
++	err = prestera_lag_id_find(port->sw, lag_dev, &lag_id);
++	if (err)
++		return err;
++
++	err = prestera_lag_member_add(port, lag_dev, lag_id);
++		return err;
++
++	/* TODO: Port should no be longer usable as a router interface */
++
++	return 0;
++}
++
++static void prestera_port_lag_leave(struct prestera_port *port,
++				    struct net_device *lag_dev)
++{
++	prestera_router_lag_member_leave(port, lag_dev);
++
++	if (prestera_lag_member_del(port))
++		return;
++
++	prestera_port_lag_clean(port, lag_dev);
++}
++
++static int prestera_netdevice_port_upper_event(struct net_device *lower_dev,
++					       struct net_device *dev,
++					       unsigned long event, void *ptr)
++{
++	struct netdev_notifier_changeupper_info *info;
++	struct prestera_port *port;
++	struct netlink_ext_ack *extack;
++	struct net_device *upper_dev;
++	struct prestera_switch *sw;
++	int err = 0;
++
++	port = netdev_priv(dev);
++	sw = port->sw;
++	info = ptr;
++	extack = netdev_notifier_info_to_extack(&info->info);
++
++	switch (event) {
++	case NETDEV_PRECHANGEUPPER:
++		upper_dev = info->upper_dev;
++		if (!netif_is_bridge_master(upper_dev) &&
++		    !netif_is_lag_master(upper_dev) &&
++		    !netif_is_macvlan(upper_dev)) {
++			NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
++			return -EINVAL;
++		}
++		if (!info->linking)
++			break;
++		if (netdev_has_any_upper_dev(upper_dev) &&
++		    (!netif_is_bridge_master(upper_dev) ||
++		     !prestera_bridge_is_offloaded(sw, upper_dev))) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "Enslaving a port to a device that already has an upper device is not supported");
++			return -EINVAL;
++		}
++		if (netif_is_lag_master(upper_dev) &&
++		    !prestera_lag_master_check(sw, upper_dev,
++					      info->upper_info, extack))
++			return -EINVAL;
++		if (netif_is_lag_master(upper_dev) && vlan_uses_dev(dev)) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "Master device is a LAG master and port has a VLAN");
++			return -EINVAL;
++		}
++		if (netif_is_lag_port(dev) && is_vlan_dev(upper_dev) &&
++		    !netif_is_lag_master(vlan_dev_real_dev(upper_dev))) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "Can not put a VLAN on a LAG port");
++			return -EINVAL;
++		}
++		if (netif_is_macvlan(upper_dev) &&
++		    !prestera_rif_exists(sw, lower_dev)) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "macvlan is only supported on top of router interfaces");
++			return -EOPNOTSUPP;
++		}
++		break;
++	case NETDEV_CHANGEUPPER:
++		upper_dev = info->upper_dev;
++		if (netif_is_bridge_master(upper_dev)) {
++			if (info->linking)
++				err = prestera_port_bridge_join(port,
++								lower_dev,
++								upper_dev,
++								extack);
++			else
++				prestera_port_bridge_leave(port,
++							   lower_dev,
++							   upper_dev);
++		} else if (netif_is_lag_master(upper_dev)) {
++			if (info->linking)
++				err = prestera_port_lag_join(port, upper_dev);
++			else
++				prestera_port_lag_leave(port, upper_dev);
++		}
++		break;
++	}
++
++	return err;
++}
++
++static int prestera_netdevice_port_lower_event(struct net_device *dev,
++					       unsigned long event, void *ptr)
++{
++	struct netdev_notifier_changelowerstate_info *info = ptr;
++	struct netdev_lag_lower_state_info *lower_state_info;
++	struct prestera_port *port = netdev_priv(dev);
++	bool enabled;
++
++	if (event != NETDEV_CHANGELOWERSTATE)
++		return 0;
++	if (!netif_is_lag_port(dev))
++		return 0;
++	if (!prestera_port_is_lag_member(port))
++		return 0;
++
++	lower_state_info = info->lower_state_info;
++	enabled = lower_state_info->tx_enabled;
++	return prestera_lag_member_enable(port, enabled);
++}
++
++static int prestera_netdevice_port_event(struct net_device *lower_dev,
++					 struct net_device *port_dev,
++					 unsigned long event, void *ptr)
++{
++	switch (event) {
++	case NETDEV_PRECHANGEUPPER:
++	case NETDEV_CHANGEUPPER:
++		return prestera_netdevice_port_upper_event(lower_dev, port_dev,
++							   event, ptr);
++	case NETDEV_CHANGELOWERSTATE:
++		return prestera_netdevice_port_lower_event(port_dev,
++							   event, ptr);
++	}
++
++	return 0;
++}
++
++static int prestera_netdevice_bridge_event(struct net_device *br_dev,
++					   unsigned long event, void *ptr)
++{
++	struct prestera_switch *sw = prestera_switch_get(br_dev);
++	struct netdev_notifier_changeupper_info *info = ptr;
++	struct netlink_ext_ack *extack;
++	struct net_device *upper_dev;
++
++	if (!sw)
++		return 0;
++
++	extack = netdev_notifier_info_to_extack(&info->info);
++
++	switch (event) {
++	case NETDEV_PRECHANGEUPPER:
++		upper_dev = info->upper_dev;
++		if (!is_vlan_dev(upper_dev) && !netif_is_macvlan(upper_dev)) {
++			NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
++			return -EOPNOTSUPP;
++		}
++		if (!info->linking)
++			break;
++		if (netif_is_macvlan(upper_dev) &&
++		    !prestera_rif_exists(sw, br_dev)) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "macvlan is only supported on top of router interfaces");
++			return -EOPNOTSUPP;
++		}
++		break;
++	case NETDEV_CHANGEUPPER:
++		/* TODO:  */
++		break;
++	}
++
++	return 0;
++}
++
++static int prestera_netdevice_lag_event(struct net_device *lag_dev,
++					unsigned long event, void *ptr)
++{
++	struct net_device *dev;
++	struct list_head *iter;
++	int err;
++
++	netdev_for_each_lower_dev(lag_dev, dev, iter) {
++		if (prestera_netdev_check(dev)) {
++			err = prestera_netdevice_port_event(lag_dev, dev, event,
++							    ptr);
++			if (err)
++				return err;
++		}
++	}
++
++	return 0;
++}
++
++static int prestera_netdevice_vlan_event(struct net_device *vlan_dev,
++					 unsigned long event, void *ptr)
++{
++	struct net_device *real_dev = vlan_dev_real_dev(vlan_dev);
++	struct prestera_switch *sw = prestera_switch_get(real_dev);
++	struct netdev_notifier_changeupper_info *info = ptr;
++	struct netlink_ext_ack *extack;
++	struct net_device *upper_dev;
++
++	if (!sw)
++		return 0;
++
++	extack = netdev_notifier_info_to_extack(&info->info);
++
++	switch (event) {
++	case NETDEV_PRECHANGEUPPER:
++		upper_dev = info->upper_dev;
++
++		if (!info->linking)
++			break;
++
++		if (prestera_bridge_is_offloaded(sw, real_dev) &&
++		    netif_is_bridge_master(upper_dev)) {
++			NL_SET_ERR_MSG_MOD(extack,
++					   "Enslaving offloaded bridge to a bridge is not supported");
++			return -EOPNOTSUPP;
++		}
++		break;
++	case NETDEV_CHANGEUPPER:
++		/* empty */
++		break;
++	}
++
++	return 0;
++}
++
++static int prestera_netdevice_macvlan_event(struct net_device *macvlan_dev,
++					    unsigned long event, void *ptr)
++{
++	struct prestera_switch *sw = prestera_switch_get(macvlan_dev);
++	struct netdev_notifier_changeupper_info *info = ptr;
++	struct netlink_ext_ack *extack;
++
++	if (!sw || event != NETDEV_PRECHANGEUPPER)
++		return 0;
++
++	extack = netdev_notifier_info_to_extack(&info->info);
++
++	NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
++
++	return -EOPNOTSUPP;
++}
++
++static int prestera_netdev_event_handler(struct notifier_block *nb,
++					 unsigned long event, void *ptr)
++{
++	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
++	struct prestera_switch *sw;
++	int err = 0;
++
++	sw = container_of(nb, struct prestera_switch, netdev_nb);
++
++	if (event == NETDEV_PRE_CHANGEADDR ||
++	    event == NETDEV_CHANGEADDR)
++		err = prestera_netdevice_router_port_event(dev, event, ptr);
++	else if (prestera_is_vrf_event(event, ptr))
++		err = prestera_netdevice_vrf_event(dev, event, ptr);
++	else if (prestera_netdev_check(dev))
++		err = prestera_netdevice_port_event(dev, dev, event, ptr);
++	else if (netif_is_bridge_master(dev))
++		err = prestera_netdevice_bridge_event(dev, event, ptr);
++	else if (netif_is_lag_master(dev))
++		err = prestera_netdevice_lag_event(dev, event, ptr);
++	else if (is_vlan_dev(dev))
++		err = prestera_netdevice_vlan_event(dev, event, ptr);
++	else if (netif_is_macvlan(dev))
++		err = prestera_netdevice_macvlan_event(dev, event, ptr);
++
++	return notifier_from_errno(err);
++}
++
++static int prestera_netdev_event_handler_register(struct prestera_switch *sw)
++{
++	sw->netdev_nb.notifier_call = prestera_netdev_event_handler;
++
++	return register_netdevice_notifier(&sw->netdev_nb);
++}
++
++static void prestera_netdev_event_handler_unregister(struct prestera_switch *sw)
++{
++	unregister_netdevice_notifier(&sw->netdev_nb);
++}
++
+ static int prestera_init(struct prestera_switch *sw)
+ {
+ 	int err;
+ 
+ 	sw->np = of_find_compatible_node(NULL, NULL, "marvell,prestera");
+ 
+-	err = mvsw_pr_hw_switch_init(sw);
++	err = prestera_hw_switch_init(sw);
+ 	if (err) {
+ 		dev_err(prestera_dev(sw), "Failed to init Switch device\n");
+ 		return err;
+ 	}
+ 
+-	err = mvsw_pr_hw_switch_trap_policer_set(sw, trap_policer_profile);
++	err = prestera_hw_switch_trap_policer_set(sw, trap_policer_profile);
+ 	if (err) {
+ 		dev_err(prestera_dev(sw),
+ 			"Failed to set trap policer profile\n");
+@@ -1877,11 +2162,15 @@ static int prestera_init(struct prestera_switch *sw)
+ 
+ 	err = prestera_lag_init(sw);
+ 	if (err)
+-		return err;
++		goto err_lag_init;
+ 
+-	err = prestera_switchdev_register(sw);
++	err = prestera_router_init(sw);
+ 	if (err)
+-		return err;
++		goto err_router_init;
++
++	err = prestera_switchdev_init(sw);
++	if (err)
++		goto err_swdev_reg;
+ 
+ 	err = prestera_devlink_register(sw);
+ 	if (err)
+@@ -1901,6 +2190,10 @@ static int prestera_init(struct prestera_switch *sw)
+ 
+ 	INIT_LIST_HEAD(&sw->port_list);
+ 
++	err = prestera_netdev_event_handler_register(sw);
++	if (err)
++		goto err_netdev_reg;
++
+ 	err = prestera_ports_create(sw);
+ 	if (err)
+ 		goto err_ports_init;
+@@ -1927,6 +2220,7 @@ static int prestera_init(struct prestera_switch *sw)
+ 	prestera_clear_ports(sw);
+ err_ports_init:
+ 	prestera_span_fini(sw);
++err_netdev_reg:
+ err_span_init:
+ 	prestera_acl_fini(sw);
+ err_acl_init:
+@@ -1934,25 +2228,32 @@ static int prestera_init(struct prestera_switch *sw)
+ err_counter_init:
+ 	prestera_devlink_unregister(sw);
+ err_devl_reg:
+-	prestera_switchdev_unregister(sw);
++	prestera_switchdev_fini(sw);
++err_swdev_reg:
++	prestera_router_fini(sw);
++err_router_init:
++err_lag_init:
++	prestera_netdev_event_handler_unregister(sw);
++
+ 	return err;
+ }
+ 
+ static void prestera_fini(struct prestera_switch *sw)
+ {
+ 	prestera_debugfs_fini(sw);
+-
+ 	prestera_event_handlers_unregister(sw);
+-
+-	prestera_clear_ports(sw);
+ 	prestera_rxtx_switch_fini(sw);
+-	prestera_devlink_unregister(sw);
+-	prestera_switchdev_unregister(sw);
++	prestera_clear_ports(sw);
++	prestera_netdev_event_handler_unregister(sw);
+ 	prestera_span_fini(sw);
+ 	prestera_acl_fini(sw);
+ 	prestera_counter_fini(sw);
++	prestera_devlink_unregister(sw);
++	prestera_switchdev_fini(sw);
++	prestera_router_fini(sw);
+ 	prestera_lag_fini(sw);
+-	mvsw_pr_hw_keepalive_fini(sw);
++
++	prestera_hw_keepalive_fini(sw);
+ 	prestera_hw_switch_reset(sw);
+ 	of_node_put(sw->np);
+ }
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_pci.c b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+index 22cb0f5..a050f79 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_pci.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_pci.c
+@@ -14,8 +14,8 @@
+ #define PRESTERA_FW_ARM64_PATH		"marvell/mvsw_prestera_fw_arm64.img"
+ 
+ #define PRESTERA_SUPP_FW_MAJ_VER	3
+-#define PRESTERA_SUPP_FW_MIN_VER	0
+-#define PRESTERA_SUPP_FW_PATCH_VER	1
++#define PRESTERA_SUPP_FW_MIN_VER	1
++#define PRESTERA_SUPP_FW_PATCH_VER	0
+ 
+ #define prestera_wait(cond, waitms) \
+ ({ \
+@@ -248,6 +248,9 @@ struct prestera_fw {
+ #define PRESTERA_DEV_ID_ALDRIN2		0xCC1E
+ #define PRESTERA_DEV_ID_ALDRIN3S	0x981F
+ #define PRESTERA_DEV_ID_98DX3500	0x9820
++#define PRESTERA_DEV_ID_98DX3501	0x9826
++#define PRESTERA_DEV_ID_98DX3510	0x9821
++#define PRESTERA_DEV_ID_98DX3520	0x9822
+ 
+ static struct prestera_pci_match {
+ 	struct pci_driver driver;
+@@ -274,6 +277,18 @@ static struct prestera_pci_match {
+ 		.driver = { .name = "AC5X 98DX3500", },
+ 		.id = { PRESTERA_DEVICE(PRESTERA_DEV_ID_98DX3500), 0 },
+ 	},
++	{
++		.driver = { .name = "AC5X 98DX3501", },
++		.id = { PRESTERA_DEVICE(PRESTERA_DEV_ID_98DX3501), 0 },
++	},
++	{
++		.driver = { .name = "AC5X 98DX3510", },
++		.id = { PRESTERA_DEVICE(PRESTERA_DEV_ID_98DX3510), 0 },
++	},
++	{
++		.driver = { .name = "AC5X 98DX3520", },
++		.id = { PRESTERA_DEVICE(PRESTERA_DEV_ID_98DX3520), 0 },
++	},
+ 	{{ }, }
+ };
+ 
+@@ -755,6 +770,9 @@ static const char *prestera_fw_path_get(struct prestera_fw *fw)
+ {
+ 	switch (fw->pci_dev->device) {
+ 	case PRESTERA_DEV_ID_98DX3500:
++	case PRESTERA_DEV_ID_98DX3501:
++	case PRESTERA_DEV_ID_98DX3510:
++	case PRESTERA_DEV_ID_98DX3520:
+ 		return PRESTERA_FW_ARM64_PATH;
+ 
+ 	default:
+@@ -821,6 +839,9 @@ static bool prestera_pci_pp_use_bar2(struct pci_dev *pdev)
+ 	switch (pdev->device) {
+ 	case PRESTERA_DEV_ID_ALDRIN3S:
+ 	case PRESTERA_DEV_ID_98DX3500:
++	case PRESTERA_DEV_ID_98DX3501:
++	case PRESTERA_DEV_ID_98DX3510:
++	case PRESTERA_DEV_ID_98DX3520:
+ 		return true;
+ 
+ 	default:
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_router.c b/drivers/net/ethernet/marvell/prestera/prestera_router.c
+index e4f6484..7bbbaa8 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_router.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_router.c
+@@ -19,27 +19,23 @@
+ 
+ #include "prestera.h"
+ #include "prestera_ct.h"
+-#include "prestera_acl.h"
+ #include "prestera_hw.h"
+ #include "prestera_log.h"
++#include "prestera_router_hw.h"
+ 
+ #define MVSW_PR_IMPLICITY_RESOLVE_DEAD_NEIGH
+ #define MVSW_PR_NH_PROBE_INTERVAL 5000 /* ms */
+-#define MVSW_PR_NHGR_UNUSED (0)
+-#define MVSW_PR_NHGR_DROP (0xFFFFFFFF)
+ 
+ static const char mvsw_driver_name[] = "mrvl_switchdev";
+ 
++/* Represent kernel object */
+ struct prestera_rif {
+-	struct prestera_iface iface;
+ 	struct net_device *dev;
+-	struct list_head router_node;
++	struct prestera_rif_entry_key rif_entry_key; /* Key to hw object */
+ 	unsigned char addr[ETH_ALEN];
+-	unsigned int mtu;
++	u32 kern_tb_id; /* tb_id from kernel (not fixed) */
++	struct list_head router_node;
+ 	bool is_active;
+-	u16 rif_id;
+-	struct mvsw_pr_vr *vr;
+-	struct prestera_switch *sw;
+ 	unsigned int ref_cnt;
+ };
+ 
+@@ -48,36 +44,10 @@ struct mvsw_pr_rif_params {
+ 	u16 vid;
+ };
+ 
+-struct mvsw_pr_fib_node {
+-	struct rhash_head ht_node; /* node of mvsw_pr_vr */
+-	struct prestera_fib_key key;
+-	struct prestera_fib_info info; /* action related info */
+-};
+-
+-struct mvsw_pr_vr {
+-	u16 hw_vr_id;			/* virtual router ID */
+-	u32 tb_id;			/* key (kernel fib table id) */
+-	struct list_head router_node;
+-	unsigned int ref_cnt;
+-};
+-
+-struct mvsw_pr_nexthop_group {
+-	struct prestera_nexthop_group_key key;
+-	/* Store intermediate object here.
+-	 * This prevent overhead kzalloc call.
+-	 */
+-	/* nh_neigh is used only to notify nexthop_group */
+-	struct mvsw_pr_nh_neigh_head {
+-		struct mvsw_pr_nexthop_group *this;
+-		struct list_head head;
+-		/* ptr to neigh is not necessary.
+-		 * It used to prevent lookup of nh_neigh by key (n) on destroy
+-		 */
+-		struct prestera_nh_neigh *neigh;
+-	} nh_neigh_head[PRESTERA_NHGR_SIZE_MAX];
+-	u32 grp_id; /* hw */
+-	struct rhash_head ht_node; /* node of mvsw_pr_vr */
+-	unsigned int ref_cnt;
++struct prestera_fib {
++	struct prestera_switch *sw;
++	struct notifier_block fib_nb;
++	struct notifier_block netevent_nb;
+ };
+ 
+ enum mvsw_pr_mp_hash_policy {
+@@ -86,8 +56,13 @@ enum mvsw_pr_mp_hash_policy {
+ 	MVSW_MP_HASH_POLICY_MAX,
+ };
+ 
++struct prestera_kern_neigh_cache_key {
++	struct prestera_ip_addr addr;
++	struct prestera_rif *rif;
++};
++
+ struct prestera_kern_neigh_cache {
+-	struct prestera_nh_neigh_key key;
++	struct prestera_kern_neigh_cache_key key;
+ 	struct rhash_head ht_node;
+ 	struct list_head kern_fib_cache_list;
+ 	/* Lock cache if neigh is present in kernel */
+@@ -109,7 +84,7 @@ struct mvsw_pr_kern_fib_cache {
+ 	struct mvsw_pr_kern_fib_cache_key key;
+ 	struct {
+ 		struct prestera_fib_key fib_key;
+-		enum mvsw_pr_fib_type fib_type;
++		enum prestera_fib_type fib_type;
+ 		struct prestera_nexthop_group_key nh_grp_key;
+ 	} lpm_info; /* hold prepared lpm info */
+ 	/* Indicate if route is not overlapped by another table */
+@@ -127,7 +102,7 @@ struct mvsw_pr_kern_fib_cache {
+ static const struct rhashtable_params __mvsw_pr_kern_neigh_cache_ht_params = {
+ 	.key_offset  = offsetof(struct prestera_kern_neigh_cache, key),
+ 	.head_offset = offsetof(struct prestera_kern_neigh_cache, ht_node),
+-	.key_len     = sizeof(struct prestera_nh_neigh_key),
++	.key_len     = sizeof(struct prestera_kern_neigh_cache_key),
+ 	.automatic_shrinking = true,
+ };
+ 
+@@ -138,25 +113,6 @@ static const struct rhashtable_params __mvsw_pr_kern_fib_cache_ht_params = {
+ 	.automatic_shrinking = true,
+ };
+ 
+-static const struct rhashtable_params __mvsw_pr_fib_ht_params = {
+-	.key_offset  = offsetof(struct mvsw_pr_fib_node, key),
+-	.head_offset = offsetof(struct mvsw_pr_fib_node, ht_node),
+-	.key_len     = sizeof(struct prestera_fib_key),
+-	.automatic_shrinking = true,
+-};
+-
+-static const struct rhashtable_params __mvsw_pr_nh_neigh_ht_params = {
+-	.key_offset  = offsetof(struct prestera_nh_neigh, key),
+-	.key_len     = sizeof(struct prestera_nh_neigh_key),
+-	.head_offset = offsetof(struct prestera_nh_neigh, ht_node),
+-};
+-
+-static const struct rhashtable_params __mvsw_pr_nexthop_group_ht_params = {
+-	.key_offset  = offsetof(struct mvsw_pr_nexthop_group, key),
+-	.key_len     = sizeof(struct prestera_nexthop_group_key),
+-	.head_offset = offsetof(struct mvsw_pr_nexthop_group, ht_node),
+-};
+-
+ static struct workqueue_struct *mvsw_r_wq;
+ static struct workqueue_struct *mvsw_r_owq;
+ 
+@@ -209,50 +165,25 @@ static const unsigned char mvsw_pr_mac_mask[ETH_ALEN] = {
+ 	0xff, 0xff, 0xff, 0xff, 0xfc, 0x00
+ };
+ 
+-static struct mvsw_pr_vr *mvsw_pr_vr_get(struct prestera_switch *sw, u32 tb_id,
+-					 struct netlink_ext_ack *extack);
+ static u32 mvsw_pr_fix_tb_id(u32 tb_id);
+-static void mvsw_pr_vr_put(struct prestera_switch *sw, struct mvsw_pr_vr *vr);
+-static void mvsw_pr_vr_util_hw_abort(struct prestera_switch *sw);
+-static struct prestera_rif *mvsw_pr_rif_create(struct prestera_switch *sw,
+-					       const struct mvsw_pr_rif_params
+-					       *params,
+-					       struct netlink_ext_ack *extack);
+-static int mvsw_pr_rif_vr_update(struct prestera_switch *sw,
+-				 struct prestera_rif *rif,
+-				 struct netlink_ext_ack *extack);
+-static void mvsw_pr_rif_destroy(struct prestera_rif *rif);
+-static void mvsw_pr_rif_put(struct prestera_rif *rif);
+-static int mvsw_pr_rif_update(struct prestera_rif *rif, char *mac);
++static struct prestera_rif *
++prestera_rif_create(struct prestera_switch *sw,
++		    const struct mvsw_pr_rif_params *params,
++		    struct netlink_ext_ack *extack);
++static void mvsw_pr_rif_destroy(struct prestera_switch *sw,
++				struct prestera_rif *rif);
++static void mvsw_pr_rif_put(struct prestera_switch *sw,
++			    struct prestera_rif *rif);
++static int mvsw_pr_rif_update(struct prestera_switch *sw,
++			      struct prestera_rif *rif);
+ static struct prestera_rif *mvsw_pr_rif_find(const struct prestera_switch *sw,
+ 					     const struct net_device *dev);
+-static u16 mvsw_pr_rif_vr_id(struct prestera_rif *rif);
+-static bool
+-mvsw_pr_nh_neigh_util_hw_state(struct prestera_switch *sw,
+-			       struct prestera_nh_neigh *nh_neigh);
+-static bool
+-mvsw_pr_nexthop_group_util_hw_state(struct prestera_switch *sw,
+-				    struct mvsw_pr_nexthop_group *nh_grp);
+-static int mvsw_pr_nh_neigh_set(struct prestera_switch *sw,
+-				struct prestera_nh_neigh *neigh);
+-static int mvsw_pr_nexthop_group_set(struct prestera_switch *sw,
+-				     struct mvsw_pr_nexthop_group *nh_grp);
+-static struct mvsw_pr_fib_node *
+-mvsw_pr_fib_node_find(struct prestera_switch *sw, struct prestera_fib_key *key);
+-static void mvsw_pr_fib_node_destroy(struct prestera_switch *sw,
+-				     struct mvsw_pr_fib_node *fib_node);
+-static struct mvsw_pr_fib_node *
+-mvsw_pr_fib_node_create(struct prestera_switch *sw,
+-			struct prestera_fib_key *key,
+-			enum mvsw_pr_fib_type fib_type,
+-			struct prestera_nexthop_group_key *nh_grp_key);
+ static bool mvsw_pr_fi_is_direct(struct fib_info *fi);
+ static bool mvsw_pr_fi_is_hw_direct(struct prestera_switch *sw,
+ 				    struct fib_info *fi);
+ static bool mvsw_pr_fi_is_nh(struct fib_info *fi);
+-static bool mvsw_pr_nh_neigh_key_is_valid(struct prestera_nh_neigh_key *key);
+ static bool
+-mvsw_pr_fib_node_util_is_neighbour(struct mvsw_pr_fib_node *fib_node);
++mvsw_pr_fib_node_util_is_neighbour(struct prestera_fib_node *fib_node);
+ static int
+ mvsw_pr_util_fi2nh_gr_key(struct prestera_switch *sw, struct fib_info *fi,
+ 			  size_t limit,
+@@ -270,7 +201,7 @@ static u16 mvsw_pr_nh_dev_to_vid(struct prestera_switch *sw,
+ 	} else if (netif_is_bridge_master(dev) && br_vlan_enabled(dev)) {
+ 		br_vlan_get_pvid(dev, &vid);
+ 	} else if (netif_is_bridge_master(dev)) {
+-		vid = prestera_vlan_dev_vlan_id(sw->bridge, dev);
++		vid = prestera_vlan_dev_vlan_id(sw, dev);
+ 	} else if (netif_is_macvlan(dev)) {
+ 		vlan = netdev_priv(dev);
+ 		return mvsw_pr_nh_dev_to_vid(sw, vlan->lowerdev);
+@@ -305,39 +236,30 @@ mvsw_pr_nh_dev_egress(struct prestera_switch *sw, struct net_device *dev,
+ 	return egress_dev;
+ }
+ 
+-static u16 mvsw_pr_rif_vr_id(struct prestera_rif *rif)
+-{
+-	return rif->vr->hw_vr_id;
+-}
+-
+-static int
+-mvsw_pr_rif_iface_init(struct prestera_rif *rif)
++static int prestera_dev2iface(struct prestera_switch *sw,
++			      struct net_device *dev,
++			      struct prestera_iface *iface)
+ {
+-	struct net_device *dev = rif->dev;
+-	struct prestera_switch *sw = rif->sw;
+-	struct prestera_port *port;
+-	int if_type = prestera_dev_if_type(dev);
++	struct prestera_port *port = netdev_priv(dev);
+ 
+-	switch (if_type) {
+-	case MVSW_IF_PORT_E:
+-		port = netdev_priv(dev);
+-		rif->iface.dev_port.hw_dev_num = port->dev_id;
+-		rif->iface.dev_port.port_num = port->hw_id;
++	memset(iface, 0, sizeof(*iface));
++	iface->type = prestera_dev_if_type(dev);
++	switch (iface->type) {
++	case PRESTERA_IF_PORT_E:
++		iface->dev_port.hw_dev_num = port->dev_id;
++		iface->dev_port.port_num = port->hw_id;
+ 		break;
+-	case MVSW_IF_LAG_E:
+-		prestera_lag_id_find(sw, dev, &rif->iface.lag_id);
++	case PRESTERA_IF_LAG_E:
++		prestera_lag_id_find(sw, dev, &iface->lag_id);
+ 		break;
+-	case MVSW_IF_VID_E:
++	case PRESTERA_IF_VID_E:
++		iface->vlan_id = mvsw_pr_nh_dev_to_vid(sw, dev);
+ 		break;
+ 	default:
+ 		pr_err("Unsupported rif type");
+ 		return -EINVAL;
+ 	}
+ 
+-	rif->iface.type = if_type;
+-	rif->iface.vlan_id = mvsw_pr_nh_dev_to_vid(sw, dev);
+-	rif->iface.vr_id = rif->vr->hw_vr_id;
+-
+ 	return 0;
+ }
+ 
+@@ -354,8 +276,8 @@ __mvsw_pr_neigh_iface_init(struct prestera_switch *sw,
+ 	iface->type = prestera_dev_if_type(dev);
+ 
+ 	switch (iface->type) {
+-	case MVSW_IF_PORT_E:
+-	case MVSW_IF_VID_E:
++	case PRESTERA_IF_PORT_E:
++	case PRESTERA_IF_VID_E:
+ 		egress_dev = mvsw_pr_nh_dev_egress(sw, dev, n->ha);
+ 		if (!egress_dev && is_nud_perm) {
+ 		/* Permanent neighbours on a bridge are not bounded to any
+@@ -376,7 +298,7 @@ __mvsw_pr_neigh_iface_init(struct prestera_switch *sw,
+ 		iface->dev_port.hw_dev_num = port->dev_id;
+ 		iface->dev_port.port_num = port->hw_id;
+ 		break;
+-	case MVSW_IF_LAG_E:
++	case PRESTERA_IF_LAG_E:
+ 		prestera_lag_id_find(sw, dev, &iface->lag_id);
+ 		break;
+ 	default:
+@@ -447,6 +369,7 @@ int prestera_util_kern_dip2nh_grp_key(struct prestera_switch *sw,
+ 	int err;
+ 	struct fib_result fib_res;
+ 	struct fib_nh *fib_nh;
++	struct prestera_rif *rif;
+ 
+ 	err = mvsw_pr_util_kern_get_route(&fib_res, tb_id, addr);
+ 	if (err)
+@@ -456,10 +379,11 @@ int prestera_util_kern_dip2nh_grp_key(struct prestera_switch *sw,
+ 		fib_nh = fib_info_nh(fib_res.fi, 0);
+ 		memset(res, 0, sizeof(*res));
+ 		res->neigh[0].addr = *addr;
+-		res->neigh[0].rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
+-		if (!res->neigh[0].rif || !res->neigh[0].rif->is_active)
++		rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
++		if (!rif || !rif->is_active)
+ 			return 0;
+ 
++		res->neigh[0].rif = rif;
+ 		return 1;
+ 	}
+ 
+@@ -467,6 +391,15 @@ int prestera_util_kern_dip2nh_grp_key(struct prestera_switch *sw,
+ 					 PRESTERA_NHGR_SIZE_MAX, res);
+ }
+ 
++static void
++prestera_util_n_cache_key2nh_key(struct prestera_kern_neigh_cache_key *ck,
++				 struct prestera_nh_neigh_key *nk)
++{
++	memset(nk, 0, sizeof(*nk));
++	nk->addr = ck->addr;
++	nk->rif = (void *)ck->rif;
++}
++
+ /* Check if neigh route is reachable */
+ static bool
+ mvsw_pr_util_kern_n_is_reachable(u32 tb_id,
+@@ -512,15 +445,39 @@ mvsw_pr_util_fib_nh2nh_neigh_key(struct prestera_switch *sw,
+ 				 struct fib_nh *fib_nh,
+ 				 struct prestera_nh_neigh_key *nh_key)
+ {
++	struct prestera_rif *rif;
++
+ 	memset(nh_key, 0, sizeof(*nh_key));
+ 	nh_key->addr.u.ipv4 = fib_nh->fib_nh_gw4;
+-	nh_key->rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
+-	if (!nh_key->rif || !nh_key->rif->is_active)
++	rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
++	if (!rif || !rif->is_active)
+ 		return -ENOENT;
+ 
++	nh_key->rif = rif;
+ 	return 0;
+ }
+ 
++static int
++prestera_util_fc2nh_gr_key(struct prestera_switch *sw,
++			   struct mvsw_pr_kern_fib_cache *fc,
++			   struct prestera_nexthop_group_key *grp_key)
++{
++	int i;
++
++	memset(grp_key, 0, sizeof(*grp_key));
++	for (i = 0; i < PRESTERA_NHGR_SIZE_MAX; i++) {
++		if (!fc->kern_neigh_cache_head[i].n_cache)
++			break;
++
++		grp_key->neigh[i].addr =
++			fc->kern_neigh_cache_head[i].n_cache->key.addr;
++		grp_key->neigh[i].rif =
++			fc->kern_neigh_cache_head[i].n_cache->key.rif;
++	}
++
++	return i;
++}
++
+ static int
+ mvsw_pr_util_fi2nh_gr_key(struct prestera_switch *sw, struct fib_info *fi,
+ 			  size_t limit,
+@@ -569,15 +526,32 @@ mvsw_pr_util_fib_cache_key2fib_key(struct mvsw_pr_kern_fib_cache_key *ckey,
+ 	fkey->tb_id = mvsw_pr_fix_tb_id(ckey->kern_tb_id);
+ }
+ 
++static int
++prestera_util_fib_nh2n_cache_key(struct prestera_switch *sw,
++				 struct fib_nh *fib_nh,
++				 struct prestera_kern_neigh_cache_key *nk)
++{
++	struct prestera_rif *rif;
++
++	memset(nk, 0, sizeof(*nk));
++	nk->addr.u.ipv4 = fib_nh->fib_nh_gw4;
++	rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
++	if (!rif || !rif->is_active)
++		return -ENOENT;
++
++	nk->rif = rif;
++	return 0;
++}
++
+ static bool
+-mvsw_pr_util_is_fib_nh_equal2nh_neigh_key(struct prestera_switch *sw,
+-					  struct fib_nh *fib_nh,
+-					  struct prestera_nh_neigh_key *nk)
++prestera_util_fib_nh_eq_n_cache_key(struct prestera_switch *sw,
++				    struct fib_nh *fib_nh,
++				    struct prestera_kern_neigh_cache_key *nk)
+ {
+ 	int err;
+-	struct prestera_nh_neigh_key tk;
++	struct prestera_kern_neigh_cache_key tk;
+ 
+-	err = mvsw_pr_util_fib_nh2nh_neigh_key(sw, fib_nh, &tk);
++	err = prestera_util_fib_nh2n_cache_key(sw, fib_nh, &tk);
+ 	if (err)
+ 		return false;
+ 
+@@ -617,7 +591,7 @@ __mvsw_pr_kern_neigh_cache_destroy(struct prestera_switch *sw,
+ 				   struct prestera_kern_neigh_cache *n_cache)
+ {
+ 	n_cache->key.rif->ref_cnt--;
+-	mvsw_pr_rif_put(n_cache->key.rif);
++	mvsw_pr_rif_put(sw, n_cache->key.rif);
+ 	rhashtable_remove_fast(&sw->router->kern_neigh_cache_ht,
+ 			       &n_cache->ht_node,
+ 			       __mvsw_pr_kern_neigh_cache_ht_params);
+@@ -649,7 +623,7 @@ __mvsw_pr_kern_neigh_cache_create(struct prestera_switch *sw,
+ 
+ err_ht_insert:
+ 	n_cache->key.rif->ref_cnt--;
+-	mvsw_pr_rif_put(n_cache->key.rif);
++	mvsw_pr_rif_put(sw, n_cache->key.rif);
+ 	kfree(n_cache);
+ err_kzalloc:
+ 	return NULL;
+@@ -715,19 +689,18 @@ mvsw_pr_kern_fib_cache_destroy(struct prestera_switch *sw,
+ 	kfree(fib_cache);
+ }
+ 
+-/* Pass also grp_key, because we may implement logic to     *
+- * differ fib_nh's and created nh_neighs.                   *
+- * Operations on fi (offload, etc) must be wrapped in utils *
++/* Operations on fi (offload, etc) must be wrapped in utils.
++ * This function just create storage.
+  */
+ static struct mvsw_pr_kern_fib_cache *
+-__mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+-				struct mvsw_pr_kern_fib_cache_key *key,
+-				struct prestera_nexthop_group_key *grp_key,
+-				struct fib_info *fi)
++prestera_kern_fib_cache_create(struct prestera_switch *sw,
++			       struct mvsw_pr_kern_fib_cache_key *key,
++			       struct fib_info *fi)
+ {
+ 	struct mvsw_pr_kern_fib_cache *fib_cache;
+ 	struct prestera_kern_neigh_cache *n_cache;
+-	int err, i;
++	struct prestera_nh_neigh_key nh_key;
++	int err, i, nhs;
+ 
+ 	fib_cache = kzalloc(sizeof(*fib_cache), GFP_KERNEL);
+ 	if (!fib_cache)
+@@ -736,6 +709,10 @@ __mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+ 	memcpy(&fib_cache->key, key, sizeof(*key));
+ 	fib_info_hold(fi);
+ 	fib_cache->fi = fi;
++	/* This is for unnatural offload flag logic
++	 * to satisfy user expectations.
++	 */
++	fib_cache->allow_oflag |= !!mvsw_pr_fi_is_hw_direct(sw, fi);
+ 
+ 	err = rhashtable_insert_fast(&sw->router->kern_fib_cache_ht,
+ 				     &fib_cache->ht_node,
+@@ -743,16 +720,24 @@ __mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+ 	if (err)
+ 		goto err_ht_insert;
+ 
+-	if (!grp_key)
++	/* Handle nexthops */
++
++	if (!mvsw_pr_fi_is_nh(fi))
+ 		goto out;
+ 
+-	for (i = 0; i < PRESTERA_NHGR_SIZE_MAX; i++) {
+-		if (!mvsw_pr_nh_neigh_key_is_valid(&grp_key->neigh[i]))
+-			break;
++	nhs = fib_info_num_path(fi);
++	if (nhs > PRESTERA_NHGR_SIZE_MAX)
++		goto out;
+ 
+-		n_cache = mvsw_pr_kern_neigh_cache_get(sw, &grp_key->neigh[i]);
++	for (i = 0; i < nhs; i++) {
++		err = mvsw_pr_util_fib_nh2nh_neigh_key(sw, fib_info_nh(fi, i),
++						       &nh_key);
++		if (err)
++			goto out;
++
++		n_cache = mvsw_pr_kern_neigh_cache_get(sw, &nh_key);
+ 		if (!n_cache)
+-			continue;
++			goto out;
+ 
+ 		fib_cache->kern_neigh_cache_head[i].this = fib_cache;
+ 		fib_cache->kern_neigh_cache_head[i].n_cache = n_cache;
+@@ -760,6 +745,11 @@ __mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+ 			 &n_cache->kern_fib_cache_list);
+ 	}
+ 
++	/* This is for unnatural offload flag logic
++	 * to satisfy user expectations.
++	 */
++	fib_cache->allow_oflag |= !!nhs;
++
+ out:
+ 	return fib_cache;
+ 
+@@ -770,63 +760,6 @@ __mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+ 	return NULL;
+ }
+ 
+-static struct mvsw_pr_kern_fib_cache *
+-mvsw_pr_kern_fib_cache_create(struct prestera_switch *sw,
+-			      struct mvsw_pr_kern_fib_cache_key *fc_key,
+-			      struct fib_info *fi)
+-{
+-	struct mvsw_pr_kern_fib_cache *fc;
+-	struct prestera_nexthop_group_key grp_key;
+-	int nh_cnt;
+-
+-	switch (fi->fib_type) {
+-	case RTN_UNICAST:
+-		nh_cnt = mvsw_pr_util_fi2nh_gr_key(sw, fi,
+-						   PRESTERA_NHGR_SIZE_MAX,
+-						   &grp_key);
+-		fc = __mvsw_pr_kern_fib_cache_create(sw, fc_key,
+-						     nh_cnt ? &grp_key : NULL,
+-						     fi);
+-		if (!fc)
+-			return NULL;
+-
+-		fc->lpm_info.fib_type = nh_cnt ?
+-					MVSW_PR_FIB_TYPE_UC_NH :
+-					MVSW_PR_FIB_TYPE_TRAP;
+-		fc->lpm_info.nh_grp_key = grp_key;
+-		fc->allow_oflag = !!(nh_cnt || mvsw_pr_fi_is_hw_direct(sw, fi));
+-		break;
+-	/* Unsupported. Leave it for kernel: */
+-	case RTN_BROADCAST:
+-	case RTN_MULTICAST:
+-	/* Routes we must trap by design: */
+-	case RTN_LOCAL:
+-	case RTN_UNREACHABLE:
+-	case RTN_PROHIBIT:
+-		fc = __mvsw_pr_kern_fib_cache_create(sw, fc_key, NULL, fi);
+-		if (!fc)
+-			return NULL;
+-
+-		fc->lpm_info.fib_type = MVSW_PR_FIB_TYPE_TRAP;
+-		break;
+-	case RTN_BLACKHOLE:
+-		fc = __mvsw_pr_kern_fib_cache_create(sw, fc_key, NULL, fi);
+-		if (!fc)
+-			return NULL;
+-
+-		fc->lpm_info.fib_type = MVSW_PR_FIB_TYPE_DROP;
+-		break;
+-	default:
+-		MVSW_LOG_ERROR("Unsupported fib_type");
+-		return NULL;
+-	}
+-
+-	mvsw_pr_util_fib_cache_key2fib_key(fc_key,
+-					   &fc->lpm_info.fib_key);
+-
+-	return fc;
+-}
+-
+ static void
+ __mvsw_pr_k_arb_fib_offload_set(struct prestera_switch *sw,
+ 				struct mvsw_pr_kern_fib_cache *fibc,
+@@ -844,9 +777,7 @@ __mvsw_pr_k_arb_fib_offload_set(struct prestera_switch *sw,
+ 			continue;
+ 		}
+ 
+-		if (mvsw_pr_util_is_fib_nh_equal2nh_neigh_key(sw,
+-							      fib_nh,
+-							      &nc->key)) {
++		if (prestera_util_fib_nh_eq_n_cache_key(sw, fib_nh, &nc->key)) {
+ 			mvsw_pr_util_kern_set_nh_offload(fib_nh, offloaded);
+ 			break;
+ 		}
+@@ -874,30 +805,45 @@ __mvsw_pr_k_arb_n_lpm_set(struct prestera_switch *sw,
+ 			  struct prestera_kern_neigh_cache *n_cache,
+ 			  bool enabled)
+ {
++	struct mvsw_pr_kern_fib_cache_key fc_key;
++	struct mvsw_pr_kern_fib_cache *fib_cache;
+ 	struct prestera_fib_key fib_key;
+-	struct mvsw_pr_fib_node *fib_node;
++	struct prestera_fib_node *fib_node;
+ 	struct prestera_nexthop_group_key nh_grp_key;
+ 
+-	memset(&fib_key, 0, sizeof(fib_key));
+-	fib_key.addr = n_cache->key.addr;
+-	fib_key.prefix_len = 32;
+-	fib_key.tb_id = n_cache->key.rif->vr->tb_id;
+-	fib_node = mvsw_pr_fib_node_find(sw, &fib_key);
+-	if (!enabled && fib_node) {
+-		if (mvsw_pr_fib_node_util_is_neighbour(fib_node))
+-			mvsw_pr_fib_node_destroy(sw, fib_node);
+-		return;
++	/* Exception for fc with prefix 32: LPM entry is already used by fib */
++	memset(&fc_key, 0, sizeof(fc_key));
++	fc_key.addr = n_cache->key.addr;
++	fc_key.prefix_len = 32;
++	/* But better to use tb_id of route, which pointed to this neighbour. */
++	/* We take it from rif, because rif inconsistent.
++	 * Must be separated in_rif and out_rif.
++	 */
++	fc_key.kern_tb_id = n_cache->key.rif->kern_tb_id;
++	fib_cache = mvsw_pr_kern_fib_cache_find(sw, &fc_key);
++	if (!fib_cache || !fib_cache->reachable) {
++		memset(&fib_key, 0, sizeof(fib_key));
++		fib_key.addr = n_cache->key.addr;
++		fib_key.prefix_len = 32;
++		fib_key.tb_id = mvsw_pr_fix_tb_id(n_cache->key.rif->kern_tb_id);
++		fib_node = prestera_fib_node_find(sw, &fib_key);
++		if (!enabled && fib_node) {
++			if (mvsw_pr_fib_node_util_is_neighbour(fib_node))
++				prestera_fib_node_destroy(sw, fib_node);
++			return;
++		}
+ 	}
+ 
+ 	if (enabled && !fib_node) {
+ 		memset(&nh_grp_key, 0, sizeof(nh_grp_key));
+-		nh_grp_key.neigh[0] = n_cache->key;
+-		fib_node = mvsw_pr_fib_node_create(sw, &fib_key,
+-						   MVSW_PR_FIB_TYPE_UC_NH,
+-						   &nh_grp_key);
++		prestera_util_n_cache_key2nh_key(&n_cache->key,
++						 &nh_grp_key.neigh[0]);
++		fib_node = prestera_fib_node_create(sw, &fib_key,
++						    PRESTERA_FIB_TYPE_UC_NH,
++						    &nh_grp_key);
+ 		if (!fib_node)
+ 			MVSW_LOG_ERROR("%s failed ip=%pI4n",
+-				       "mvsw_pr_fib_node_create",
++				       "prestera_fib_node_create",
+ 				       &fib_key.addr.u.ipv4);
+ 		return;
+ 	}
+@@ -907,7 +853,7 @@ static void
+ __mvsw_pr_k_arb_nc_kern_fib_fetch(struct prestera_switch *sw,
+ 				  struct prestera_kern_neigh_cache *nc)
+ {
+-	if (mvsw_pr_util_kern_n_is_reachable(nc->key.rif->vr->tb_id,
++	if (mvsw_pr_util_kern_n_is_reachable(nc->key.rif->kern_tb_id,
+ 					     &nc->key.addr,
+ 					     nc->key.rif->dev))
+ 		nc->reachable = true;
+@@ -921,6 +867,7 @@ __mvsw_pr_k_arb_nc_kern_n_fetch(struct prestera_switch *sw,
+ 				struct prestera_kern_neigh_cache *nc)
+ {
+ 	struct neighbour *n;
++	struct prestera_rif_entry *re;
+ 	int err;
+ 
+ 	memset(&nc->nh_neigh_info, 0, sizeof(nc->nh_neigh_info));
+@@ -936,6 +883,17 @@ __mvsw_pr_k_arb_nc_kern_n_fetch(struct prestera_switch *sw,
+ 				       n->primary_key, &n->ha[0]);
+ 			goto n_read_out;
+ 		}
++		/* This line is dirty.
++		 * We add it, because there is vlan, wich mapped by vr_id.
++		 * But this is incorrect. Because nh is pointed to vlan, not vr!
++		 * If kernel will manage routing vlans - this will be more
++		 * logicaly.
++		 */
++		re = prestera_rif_entry_find(sw, &nc->key.rif->rif_entry_key);
++		if (re)
++			nc->nh_neigh_info.iface.vr_id = re->vr->hw_vr_id;
++		else
++			goto n_read_out;
+ 
+ 		memcpy(&nc->nh_neigh_info.ha[0], &n->ha[0], ETH_ALEN);
+ 		nc->nh_neigh_info.connected = true;
+@@ -953,6 +911,7 @@ static void
+ __mvsw_pr_k_arb_nc_apply(struct prestera_switch *sw,
+ 			 struct prestera_kern_neigh_cache *nc)
+ {
++	struct prestera_nh_neigh_key nh_key;
+ 	struct prestera_nh_neigh *nh_neigh;
+ 	struct mvsw_pr_kern_neigh_cache_head *nhead;
+ 	struct prestera_acl_nat_port *nat_port;
+@@ -966,8 +925,9 @@ __mvsw_pr_k_arb_nc_apply(struct prestera_switch *sw,
+ 				      nc->reachable && nc->in_kernel);
+ 
+ 	/* update NAT port on neighbour change */
+-	port_hw_id = nc->key.rif->iface.dev_port.port_num;
+-	port_dev_id = nc->key.rif->iface.dev_port.hw_dev_num;
++	/* Note: should be no such lines here. It's iincorrect static NAT. */
++	port_hw_id = nc->key.rif->rif_entry_key.iface.dev_port.port_num;
++	port_dev_id = nc->key.rif->rif_entry_key.iface.dev_port.hw_dev_num;
+ 	nat_port = prestera_acl_nat_port_get(sw->acl, port_hw_id,
+ 					     port_dev_id);
+ 	if (!nat_port)
+@@ -985,7 +945,8 @@ __mvsw_pr_k_arb_nc_apply(struct prestera_switch *sw,
+ 			       nc->nh_neigh_info.ha);
+ 
+ skip_nat_port_update:
+-	nh_neigh = prestera_nh_neigh_find(sw, &nc->key);
++	prestera_util_n_cache_key2nh_key(&nc->key, &nh_key);
++	nh_neigh = prestera_nh_neigh_find(sw, &nh_key);
+ 	if (!nh_neigh)
+ 		goto out;
+ 
+@@ -994,7 +955,7 @@ __mvsw_pr_k_arb_nc_apply(struct prestera_switch *sw,
+ 		   sizeof(nh_neigh->info))) {
+ 		memcpy(&nh_neigh->info, &nc->nh_neigh_info,
+ 		       sizeof(nh_neigh->info));
+-		err = mvsw_pr_nh_neigh_set(sw, nh_neigh);
++		err = prestera_nh_neigh_set(sw, nh_neigh);
+ 		if (err) {
+ 			MVSW_LOG_ERROR("%s failed with err=%d ip=%pI4n mac=%pM",
+ 				       "mvsw_pr_nh_neigh_set", err,
+@@ -1017,17 +978,19 @@ static void __mvsw_pr_k_arb_hw_state_upd(struct prestera_switch *sw,
+ 					 struct prestera_kern_neigh_cache *nc)
+ {
+ 	bool hw_active;
++	struct prestera_nh_neigh_key nh_key;
+ 	struct prestera_nh_neigh *nh_neigh;
+ 	struct neighbour *n;
+ 
+-	nh_neigh = prestera_nh_neigh_find(sw, &nc->key);
++	prestera_util_n_cache_key2nh_key(&nc->key, &nh_key);
++	nh_neigh = prestera_nh_neigh_find(sw, &nh_key);
+ 	if (!nh_neigh) {
+ 		MVSW_LOG_ERROR("Cannot find nh_neigh for cached %pI4n",
+ 			       &nc->key.addr.u.ipv4);
+ 		return;
+ 	}
+ 
+-	hw_active = mvsw_pr_nh_neigh_util_hw_state(sw, nh_neigh);
++	hw_active = prestera_nh_neigh_util_hw_state(sw, nh_neigh);
+ 
+ #ifdef MVSW_PR_IMPLICITY_RESOLVE_DEAD_NEIGH
+ 	if (!hw_active && nc->in_kernel)
+@@ -1061,18 +1024,18 @@ static int __mvsw_pr_k_arb_f_lpm_set(struct prestera_switch *sw,
+ 				     struct mvsw_pr_kern_fib_cache *fc,
+ 				     bool enabled)
+ {
+-	struct mvsw_pr_fib_node *fib_node;
++	struct prestera_fib_node *fib_node;
+ 
+-	fib_node = mvsw_pr_fib_node_find(sw, &fc->lpm_info.fib_key);
++	fib_node = prestera_fib_node_find(sw, &fc->lpm_info.fib_key);
+ 	if (fib_node)
+-		mvsw_pr_fib_node_destroy(sw, fib_node);
++		prestera_fib_node_destroy(sw, fib_node);
+ 
+ 	if (!enabled)
+ 		return 0;
+ 
+-	fib_node = mvsw_pr_fib_node_create(sw, &fc->lpm_info.fib_key,
+-					   fc->lpm_info.fib_type,
+-					   &fc->lpm_info.nh_grp_key);
++	fib_node = prestera_fib_node_create(sw, &fc->lpm_info.fib_key,
++					    fc->lpm_info.fib_type,
++					    &fc->lpm_info.nh_grp_key);
+ 
+ 	if (!fib_node) {
+ 		MVSW_LOG_ERROR("fib_node=NULL %pI4n/%d kern_tb_id = %d",
+@@ -1088,6 +1051,68 @@ static int __mvsw_pr_k_arb_fc_apply(struct prestera_switch *sw,
+ 				    struct mvsw_pr_kern_fib_cache *fc)
+ {
+ 	int err;
++	int nh_cnt;
++	struct prestera_rif *rif;
++	struct fib_nh *fib_nh;
++
++	memset(&fc->lpm_info, 0, sizeof(fc->lpm_info));
++
++	switch (fc->fi->fib_type) {
++	case RTN_UNICAST:
++		if (mvsw_pr_fi_is_direct(fc->fi) &&
++		    fc->key.prefix_len == 32 &&
++		    fc->key.addr.v == PRESTERA_IPV4) {
++			/* This is special case.
++			 * When prefix is 32. Than we will have conflict in lpm
++			 * for direct route - once TRAP added, there is no
++			 * place for neighbour entry. So represent direct route
++			 * with prefix 32, as NH. So neighbour will be resolved
++			 * as nexthop of this route.
++			 */
++			fib_nh = fib_info_nh(fc->fi, 0);
++			rif = mvsw_pr_rif_find(sw, fib_nh->fib_nh_dev);
++			/* If we realy can access this route via HW */
++			if (!rif || !rif->is_active) {
++				fc->lpm_info.fib_type = PRESTERA_FIB_TYPE_TRAP;
++			} else {
++				fc->lpm_info.fib_type = PRESTERA_FIB_TYPE_UC_NH;
++				fc->lpm_info.nh_grp_key.neigh[0].addr =
++					fc->key.addr;
++				fc->lpm_info.nh_grp_key.neigh[0].rif = rif;
++			}
++
++			break;
++		}
++
++		/* We can also get nh_grp_key from fi. This will be correct to
++		 * because cache not always represent, what actually written to
++		 * lpm. But we use nh cache, as well for now (for this case).
++		 */
++		nh_cnt = prestera_util_fc2nh_gr_key(sw, fc,
++						    &fc->lpm_info.nh_grp_key);
++		fc->lpm_info.fib_type = nh_cnt ?
++					PRESTERA_FIB_TYPE_UC_NH :
++					PRESTERA_FIB_TYPE_TRAP;
++		break;
++	/* Unsupported. Leave it for kernel: */
++	case RTN_BROADCAST:
++	case RTN_MULTICAST:
++	/* Routes we must trap by design: */
++	case RTN_LOCAL:
++	case RTN_UNREACHABLE:
++	case RTN_PROHIBIT:
++		fc->lpm_info.fib_type = PRESTERA_FIB_TYPE_TRAP;
++		break;
++	case RTN_BLACKHOLE:
++		fc->lpm_info.fib_type = PRESTERA_FIB_TYPE_DROP;
++		break;
++	default:
++		MVSW_LOG_ERROR("Unsupported fib_type");
++		return -EOPNOTSUPP;
++	}
++
++	mvsw_pr_util_fib_cache_key2fib_key(&fc->key,
++					   &fc->lpm_info.fib_key);
+ 
+ 	/* 1. Update lpm */
+ 	err = __mvsw_pr_k_arb_f_lpm_set(sw, fc, fc->reachable);
+@@ -1095,7 +1120,7 @@ static int __mvsw_pr_k_arb_fc_apply(struct prestera_switch *sw,
+ 		return err;
+ 
+ 	/* UC_NH offload flag is managed by neighbours cache */
+-	if (fc->lpm_info.fib_type != MVSW_PR_FIB_TYPE_UC_NH || !fc->reachable)
++	if (fc->lpm_info.fib_type != PRESTERA_FIB_TYPE_UC_NH || !fc->reachable)
+ 		__mvsw_pr_k_arb_fib_offload_set(sw, fc, NULL, fc->reachable &&
+ 						fc->allow_oflag);
+ 
+@@ -1157,6 +1182,10 @@ static void __mvsw_pr_k_arb_abort_neigh(struct prestera_switch *sw)
+ 		} else if (IS_ERR(n_cache)) {
+ 			continue;
+ 		} else if (n_cache) {
++			if (!list_empty(&n_cache->kern_fib_cache_list)) {
++				WARN_ON(1); /* BUG */
++				continue;
++			}
+ 			__mvsw_pr_k_arb_n_offload_set(sw, n_cache, false);
+ 			n_cache->in_kernel = false;
+ 			/* No need to destroy lpm.
+@@ -1356,8 +1385,8 @@ mvsw_pr_k_arb_fib_evt(struct prestera_switch *sw,
+ 	}
+ 
+ 	if (replace) {
+-		fib_cache = mvsw_pr_kern_fib_cache_create(sw, &fc_key,
+-							  fen_info->fi);
++		fib_cache = prestera_kern_fib_cache_create(sw, &fc_key,
++							   fen_info->fi);
+ 		if (!fib_cache) {
+ 			MVSW_LOG_ERROR("fib_cache == NULL");
+ 			return -ENOENT;
+@@ -1430,7 +1459,7 @@ __mvsw_pr_k_arb_fc_rebuild(struct prestera_switch *sw,
+ 	__mvsw_pr_k_arb_fc_apply(sw, fc);
+ 	mvsw_pr_kern_fib_cache_destroy(sw, fc);
+ 
+-	new_fc = mvsw_pr_kern_fib_cache_create(sw, &key, fi);
++	new_fc = prestera_kern_fib_cache_create(sw, &key, fi);
+ 	fib_info_put(fi);
+ 	if (!new_fc)
+ 		return NULL;
+@@ -1590,15 +1619,8 @@ static void mvsw_pr_router_update_neighs_work(struct work_struct *work)
+ 			   msecs_to_jiffies(router->neighs_update.interval));
+ }
+ 
+-static int mvsw_pr_neigh_init(struct prestera_switch *sw)
++static int prestera_neigh_work_init(struct prestera_switch *sw)
+ {
+-	int err;
+-
+-	err = rhashtable_init(&sw->router->nh_neigh_ht,
+-			      &__mvsw_pr_nh_neigh_ht_params);
+-	if (err)
+-		return err;
+-
+ 	mvsw_pr_router_neighs_update_interval_init(sw->router);
+ 
+ 	INIT_DELAYED_WORK(&sw->router->neighs_update.dw,
+@@ -1607,10 +1629,9 @@ static int mvsw_pr_neigh_init(struct prestera_switch *sw)
+ 	return 0;
+ }
+ 
+-static void mvsw_pr_neigh_fini(struct prestera_switch *sw)
++static void prestera_neigh_work_fini(struct prestera_switch *sw)
+ {
+ 	cancel_delayed_work_sync(&sw->router->neighs_update.dw);
+-	rhashtable_destroy(&sw->router->nh_neigh_ht);
+ }
+ 
+ static struct prestera_rif*
+@@ -1638,7 +1659,7 @@ mvsw_pr_port_vlan_router_join(struct prestera_port_vlan *mvsw_pr_port_vlan,
+ 			      struct net_device *dev,
+ 			      struct netlink_ext_ack *extack)
+ {
+-	struct prestera_port *port = mvsw_pr_port_vlan->mvsw_pr_port;
++	struct prestera_port *port = mvsw_pr_port_vlan->port;
+ 	struct prestera_switch *sw = port->sw;
+ 
+ 	struct mvsw_pr_rif_params params = {
+@@ -1650,7 +1671,7 @@ mvsw_pr_port_vlan_router_join(struct prestera_port_vlan *mvsw_pr_port_vlan,
+ 
+ 	rif = mvsw_pr_rif_find(sw, dev);
+ 	if (!rif)
+-		rif = mvsw_pr_rif_create(sw, &params, extack);
++		rif = prestera_rif_create(sw, &params, extack);
+ 
+ 	if (IS_ERR(rif))
+ 		return PTR_ERR(rif);
+@@ -1670,7 +1691,7 @@ mvsw_pr_port_vlan_router_leave(struct prestera_port_vlan *mvsw_pr_port_vlan,
+ 			       struct net_device *dev)
+ 
+ {
+-	struct prestera_port *port = mvsw_pr_port_vlan->mvsw_pr_port;
++	struct prestera_port *port = mvsw_pr_port_vlan->port;
+ 	struct prestera_switch *sw = port->sw;
+ 	struct prestera_rif *rif;
+ 
+@@ -1698,7 +1719,7 @@ mvsw_pr_port_router_join(struct prestera_port *port,
+ 
+ 	rif = mvsw_pr_rif_find(sw, dev);
+ 	if (!rif)
+-		rif = mvsw_pr_rif_create(sw, &params, extack);
++		rif = prestera_rif_create(sw, &params, extack);
+ 
+ 	if (IS_ERR(rif))
+ 		return PTR_ERR(rif);
+@@ -1725,29 +1746,17 @@ void prestera_port_router_leave(struct prestera_port *port)
+ 	rif = mvsw_pr_rif_find(port->sw, port->net_dev);
+ 	if (rif) {
+ 		rif->is_active = false;
+-		mvsw_pr_rif_put(rif);
++		mvsw_pr_rif_put(port->sw, rif);
+ 	}
+ }
+ 
+-static int mvsw_pr_rif_fdb_op(struct prestera_rif *rif, const char *mac,
+-			      bool adding)
+-{
+-	if (adding)
+-		prestera_macvlan_add(rif->sw, mvsw_pr_rif_vr_id(rif), mac,
+-				     rif->iface.vlan_id);
+-	else
+-		prestera_macvlan_del(rif->sw, mvsw_pr_rif_vr_id(rif), mac,
+-				     rif->iface.vlan_id);
+-
+-	return 0;
+-}
+-
+ static int mvsw_pr_rif_macvlan_add(struct prestera_switch *sw,
+ 				   const struct net_device *macvlan_dev,
+ 				   struct netlink_ext_ack *extack)
+ {
+ 	struct macvlan_dev *vlan = netdev_priv(macvlan_dev);
+ 	struct prestera_rif *rif;
++	struct prestera_rif_entry *re;
+ 	int err;
+ 
+ 	rif = mvsw_pr_rif_find(sw, vlan->lowerdev);
+@@ -1757,7 +1766,12 @@ static int mvsw_pr_rif_macvlan_add(struct prestera_switch *sw,
+ 		return -EOPNOTSUPP;
+ 	}
+ 
+-	err = mvsw_pr_rif_fdb_op(rif, macvlan_dev->dev_addr, true);
++	re = prestera_rif_entry_find(sw, &rif->rif_entry_key);
++	if (!re)
++		return -ENOENT;
++
++	err = prestera_rif_entry_set_macvlan(sw, re, true,
++					     macvlan_dev->dev_addr);
+ 	if (err)
+ 		return err;
+ 
+@@ -1769,12 +1783,17 @@ static void __mvsw_pr_rif_macvlan_del(struct prestera_switch *sw,
+ {
+ 	struct macvlan_dev *vlan = netdev_priv(macvlan_dev);
+ 	struct prestera_rif *rif;
++	struct prestera_rif_entry *re;
+ 
+ 	rif = mvsw_pr_rif_find(sw, vlan->lowerdev);
+ 	if (!rif)
+ 		return;
+ 
+-	mvsw_pr_rif_fdb_op(rif, macvlan_dev->dev_addr,  false);
++	re = prestera_rif_entry_find(sw, &rif->rif_entry_key);
++	if (!re)
++		return;
++
++	prestera_rif_entry_set_macvlan(sw, re, false, macvlan_dev->dev_addr);
+ }
+ 
+ static void mvsw_pr_rif_macvlan_del(struct prestera_switch *sw,
+@@ -1853,7 +1872,7 @@ static int mvsw_pr_inetaddr_bridge_event(struct prestera_switch *sw,
+ 	case NETDEV_UP:
+ 		rif = mvsw_pr_rif_find(sw, dev);
+ 		if (!rif)
+-			rif = mvsw_pr_rif_create(sw, &params, extack);
++			rif = prestera_rif_create(sw, &params, extack);
+ 
+ 		if (IS_ERR(rif))
+ 			return PTR_ERR(rif);
+@@ -1862,7 +1881,7 @@ static int mvsw_pr_inetaddr_bridge_event(struct prestera_switch *sw,
+ 	case NETDEV_DOWN:
+ 		rif = mvsw_pr_rif_find(sw, dev);
+ 		rif->is_active = false;
+-		mvsw_pr_rif_put(rif);
++		mvsw_pr_rif_put(sw, rif);
+ 		break;
+ 	}
+ 
+@@ -1932,7 +1951,7 @@ static int mvsw_pr_inetaddr_lag_event(struct prestera_switch *sw,
+ 	case NETDEV_UP:
+ 		rif = mvsw_pr_rif_find(sw, lag_dev);
+ 		if (!rif)
+-			rif = mvsw_pr_rif_create(sw, &params, extack);
++			rif = prestera_rif_create(sw, &params, extack);
+ 
+ 		if (IS_ERR(rif))
+ 			return PTR_ERR(rif);
+@@ -1941,7 +1960,7 @@ static int mvsw_pr_inetaddr_lag_event(struct prestera_switch *sw,
+ 	case NETDEV_DOWN:
+ 		rif = mvsw_pr_rif_find(sw, lag_dev);
+ 		rif->is_active = false;
+-		mvsw_pr_rif_put(rif);
++		mvsw_pr_rif_put(sw, rif);
+ 		break;
+ 	}
+ 
+@@ -2029,8 +2048,8 @@ static int mvsw_pr_inetaddr_event(struct notifier_block *nb,
+ 	return notifier_from_errno(err);
+ }
+ 
+-int prestera_inetaddr_valid_event(struct notifier_block *unused,
+-				  unsigned long event, void *ptr)
++static int prestera_inetaddr_valid_event(struct notifier_block *unused,
++					 unsigned long event, void *ptr)
+ {
+ 	struct in_validator_info *ivi = (struct in_validator_info *)ptr;
+ 	struct net_device *dev = ivi->ivi_dev->dev;
+@@ -2108,467 +2127,11 @@ static bool mvsw_pr_fi_is_nh(struct fib_info *fi)
+ 	return !__mvsw_pr_fi_is_direct(fi);
+ }
+ 
+-static void __mvsw_pr_nh_neigh_destroy(struct prestera_switch *sw,
+-				       struct prestera_nh_neigh *neigh)
+-{
+-	neigh->key.rif->ref_cnt--;
+-	mvsw_pr_rif_put(neigh->key.rif);
+-	rhashtable_remove_fast(&sw->router->nh_neigh_ht,
+-			       &neigh->ht_node,
+-			       __mvsw_pr_nh_neigh_ht_params);
+-	kfree(neigh);
+-}
+-
+-static struct prestera_nh_neigh *
+-__mvsw_pr_nh_neigh_create(struct prestera_switch *sw,
+-			  struct prestera_nh_neigh_key *key)
+-{
+-	struct prestera_nh_neigh *neigh;
+-	int err;
+-
+-	neigh = kzalloc(sizeof(*neigh), GFP_KERNEL);
+-	if (!neigh)
+-		goto err_kzalloc;
+-
+-	memcpy(&neigh->key, key, sizeof(*key));
+-	neigh->key.rif->ref_cnt++;
+-	neigh->info.connected = false;
+-	INIT_LIST_HEAD(&neigh->nexthop_group_list);
+-	INIT_LIST_HEAD(&neigh->nh_mangle_entry_list);
+-	err = rhashtable_insert_fast(&sw->router->nh_neigh_ht,
+-				     &neigh->ht_node,
+-				     __mvsw_pr_nh_neigh_ht_params);
+-	if (err)
+-		goto err_rhashtable_insert;
+-
+-	return neigh;
+-
+-err_rhashtable_insert:
+-	neigh->key.rif->ref_cnt--;
+-	mvsw_pr_rif_put(neigh->key.rif);
+-	kfree(neigh);
+-err_kzalloc:
+-	return NULL;
+-}
+-
+-struct prestera_nh_neigh *
+-prestera_nh_neigh_find(struct prestera_switch *sw,
+-		       struct prestera_nh_neigh_key *key)
+-{
+-	struct prestera_nh_neigh *nh_neigh;
+-
+-	nh_neigh = rhashtable_lookup_fast(&sw->router->nh_neigh_ht,
+-					  key, __mvsw_pr_nh_neigh_ht_params);
+-	return IS_ERR(nh_neigh) ? NULL : nh_neigh;
+-}
+-
+-struct prestera_nh_neigh *
+-prestera_nh_neigh_get(struct prestera_switch *sw,
+-		      struct prestera_nh_neigh_key *key)
+-{
+-	struct prestera_nh_neigh *neigh;
+-
+-	neigh = prestera_nh_neigh_find(sw, key);
+-	if (!neigh)
+-		return __mvsw_pr_nh_neigh_create(sw, key);
+-
+-	return neigh;
+-}
+-
+-void prestera_nh_neigh_put(struct prestera_switch *sw,
+-			   struct prestera_nh_neigh *neigh)
+-{
+-	if (list_empty(&neigh->nexthop_group_list) &&
+-	    list_empty(&neigh->nh_mangle_entry_list))
+-		__mvsw_pr_nh_neigh_destroy(sw, neigh);
+-}
+-
+-/* Updates new mvsw_pr_neigh_info */
+-static int mvsw_pr_nh_neigh_set(struct prestera_switch *sw,
+-				struct prestera_nh_neigh *neigh)
+-{
+-	struct mvsw_pr_nh_neigh_head *nh_head;
+-	struct mvsw_pr_nexthop_group *nh_grp;
+-	struct prestera_nh_mangle_entry *nm;
+-	int err;
+-
+-	list_for_each_entry(nh_head, &neigh->nexthop_group_list, head) {
+-		nh_grp = nh_head->this;
+-		err = mvsw_pr_nexthop_group_set(sw, nh_grp);
+-		if (err)
+-			return err;
+-	}
+-
+-	list_for_each_entry(nm, &neigh->nh_mangle_entry_list, nh_neigh_head) {
+-		err = prestera_nh_mangle_entry_set(sw, nm);
+-		if (err)
+-			return err;
+-	}
+-
+-	return 0;
+-}
+-
+-static bool mvsw_pr_nh_neigh_key_is_valid(struct prestera_nh_neigh_key *key)
+-{
+-	return memchr_inv(key, 0, sizeof(*key)) ? true : false;
+-}
+-
+-static bool
+-mvsw_pr_nh_neigh_util_hw_state(struct prestera_switch *sw,
+-			       struct prestera_nh_neigh *nh_neigh)
+-{
+-	bool state;
+-	struct mvsw_pr_nh_neigh_head *nh_head, *tmp;
+-	struct prestera_nh_mangle_entry  *nm, *nm_tmp;
+-
+-	state = false;
+-	list_for_each_entry_safe(nh_head, tmp,
+-				 &nh_neigh->nexthop_group_list, head) {
+-		state = mvsw_pr_nexthop_group_util_hw_state(sw, nh_head->this);
+-		if (state)
+-			goto out;
+-	}
+-	list_for_each_entry_safe(nm, nm_tmp, &nh_neigh->nh_mangle_entry_list,
+-				 nh_neigh_head) {
+-		state = prestera_nh_mangle_entry_util_hw_state(sw, nm);
+-		if (state)
+-			goto out;
+-	}
+-
+-out:
+-	return state;
+-}
+-
+-static struct mvsw_pr_nexthop_group *
+-__mvsw_pr_nexthop_group_create(struct prestera_switch *sw,
+-			       struct prestera_nexthop_group_key *key)
+-{
+-	struct mvsw_pr_nexthop_group *nh_grp;
+-	struct prestera_nh_neigh *nh_neigh;
+-	int nh_cnt, err, gid;
+-
+-	nh_grp = kzalloc(sizeof(*nh_grp), GFP_KERNEL);
+-	if (!nh_grp)
+-		goto err_kzalloc;
+-
+-	memcpy(&nh_grp->key, key, sizeof(*key));
+-	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
+-		if (!mvsw_pr_nh_neigh_key_is_valid(&nh_grp->key.neigh[nh_cnt])
+-		   )
+-			break;
+-
+-		nh_neigh = prestera_nh_neigh_get(sw,
+-						 &nh_grp->key.neigh[nh_cnt]);
+-		if (!nh_neigh)
+-			goto err_nh_neigh_get;
+-
+-		nh_grp->nh_neigh_head[nh_cnt].neigh = nh_neigh;
+-		nh_grp->nh_neigh_head[nh_cnt].this = nh_grp;
+-		list_add(&nh_grp->nh_neigh_head[nh_cnt].head,
+-			 &nh_neigh->nexthop_group_list);
+-	}
+-
+-	err = prestera_nh_group_create(sw, nh_cnt, &nh_grp->grp_id);
+-	if (err)
+-		goto err_nh_group_create;
+-
+-	err = mvsw_pr_nexthop_group_set(sw, nh_grp);
+-	if (err)
+-		goto err_nexthop_group_set;
+-
+-	err = rhashtable_insert_fast(&sw->router->nexthop_group_ht,
+-				     &nh_grp->ht_node,
+-				     __mvsw_pr_nexthop_group_ht_params);
+-	if (err)
+-		goto err_ht_insert;
+-
+-	/* reset cache for created group */
+-	gid = nh_grp->grp_id;
+-	sw->router->nhgrp_hw_state_cache[gid / 8] &= ~BIT(gid % 8);
+-
+-	return nh_grp;
+-
+-err_ht_insert:
+-err_nexthop_group_set:
+-	prestera_nh_group_delete(sw, nh_cnt, nh_grp->grp_id);
+-err_nh_group_create:
+-err_nh_neigh_get:
+-	for (nh_cnt--; nh_cnt >= 0; nh_cnt--) {
+-		list_del(&nh_grp->nh_neigh_head[nh_cnt].head);
+-		prestera_nh_neigh_put(sw, nh_grp->nh_neigh_head[nh_cnt].neigh);
+-	}
+-
+-	kfree(nh_grp);
+-err_kzalloc:
+-	return NULL;
+-}
+-
+-static void
+-__mvsw_pr_nexthop_group_destroy(struct prestera_switch *sw,
+-				struct mvsw_pr_nexthop_group *nh_grp)
+-{
+-	struct prestera_nh_neigh *nh_neigh;
+-	int nh_cnt;
+-
+-	rhashtable_remove_fast(&sw->router->nexthop_group_ht,
+-			       &nh_grp->ht_node,
+-			       __mvsw_pr_nexthop_group_ht_params);
+-
+-	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
+-		nh_neigh = nh_grp->nh_neigh_head[nh_cnt].neigh;
+-		if (!nh_neigh)
+-			break;
+-
+-		list_del(&nh_grp->nh_neigh_head[nh_cnt].head);
+-		prestera_nh_neigh_put(sw, nh_neigh);
+-	}
+-
+-	prestera_nh_group_delete(sw, nh_cnt, nh_grp->grp_id);
+-	kfree(nh_grp);
+-}
+-
+-static struct mvsw_pr_nexthop_group *
+-mvsw_pr_nexthop_group_find(struct prestera_switch *sw,
+-			   struct prestera_nexthop_group_key *key)
+-{
+-	struct mvsw_pr_nexthop_group *nh_grp;
+-
+-	nh_grp = rhashtable_lookup_fast(&sw->router->nexthop_group_ht,
+-					key, __mvsw_pr_nexthop_group_ht_params);
+-	return IS_ERR(nh_grp) ? NULL : nh_grp;
+-}
+-
+-static struct mvsw_pr_nexthop_group *
+-mvsw_pr_nexthop_group_get(struct prestera_switch *sw,
+-			  struct prestera_nexthop_group_key *key)
+-{
+-	struct mvsw_pr_nexthop_group *nh_grp;
+-
+-	nh_grp = mvsw_pr_nexthop_group_find(sw, key);
+-	if (!nh_grp)
+-		return __mvsw_pr_nexthop_group_create(sw, key);
+-
+-	return nh_grp;
+-}
+-
+-static void mvsw_pr_nexthop_group_put(struct prestera_switch *sw,
+-				      struct mvsw_pr_nexthop_group *nh_grp)
+-{
+-	if (!nh_grp->ref_cnt)
+-		__mvsw_pr_nexthop_group_destroy(sw, nh_grp);
+-}
+-
+-/* Updates with new nh_neigh's info */
+-static int mvsw_pr_nexthop_group_set(struct prestera_switch *sw,
+-				     struct mvsw_pr_nexthop_group *nh_grp)
+-{
+-	struct prestera_neigh_info info[PRESTERA_NHGR_SIZE_MAX];
+-	struct prestera_nh_neigh *neigh;
+-	int nh_cnt;
+-
+-	memset(&info[0], 0, sizeof(info));
+-	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
+-		neigh = nh_grp->nh_neigh_head[nh_cnt].neigh;
+-		if (!neigh)
+-			break;
+-
+-		memcpy(&info[nh_cnt], &neigh->info, sizeof(neigh->info));
+-	}
+-
+-	return prestera_nh_entries_set(sw, nh_cnt, &info[0], nh_grp->grp_id);
+-}
+-
+-static bool
+-mvsw_pr_nexthop_group_util_hw_state(struct prestera_switch *sw,
+-				    struct mvsw_pr_nexthop_group *nh_grp)
+-{
+-	int err;
+-	u32 buf_size = sw->size_tbl_router_nexthop / 8 + 1;
+-	u32 gid = nh_grp->grp_id;
+-	u8 *cache = sw->router->nhgrp_hw_state_cache;
+-
+-	/* Antijitter
+-	 * Prevent situation, when we read state of nh_grp twice in short time,
+-	 * and state bit is still cleared on second call. So just stuck active
+-	 * state for MVSW_PR_NH_ACTIVE_JIFFER_FILTER, after last occurred.
+-	 */
+-	if (!time_before(jiffies, sw->router->nhgrp_hw_cache_kick +
+-			msecs_to_jiffies(MVSW_PR_NH_ACTIVE_JIFFER_FILTER))) {
+-		err = prestera_nhgrp_blk_get(sw, cache, buf_size);
+-		if (err) {
+-			MVSW_LOG_ERROR("Failed to get hw state nh_grp's");
+-			return false;
+-		}
+-
+-		sw->router->nhgrp_hw_cache_kick = jiffies;
+-	}
+-
+-	if (cache[gid / 8] & BIT(gid % 8))
+-		return true;
+-
+-	return false;
+-}
+-
+-static struct mvsw_pr_fib_node *
+-mvsw_pr_fib_node_find(struct prestera_switch *sw, struct prestera_fib_key *key)
+-{
+-	struct mvsw_pr_fib_node *fib_node;
+-
+-	fib_node = rhashtable_lookup_fast(&sw->router->fib_ht, key,
+-					  __mvsw_pr_fib_ht_params);
+-	return IS_ERR(fib_node) ? NULL : fib_node;
+-}
+-
+-static void __mvsw_pr_fib_node_destruct(struct prestera_switch *sw,
+-					struct mvsw_pr_fib_node *fib_node)
+-{
+-	struct mvsw_pr_vr *vr;
+-
+-	vr = fib_node->info.vr;
+-	prestera_lpm_del(sw, vr->hw_vr_id, &fib_node->key.addr,
+-			 fib_node->key.prefix_len);
+-	switch (fib_node->info.type) {
+-	case MVSW_PR_FIB_TYPE_UC_NH:
+-		fib_node->info.nh_grp->ref_cnt--;
+-		mvsw_pr_nexthop_group_put(sw, fib_node->info.nh_grp);
+-		break;
+-	case MVSW_PR_FIB_TYPE_TRAP:
+-		break;
+-	case MVSW_PR_FIB_TYPE_DROP:
+-		break;
+-	default:
+-	      MVSW_LOG_ERROR("Unknown fib_node->info.type = %d",
+-			     fib_node->info.type);
+-	}
+-
+-	vr->ref_cnt--;
+-	mvsw_pr_vr_put(sw, vr);
+-}
+-
+-static void mvsw_pr_fib_node_destroy(struct prestera_switch *sw,
+-				     struct mvsw_pr_fib_node *fib_node)
+-{
+-	__mvsw_pr_fib_node_destruct(sw, fib_node);
+-	rhashtable_remove_fast(&sw->router->fib_ht, &fib_node->ht_node,
+-			       __mvsw_pr_fib_ht_params);
+-	kfree(fib_node);
+-}
+-
+-static void mvsw_pr_fib_node_destroy_ht(struct prestera_switch *sw)
+-{
+-	struct mvsw_pr_fib_node *node, *tnode;
+-	struct rhashtable_iter iter;
+-
+-	tnode = NULL;
+-	rhashtable_walk_enter(&sw->router->fib_ht, &iter);
+-	rhashtable_walk_start(&iter);
+-	while (1) {
+-		node = rhashtable_walk_next(&iter);
+-		if (tnode) {
+-			rhashtable_remove_fast(&sw->router->fib_ht,
+-					       &tnode->ht_node,
+-					       __mvsw_pr_fib_ht_params);
+-			kfree(tnode);
+-			tnode = NULL;
+-		}
+-
+-		if (!node)
+-			break;
+-
+-		if (IS_ERR(node))
+-			continue;
+-
+-		rhashtable_walk_stop(&iter);
+-		__mvsw_pr_fib_node_destruct(sw, node);
+-		rhashtable_walk_start(&iter);
+-		tnode = node;
+-	}
+-	rhashtable_walk_stop(&iter);
+-	rhashtable_walk_exit(&iter);
+-}
+-
+-/* nh_grp_key valid only if fib_type == MVSW_PR_FIB_TYPE_UC_NH */
+-static struct mvsw_pr_fib_node *
+-mvsw_pr_fib_node_create(struct prestera_switch *sw,
+-			struct prestera_fib_key *key,
+-			enum mvsw_pr_fib_type fib_type,
+-			struct prestera_nexthop_group_key *nh_grp_key)
+-{
+-	struct mvsw_pr_fib_node *fib_node;
+-	u32 grp_id;
+-	struct mvsw_pr_vr *vr;
+-	int err;
+-
+-	fib_node = kzalloc(sizeof(*fib_node), GFP_KERNEL);
+-	if (!fib_node)
+-		goto err_kzalloc;
+-
+-	memcpy(&fib_node->key, key, sizeof(*key));
+-	fib_node->info.type = fib_type;
+-
+-	vr = mvsw_pr_vr_get(sw, key->tb_id, NULL);
+-	if (IS_ERR(vr))
+-		goto err_vr_get;
+-
+-	fib_node->info.vr = vr;
+-	vr->ref_cnt++;
+-
+-	switch (fib_type) {
+-	case MVSW_PR_FIB_TYPE_TRAP:
+-		grp_id = MVSW_PR_NHGR_UNUSED;
+-		break;
+-	case MVSW_PR_FIB_TYPE_DROP:
+-		grp_id = MVSW_PR_NHGR_DROP;
+-		break;
+-	case MVSW_PR_FIB_TYPE_UC_NH:
+-		fib_node->info.nh_grp = mvsw_pr_nexthop_group_get(sw,
+-								  nh_grp_key);
+-		if (!fib_node->info.nh_grp)
+-			goto err_nh_grp_get;
+-
+-		fib_node->info.nh_grp->ref_cnt++;
+-		grp_id = fib_node->info.nh_grp->grp_id;
+-		break;
+-	default:
+-		MVSW_LOG_ERROR("Unsupported fib_type %d", fib_type);
+-		goto err_nh_grp_get;
+-	}
+-
+-
+-	err = prestera_lpm_add(sw, vr->hw_vr_id, &key->addr,
+-			       key->prefix_len, grp_id);
+-	if (err)
+-		goto err_lpm_add;
+-
+-	err = rhashtable_insert_fast(&sw->router->fib_ht, &fib_node->ht_node,
+-				     __mvsw_pr_fib_ht_params);
+-	if (err)
+-		goto err_ht_insert;
+-
+-	return fib_node;
+-
+-err_ht_insert:
+-	prestera_lpm_del(sw, vr->hw_vr_id, &key->addr, key->prefix_len);
+-err_lpm_add:
+-	if (fib_type == MVSW_PR_FIB_TYPE_UC_NH) {
+-		fib_node->info.nh_grp->ref_cnt--;
+-		mvsw_pr_nexthop_group_put(sw, fib_node->info.nh_grp);
+-	}
+-err_nh_grp_get:
+-	vr->ref_cnt--;
+-	mvsw_pr_vr_put(sw, vr);
+-err_vr_get:
+-	kfree(fib_node);
+-err_kzalloc:
+-	return NULL;
+-
+-}
+-
+ /* Decided, that uc_nh route with key==nh is obviously neighbour route */
+ static bool
+-mvsw_pr_fib_node_util_is_neighbour(struct mvsw_pr_fib_node *fib_node)
++mvsw_pr_fib_node_util_is_neighbour(struct prestera_fib_node *fib_node)
+ {
+-	if (fib_node->info.type != MVSW_PR_FIB_TYPE_UC_NH)
++	if (fib_node->info.type != PRESTERA_FIB_TYPE_UC_NH)
+ 		return false;
+ 
+ 	if (fib_node->info.nh_grp->nh_neigh_head[1].neigh)
+@@ -2586,8 +2149,8 @@ mvsw_pr_fib_node_util_is_neighbour(struct mvsw_pr_fib_node *fib_node)
+ 
+ static void mvsw_pr_router_fib_abort(struct prestera_switch *sw)
+ {
+-	mvsw_pr_vr_util_hw_abort(sw);
+-	mvsw_pr_fib_node_destroy_ht(sw);
++	prestera_vr_util_hw_abort(sw);
++	prestera_fib_node_destroy_ht(sw);
+ 	mvsw_pr_k_arb_abort(sw);
+ }
+ 
+@@ -2761,36 +2324,34 @@ static void mvsw_pr_router_fib_dump_flush(struct notifier_block *nb)
+ 	router = container_of(nb, struct prestera_router, fib_nb);
+ 	flush_workqueue(mvsw_r_owq);
+ 	flush_workqueue(mvsw_r_wq);
+-	mvsw_pr_fib_node_destroy_ht(router->sw);
++	prestera_fib_node_destroy_ht(router->sw);
+ }
+ 
+ static int
+-mvsw_pr_router_port_change(struct prestera_rif *rif)
++mvsw_pr_router_port_change(struct prestera_switch *sw,
++			   struct prestera_rif *rif)
+ {
+-	struct net_device *dev = rif->dev;
+ 	int err;
+ 
+-	err = mvsw_pr_rif_update(rif, dev->dev_addr);
++	err = mvsw_pr_rif_update(sw, rif);
+ 	if (err)
+ 		return err;
+ 
+-	ether_addr_copy(rif->addr, dev->dev_addr);
+-	rif->mtu = dev->mtu;
+-
+-	netdev_dbg(dev, "Updated RIF=%d\n", rif->rif_id);
++	netdev_dbg(rif->dev, "Update RIF\n");
+ 
+ 	return 0;
+ }
+ 
+ static int
+-mvsw_pr_router_port_pre_change(struct prestera_rif *rif,
++mvsw_pr_router_port_pre_change(struct prestera_switch *sw,
++			       struct prestera_rif *rif,
+ 			       struct netdev_notifier_pre_changeaddr_info *info)
+ {
+ 	struct netlink_ext_ack *extack;
+ 
+ 	extack = netdev_notifier_info_to_extack(&info->info);
+-	return mvsw_pr_router_port_check_rif_addr(rif->sw, rif->dev,
+-						  info->dev_addr, extack);
++	return mvsw_pr_router_port_check_rif_addr(sw, rif->dev, info->dev_addr,
++						  extack);
+ }
+ 
+ int prestera_netdevice_router_port_event(struct net_device *dev,
+@@ -2809,9 +2370,9 @@ int prestera_netdevice_router_port_event(struct net_device *dev,
+ 
+ 	switch (event) {
+ 	case NETDEV_CHANGEADDR:
+-		return mvsw_pr_router_port_change(rif);
++		return mvsw_pr_router_port_change(sw, rif);
+ 	case NETDEV_PRE_CHANGEADDR:
+-		return mvsw_pr_router_port_pre_change(rif, ptr);
++		return mvsw_pr_router_port_pre_change(sw, rif, ptr);
+ 	}
+ 
+ 	return 0;
+@@ -2832,7 +2393,7 @@ static int mvsw_pr_port_vrf_join(struct prestera_switch *sw,
+ 
+ 	__mvsw_pr_inetaddr_event(sw, dev, NETDEV_UP, extack);
+ 	rif = mvsw_pr_rif_find(sw, dev);
+-	return mvsw_pr_rif_vr_update(sw, rif, extack);
++	return mvsw_pr_rif_update(sw, rif);
+ }
+ 
+ static void mvsw_pr_port_vrf_leave(struct prestera_switch *sw,
+@@ -2850,7 +2411,7 @@ static void mvsw_pr_port_vrf_leave(struct prestera_switch *sw,
+ 
+ 	rif = mvsw_pr_rif_find(sw, dev);
+ 	if (rif)
+-		mvsw_pr_rif_vr_update(sw, rif, extack);
++		mvsw_pr_rif_update(sw, rif);
+ 
+ 	idev = __in_dev_get_rtnl(dev);
+ 	/* Restore rif in the default vrf: do so only if IF address's present*/
+@@ -2885,33 +2446,6 @@ int prestera_netdevice_vrf_event(struct net_device *dev, unsigned long event,
+ 	return err;
+ }
+ 
+-static int __mvsw_pr_rif_macvlan_flush(struct net_device *dev,
+-				       struct netdev_nested_priv *priv)
+-{
+-	struct prestera_rif *rif = priv->data;
+-
+-	if (!netif_is_macvlan(dev))
+-		return 0;
+-
+-	return mvsw_pr_rif_fdb_op(rif, dev->dev_addr, false);
+-}
+-
+-static int mvsw_pr_rif_macvlan_flush(struct prestera_rif *rif)
+-{
+-	struct netdev_nested_priv priv = {
+-		.data = (void *)rif,
+-	};
+-
+-	if (!netif_is_macvlan_port(rif->dev))
+-		return 0;
+-
+-	netdev_warn(rif->dev,
+-		    "Router interface is deleted. Upper macvlans will not work\n");
+-	return netdev_walk_all_upper_dev_rcu(rif->dev,
+-					     __mvsw_pr_rif_macvlan_flush,
+-					     &priv);
+-}
+-
+ #ifdef CONFIG_IP_ROUTE_MULTIPATH
+ static int mvsw_pr_mp_hash_init(struct prestera_switch *sw)
+ {
+@@ -2946,15 +2480,9 @@ int prestera_router_init(struct prestera_switch *sw)
+ 	if (err)
+ 		goto err_mp_hash_init;
+ 
+-	err = rhashtable_init(&router->nexthop_group_ht,
+-			      &__mvsw_pr_nexthop_group_ht_params);
+-	if (err)
+-		goto err_nexthop_grp_ht_init;
+-
+-	err = rhashtable_init(&router->fib_ht,
+-			      &__mvsw_pr_fib_ht_params);
++	err = prestera_router_hw_init(sw);
+ 	if (err)
+-		goto err_fib_ht_init;
++		goto err_router_lib_init;
+ 
+ 	err = rhashtable_init(&router->kern_fib_cache_ht,
+ 			      &__mvsw_pr_kern_fib_cache_ht_params);
+@@ -2972,7 +2500,6 @@ int prestera_router_init(struct prestera_switch *sw)
+ 		return -ENOMEM;
+ 
+ 	INIT_LIST_HEAD(&sw->router->rif_list);
+-	INIT_LIST_HEAD(&sw->router->vr_list);
+ 
+ 	mvsw_r_wq = alloc_workqueue(mvsw_driver_name, 0, 0);
+ 	if (!mvsw_r_wq) {
+@@ -2995,7 +2522,7 @@ int prestera_router_init(struct prestera_switch *sw)
+ 	if (err)
+ 		goto err_register_inetaddr_notifier;
+ 
+-	err = mvsw_pr_neigh_init(sw);
++	err = prestera_neigh_work_init(sw);
+ 	if (err)
+ 		goto err_neigh_init;
+ 
+@@ -3015,7 +2542,7 @@ int prestera_router_init(struct prestera_switch *sw)
+ err_register_fib_notifier:
+ 	unregister_netevent_notifier(&sw->router->netevent_nb);
+ err_register_netevent_notifier:
+-	mvsw_pr_neigh_fini(sw);
++	prestera_neigh_work_fini(sw);
+ err_neigh_init:
+ 	unregister_inetaddr_notifier(&router->inetaddr_nb);
+ err_register_inetaddr_notifier:
+@@ -3029,10 +2556,7 @@ int prestera_router_init(struct prestera_switch *sw)
+ err_kern_neigh_cache_ht_init:
+ 	rhashtable_destroy(&router->kern_fib_cache_ht);
+ err_kern_fib_cache_ht_init:
+-	rhashtable_destroy(&router->fib_ht);
+-err_fib_ht_init:
+-	rhashtable_destroy(&router->nexthop_group_ht);
+-err_nexthop_grp_ht_init:
++err_router_lib_init:
+ err_mp_hash_init:
+ 	kfree(sw->router);
+ 	return err;
+@@ -3043,8 +2567,14 @@ static void mvsw_pr_rifs_fini(struct prestera_switch *sw)
+ 	struct prestera_rif *rif, *tmp;
+ 
+ 	list_for_each_entry_safe(rif, tmp, &sw->router->rif_list, router_node) {
+-		rif->is_active = false;
+-		mvsw_pr_rif_destroy(rif);
++		/* We expect, that rif is holded by is_active.
++		 * ref_cnt must already became 0
++		 */
++		if (rif->ref_cnt || !rif->is_active) {
++			WARN_ON(1); /* BUG */
++			continue;
++		}
++		mvsw_pr_rif_destroy(sw, rif);
+ 	}
+ }
+ 
+@@ -3054,25 +2584,32 @@ void prestera_router_fini(struct prestera_switch *sw)
+ 	unregister_netevent_notifier(&sw->router->netevent_nb);
+ 	unregister_inetaddr_notifier(&sw->router->inetaddr_nb);
+ 	unregister_inetaddr_validator_notifier(&mvsw_pr_inetaddr_valid_nb);
+-	mvsw_pr_neigh_fini(sw);
++	prestera_neigh_work_fini(sw);
++	destroy_workqueue(mvsw_r_wq);
++	destroy_workqueue(mvsw_r_owq);
++
++	/* I not sure, that unregistering notifiers is enough to prevent
++	 * arbiter events... We can receive it, e.g. from bridge routine.
++	 * So hold rtnl_lock()
++	 */
++	/* prestera_switchdev_fini() flushing WQ without mvsw_owq_flush().
++	 * So lock rtnl here to prevent deadlock.
++	 */
++	rtnl_lock();
++
+ 	/* TODO: check if vrs necessary ? */
+-	mvsw_pr_rifs_fini(sw);
+ 	mvsw_pr_k_arb_abort(sw);
+-
++	mvsw_pr_rifs_fini(sw);
+ 	rhashtable_destroy(&sw->router->kern_neigh_cache_ht);
+ 	rhashtable_destroy(&sw->router->kern_fib_cache_ht);
+-	rhashtable_destroy(&sw->router->fib_ht);
+-	rhashtable_destroy(&sw->router->nexthop_group_ht);
+-
+-	flush_workqueue(mvsw_r_wq);
+-	flush_workqueue(mvsw_r_owq);
+-	destroy_workqueue(mvsw_r_wq);
+-	destroy_workqueue(mvsw_r_owq);
+-
+ 	WARN_ON(!list_empty(&sw->router->rif_list));
+ 
++	prestera_router_hw_fini(sw);
++
+ 	kfree(sw->router);
+ 	sw->router = NULL;
++
++	rtnl_unlock();
+ }
+ 
+ static u32 mvsw_pr_fix_tb_id(u32 tb_id)
+@@ -3085,91 +2622,53 @@ static u32 mvsw_pr_fix_tb_id(u32 tb_id)
+ 	return tb_id;
+ }
+ 
+-static struct mvsw_pr_vr *__mvsw_pr_vr_find(struct prestera_switch *sw,
+-					    u32 tb_id)
+-{
+-	struct mvsw_pr_vr *vr;
+-
+-	list_for_each_entry(vr, &sw->router->vr_list, router_node) {
+-		if (vr->tb_id == tb_id)
+-			return vr;
+-	}
+-
+-	return NULL;
+-}
+-
+-static struct mvsw_pr_vr *__mvsw_pr_vr_create(struct prestera_switch *sw,
+-					      u32 tb_id,
+-					      struct netlink_ext_ack *extack)
++static int
++__prestera_rif_macvlan_offload_cb(struct net_device *dev,
++				  struct netdev_nested_priv *priv)
+ {
+-	struct mvsw_pr_vr *vr;
+-	u16 hw_vr_id;
+-	int err;
+-
+-	err = mvsw_pr_hw_vr_create(sw, &hw_vr_id);
+-	if (err)
+-		return ERR_PTR(-ENOMEM);
+-
+-	vr = kzalloc(sizeof(*vr), GFP_KERNEL);
+-	if (!vr) {
+-		err = -ENOMEM;
+-		goto err_alloc_vr;
+-	}
+-
+-	vr->tb_id = tb_id;
+-	vr->hw_vr_id = hw_vr_id;
+-
+-	list_add(&vr->router_node, &sw->router->vr_list);
+-
+-	return vr;
++	struct prestera_rif_entry *re = priv->data;
++	struct prestera_switch *sw = prestera_switch_get(dev);
+ 
+-err_alloc_vr:
+-	mvsw_pr_hw_vr_delete(sw, hw_vr_id);
+-	kfree(vr);
+-	return ERR_PTR(err);
+-}
++	if (!netif_is_macvlan(dev))
++		return 0;
+ 
+-static void __mvsw_pr_vr_destroy(struct prestera_switch *sw,
+-				 struct mvsw_pr_vr *vr)
+-{
+-	mvsw_pr_hw_vr_delete(sw, vr->hw_vr_id);
+-	list_del(&vr->router_node);
+-	kfree(vr);
++	return prestera_rif_entry_set_macvlan(sw, re, true, dev->dev_addr);
+ }
+ 
+-static struct mvsw_pr_vr *mvsw_pr_vr_get(struct prestera_switch *sw, u32 tb_id,
+-					 struct netlink_ext_ack *extack)
++static int __prestera_rif_offload(struct prestera_switch *sw, bool replace,
++				  struct prestera_rif *rif)
+ {
+-	struct mvsw_pr_vr *vr;
++	struct prestera_rif_entry *re;
++	struct netdev_nested_priv priv;
+ 
+-	vr = __mvsw_pr_vr_find(sw, tb_id);
+-	if (!vr)
+-		vr = __mvsw_pr_vr_create(sw, tb_id, extack);
+-	if (IS_ERR(vr))
+-		return ERR_CAST(vr);
++	re = prestera_rif_entry_find(sw, &rif->rif_entry_key);
++	if (re)
++		prestera_rif_entry_destroy(sw, re);
+ 
+-	return vr;
+-}
++	if (!replace)
++		return 0;
+ 
+-static void mvsw_pr_vr_put(struct prestera_switch *sw, struct mvsw_pr_vr *vr)
+-{
+-	if (!vr->ref_cnt)
+-		__mvsw_pr_vr_destroy(sw, vr);
+-}
++	re = prestera_rif_entry_create(sw, &rif->rif_entry_key,
++				       mvsw_pr_fix_tb_id(rif->kern_tb_id),
++				       rif->addr);
++	if (!re)
++		return -EINVAL;
+ 
+-static void mvsw_pr_vr_util_hw_abort(struct prestera_switch *sw)
+-{
+-	struct mvsw_pr_vr *vr, *vr_tmp;
++	priv.data = re;
++	if (netdev_walk_all_upper_dev_rcu(rif->dev,
++					  __prestera_rif_macvlan_offload_cb,
++					  &priv)) {
++		prestera_rif_entry_destroy(sw, re);
++		return -ENOENT;
++	}
+ 
+-	list_for_each_entry_safe(vr, vr_tmp,
+-				 &sw->router->vr_list, router_node)
+-		mvsw_pr_hw_vr_abort(sw, vr->hw_vr_id);
++	return 0;
+ }
+ 
+-static struct prestera_rif*
+-mvsw_pr_rif_alloc(struct prestera_switch *sw,
+-		  struct mvsw_pr_vr *vr,
+-		  const struct mvsw_pr_rif_params *params)
++static struct prestera_rif *
++prestera_rif_create(struct prestera_switch *sw,
++		    const struct mvsw_pr_rif_params *params,
++		    struct netlink_ext_ack *extack)
+ {
+ 	struct prestera_rif *rif;
+ 	int err;
+@@ -3180,90 +2679,49 @@ mvsw_pr_rif_alloc(struct prestera_switch *sw,
+ 		goto err_rif_alloc;
+ 	}
+ 
+-	rif->sw = sw;
+-	rif->vr = vr;
+ 	rif->dev = params->dev;
+-	err = mvsw_pr_rif_iface_init(rif);
++	dev_hold(rif->dev);
++
++	err = prestera_dev2iface(sw, rif->dev, &rif->rif_entry_key.iface);
+ 	if (err)
+-		goto err_rif_iface_init;
++		goto err_dev2iface;
+ 
+ 	ether_addr_copy(rif->addr, params->dev->dev_addr);
+-	rif->mtu = params->dev->mtu;
++	rif->kern_tb_id = l3mdev_fib_table(params->dev);
+ 
+-	return rif;
+-
+-err_rif_iface_init:
+-	kfree(rif);
+-err_rif_alloc:
+-	return ERR_PTR(err);
+-}
+-
+-static int mvsw_pr_rif_offload(struct prestera_rif *rif)
+-{
+-	return mvsw_pr_hw_rif_create(rif->sw, &rif->iface, rif->addr,
+-				     &rif->rif_id);
+-}
+-
+-static struct prestera_rif *mvsw_pr_rif_create(struct prestera_switch *sw,
+-					       const struct mvsw_pr_rif_params
+-					       *params,
+-					       struct netlink_ext_ack *extack)
+-{
+-	u32 tb_id = mvsw_pr_fix_tb_id(l3mdev_fib_table(params->dev));
+-	struct prestera_rif *rif;
+-	struct mvsw_pr_vr *vr;
+-	int err;
+-
+-	vr = mvsw_pr_vr_get(sw, tb_id, extack);
+-	if (IS_ERR(vr))
+-		return ERR_CAST(vr);
+-
+-	rif = mvsw_pr_rif_alloc(sw, vr, params);
+-	if (IS_ERR(rif)) {
+-		mvsw_pr_vr_put(sw, vr);
+-		return rif;
+-	}
+-
+-	err = mvsw_pr_rif_offload(rif);
++	err = __prestera_rif_offload(sw, true, rif);
+ 	if (err)  {
+ 		NL_SET_ERR_MSG_MOD(extack,
+ 				   "Exceeded number of supported rifs");
+ 		goto err_rif_offload;
+ 	}
+ 
+-	vr->ref_cnt++;
+-	dev_hold(rif->dev);
+ 	list_add(&rif->router_node, &sw->router->rif_list);
+ 
+ 	return rif;
+ 
+ err_rif_offload:
++err_dev2iface:
++	dev_put(rif->dev);
+ 	kfree(rif);
++err_rif_alloc:
+ 	return ERR_PTR(err);
+ }
+ 
+-static int mvsw_pr_rif_delete(struct prestera_rif *rif)
+-{
+-	return mvsw_pr_hw_rif_delete(rif->sw, rif->rif_id, &rif->iface);
+-}
+-
+-static void mvsw_pr_rif_destroy(struct prestera_rif *rif)
++static void mvsw_pr_rif_destroy(struct prestera_switch *sw,
++				struct prestera_rif *rif)
+ {
+-	mvsw_pr_rif_macvlan_flush(rif);
+-	if (!rif->is_active) {
+-		mvsw_pr_rif_delete(rif);
+-		list_del(&rif->router_node);
+-		dev_put(rif->dev);
+-		rif->vr->ref_cnt--;
+-		mvsw_pr_vr_put(rif->sw, rif->vr);
+-		kfree(rif);
+-	}
++	list_del(&rif->router_node);
++	__prestera_rif_offload(sw, false, rif);
++	dev_put(rif->dev);
++	kfree(rif);
+ }
+ 
+-static void mvsw_pr_rif_put(struct prestera_rif *rif)
++static void mvsw_pr_rif_put(struct prestera_switch *sw,
++			    struct prestera_rif *rif)
+ {
+ 	if (!rif->ref_cnt && !rif->is_active)
+-		mvsw_pr_rif_destroy(rif);
++		mvsw_pr_rif_destroy(sw, rif);
+ }
+ 
+ void prestera_rif_enable(struct prestera_switch *sw,
+@@ -3275,36 +2733,15 @@ void prestera_rif_enable(struct prestera_switch *sw,
+ 	if (!rif)
+ 		return;
+ 
+-	if (enable)
+-		mvsw_pr_rif_offload(rif);
+-	else
+-		mvsw_pr_rif_delete(rif);
+-}
+-
+-static int mvsw_pr_rif_update(struct prestera_rif *rif, char *mac)
+-{
+-	return mvsw_pr_hw_rif_set(rif->sw, &rif->rif_id, &rif->iface, mac);
++	__prestera_rif_offload(sw, enable, rif);
+ }
+ 
+-static int mvsw_pr_rif_vr_update(struct prestera_switch *sw,
+-				 struct prestera_rif *rif,
+-				 struct netlink_ext_ack *extack)
++static int mvsw_pr_rif_update(struct prestera_switch *sw,
++			      struct prestera_rif *rif)
+ {
+-	u32 tb_id = mvsw_pr_fix_tb_id(l3mdev_fib_table(rif->dev));
+-	struct mvsw_pr_vr *vr;
+-
+-	rif->vr->ref_cnt--;
+-	mvsw_pr_rif_delete(rif);
+-	mvsw_pr_vr_put(sw, rif->vr);
+-	vr = mvsw_pr_vr_get(sw, tb_id, extack);
+-	if (IS_ERR(vr))
+-		return PTR_ERR(vr);
+-	rif->vr = vr;
+-	mvsw_pr_rif_iface_init(rif);
+-	mvsw_pr_rif_offload(rif);
+-	rif->vr->ref_cnt++;
+-
+-	return 0;
++	ether_addr_copy(rif->addr, rif->dev->dev_addr);
++	rif->kern_tb_id = l3mdev_fib_table(rif->dev);
++	return __prestera_rif_offload(sw, true, rif);
+ }
+ 
+ void prestera_router_lag_member_leave(const struct prestera_port *port,
+@@ -3317,7 +2754,7 @@ void prestera_router_lag_member_leave(const struct prestera_port *port,
+ 	if (!rif)
+ 		return;
+ 
+-	vr_id = mvsw_pr_rif_vr_id(rif);
++	vr_id = mvsw_pr_fix_tb_id(rif->kern_tb_id);
+ 	prestera_lag_member_rif_leave(port, port->lag_id, vr_id);
+ }
+ 
+@@ -3329,7 +2766,7 @@ void prestera_lag_router_leave(struct prestera_switch *sw,
+ 	rif = mvsw_pr_rif_find(sw, lag_dev);
+ 	if (rif) {
+ 		rif->is_active = false;
+-		mvsw_pr_rif_put(rif);
++		mvsw_pr_rif_put(sw, rif);
+ 	}
+ }
+ 
+@@ -3346,14 +2783,14 @@ static int mvsw_pr_bridge_device_rif_put(struct net_device *dev,
+ 		rif->is_active = false;
+ 		mvsw_pr_k_arb_rif_evt(sw, rif);
+ 		rif->ref_cnt--;
+-		mvsw_pr_rif_put(rif);
++		mvsw_pr_rif_put(sw, rif);
+ 	}
+ 
+ 	return 0;
+ }
+ 
+-void prestera_bridge_device_rifs_destroy(struct prestera_switch *sw,
+-					 struct net_device *bridge_dev)
++void prestera_bridge_rifs_destroy(struct prestera_switch *sw,
++				  struct net_device *bridge_dev)
+ {
+ 	struct netdev_nested_priv priv = {
+ 		.data = (void *)sw,
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_router_hw.c b/drivers/net/ethernet/marvell/prestera/prestera_router_hw.c
+new file mode 100644
+index 0000000..f41cc38
+--- /dev/null
++++ b/drivers/net/ethernet/marvell/prestera/prestera_router_hw.c
+@@ -0,0 +1,833 @@
++// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
++/* Copyright (c) 2019-2021 Marvell International Ltd. All rights reserved */
++
++#include <linux/rhashtable.h>
++
++#include "prestera.h"
++#include "prestera_log.h"
++#include "prestera_hw.h"
++#include "prestera_router_hw.h"
++#include "prestera_acl.h"
++
++/*
++ *                                Nexthop is pointed
++ *                                to port (not rif)
++ *                                +-------+
++ *                              +>|nexthop|<--+
++ *                              | +-------+   |
++ *                              |             |
++ *            +--+        +-----++         +--+------+
++ *   +------->|vr|<-+   +>|nh_grp|         |nh_mangle|<-+
++ *   |        +--+  |   | +------+         +---------+  |
++ *   |              |   |                               |
++ * +-+-------+   +--+---+-+                   +---------+----+
++ * |rif_entry|   |fib_node|                   |acl_rule_entry|
++ * +---------+   +--------+                   +--------------+
++ *  Rif is        Fib - is exit point
++ *  used as
++ *  entry point
++ *  for vr in hw
++ */
++
++#define PRESTERA_NHGR_UNUSED (0)
++#define PRESTERA_NHGR_DROP (0xFFFFFFFF)
++/* Need to merge it with router_manager */
++#define PRESTERA_NH_ACTIVE_JIFFER_FILTER 3000 /* ms */
++
++static const struct rhashtable_params __prestera_fib_ht_params = {
++	.key_offset  = offsetof(struct prestera_fib_node, key),
++	.head_offset = offsetof(struct prestera_fib_node, ht_node),
++	.key_len     = sizeof(struct prestera_fib_key),
++	.automatic_shrinking = true,
++};
++
++static const struct rhashtable_params __prestera_nh_neigh_ht_params = {
++	.key_offset  = offsetof(struct prestera_nh_neigh, key),
++	.key_len     = sizeof(struct prestera_nh_neigh_key),
++	.head_offset = offsetof(struct prestera_nh_neigh, ht_node),
++};
++
++static const struct rhashtable_params __prestera_nexthop_group_ht_params = {
++	.key_offset  = offsetof(struct prestera_nexthop_group, key),
++	.key_len     = sizeof(struct prestera_nexthop_group_key),
++	.head_offset = offsetof(struct prestera_nexthop_group, ht_node),
++};
++
++static int prestera_nexthop_group_set(struct prestera_switch *sw,
++				      struct prestera_nexthop_group *nh_grp);
++static bool
++prestera_nexthop_group_util_hw_state(struct prestera_switch *sw,
++				     struct prestera_nexthop_group *nh_grp);
++
++/* TODO: move to router.h as macros */
++static bool prestera_nh_neigh_key_is_valid(struct prestera_nh_neigh_key *key)
++{
++	return memchr_inv(key, 0, sizeof(*key)) ? true : false;
++}
++
++int prestera_router_hw_init(struct prestera_switch *sw)
++{
++	int err;
++
++	err = rhashtable_init(&sw->router->nh_neigh_ht,
++			      &__prestera_nh_neigh_ht_params);
++	if (err)
++		goto err_nh_neigh_ht_init;
++
++	err = rhashtable_init(&sw->router->nexthop_group_ht,
++			      &__prestera_nexthop_group_ht_params);
++	if (err)
++		goto err_nexthop_grp_ht_init;
++
++	err = rhashtable_init(&sw->router->fib_ht,
++			      &__prestera_fib_ht_params);
++	if (err)
++		goto err_fib_ht_init;
++
++	INIT_LIST_HEAD(&sw->router->vr_list);
++	INIT_LIST_HEAD(&sw->router->rif_entry_list);
++
++	return 0;
++
++err_fib_ht_init:
++	rhashtable_destroy(&sw->router->nexthop_group_ht);
++err_nexthop_grp_ht_init:
++	rhashtable_destroy(&sw->router->nh_neigh_ht);
++err_nh_neigh_ht_init:
++	return err;
++}
++
++void prestera_router_hw_fini(struct prestera_switch *sw)
++{
++	/* Ensure there is no objects */
++	prestera_fib_node_destroy_ht(sw);
++	/* Check if there can be nh_mangle ? */
++
++	rhashtable_destroy(&sw->router->nexthop_group_ht);
++	rhashtable_destroy(&sw->router->nh_neigh_ht);
++	rhashtable_destroy(&sw->router->fib_ht);
++
++	/* Sanity */
++	WARN_ON(!list_empty(&sw->router->rif_entry_list));
++	WARN_ON(!list_empty(&sw->router->vr_list));
++}
++
++static struct prestera_vr *__prestera_vr_find(struct prestera_switch *sw,
++					      u32 tb_id)
++{
++	struct prestera_vr *vr;
++
++	list_for_each_entry(vr, &sw->router->vr_list, router_node) {
++		if (vr->tb_id == tb_id)
++			return vr;
++	}
++
++	return NULL;
++}
++
++static struct prestera_vr *__prestera_vr_create(struct prestera_switch *sw,
++						u32 tb_id,
++						struct netlink_ext_ack *extack)
++{
++	struct prestera_vr *vr;
++	u16 hw_vr_id;
++	int err;
++
++	err = prestera_hw_vr_create(sw, &hw_vr_id);
++	if (err)
++		return ERR_PTR(-ENOMEM);
++
++	vr = kzalloc(sizeof(*vr), GFP_KERNEL);
++	if (!vr) {
++		err = -ENOMEM;
++		goto err_alloc_vr;
++	}
++
++	vr->tb_id = tb_id;
++	vr->hw_vr_id = hw_vr_id;
++
++	list_add(&vr->router_node, &sw->router->vr_list);
++
++	return vr;
++
++err_alloc_vr:
++	prestera_hw_vr_delete(sw, hw_vr_id);
++	kfree(vr);
++	return ERR_PTR(err);
++}
++
++static void __prestera_vr_destroy(struct prestera_switch *sw,
++				  struct prestera_vr *vr)
++{
++	prestera_hw_vr_delete(sw, vr->hw_vr_id);
++	list_del(&vr->router_node);
++	kfree(vr);
++}
++
++static struct prestera_vr *prestera_vr_get(struct prestera_switch *sw, u32 tb_id,
++					   struct netlink_ext_ack *extack)
++{
++	struct prestera_vr *vr;
++
++	vr = __prestera_vr_find(sw, tb_id);
++	if (!vr)
++		vr = __prestera_vr_create(sw, tb_id, extack);
++	if (IS_ERR(vr))
++		return ERR_CAST(vr);
++
++	return vr;
++}
++
++static void prestera_vr_put(struct prestera_switch *sw, struct prestera_vr *vr)
++{
++	if (!vr->ref_cnt)
++		__prestera_vr_destroy(sw, vr);
++}
++
++/* TODO: use router_hw_abort. Make this static */
++void prestera_vr_util_hw_abort(struct prestera_switch *sw)
++{
++	struct prestera_vr *vr, *vr_tmp;
++
++	list_for_each_entry_safe(vr, vr_tmp,
++				 &sw->router->vr_list, router_node)
++		prestera_hw_vr_abort(sw, vr->hw_vr_id);
++}
++
++/* make good things. iface is overhead struct... crutch
++ * TODO May be it must be union + vr_id should be removed
++ */
++static int
++__prestera_rif_entry_key_copy(const struct prestera_rif_entry_key *in,
++			      struct prestera_rif_entry_key *out)
++{
++	memset(out, 0, sizeof(*out));
++	out->iface.type = in->iface.type;
++
++	switch (out->iface.type) {
++	case PRESTERA_IF_PORT_E:
++		out->iface.dev_port.hw_dev_num = in->iface.dev_port.hw_dev_num;
++		out->iface.dev_port.port_num = in->iface.dev_port.port_num;
++		break;
++	case PRESTERA_IF_LAG_E:
++		out->iface.lag_id = in->iface.lag_id;
++		break;
++	case PRESTERA_IF_VID_E:
++		out->iface.vlan_id = in->iface.vlan_id;
++		break;
++	default:
++		pr_err("Unsupported iface type");
++		return -EINVAL;
++	}
++
++	return 0;
++}
++
++static int __prestera_rif_entry_macvlan_add(const struct prestera_switch *sw,
++					    struct prestera_rif_entry *e,
++					    const char *addr)
++{
++	int err;
++	struct prestera_rif_macvlan_list_node *n;
++
++	n = kzalloc(sizeof(*n), GFP_KERNEL);
++	if (!n) {
++		err = -ENOMEM;
++		goto err_kzalloc;
++	}
++
++	/* vr_id should be unused for this call. If we want to do something
++	 * with port (not vlan) - use port_rif_id to vid mapping on Agent side,
++	 * or use rif vid, received from Agent... Or we need not to add initial
++	 * mac address on rif creation. Why rif init MAC is deleted by index,
++	 * but macvlan deleted by MAC ?
++	 * Now it is inconsistent.
++	 */
++	err = prestera_hw_macvlan_add(sw, e->vr->hw_vr_id, addr,
++				      e->key.iface.vlan_id);
++	if (err)
++		goto err_hw;
++
++	memcpy(n->addr, addr, sizeof(n->addr));
++	list_add(&n->head, &e->macvlan_list);
++
++	return 0;
++
++err_hw:
++	kfree(n);
++err_kzalloc:
++	return err;
++}
++
++static void
++__prestera_rif_entry_macvlan_del(const struct prestera_switch *sw,
++				 struct prestera_rif_entry *e,
++				 struct prestera_rif_macvlan_list_node *n)
++{
++	int err;
++
++	err = prestera_hw_macvlan_del(sw, e->vr->hw_vr_id, n->addr,
++				      e->key.iface.vlan_id);
++	if (err)
++		pr_err("%s:%d failed to delete macvlan from hw err = %d",
++		       __func__, __LINE__, err);
++
++	list_del(&n->head);
++	kfree(n);
++}
++
++static void __prestera_rif_entry_macvlan_flush(const struct prestera_switch *sw,
++					       struct prestera_rif_entry *e)
++{
++	struct prestera_rif_macvlan_list_node *n, *tmp;
++
++	list_for_each_entry_safe(n, tmp, &e->macvlan_list, head)
++		__prestera_rif_entry_macvlan_del(sw, e, n);
++}
++
++int prestera_rif_entry_set_macvlan(const struct prestera_switch *sw,
++				   struct prestera_rif_entry *e,
++				   bool enable, const char *addr)
++{
++	struct prestera_rif_macvlan_list_node *n, *tmp;
++
++	list_for_each_entry_safe(n, tmp, &e->macvlan_list, head) {
++		if (!memcmp(n->addr, addr, sizeof(n->addr))) {
++			if (!enable)
++				__prestera_rif_entry_macvlan_del(sw, e, n);
++
++			return 0;
++		}
++	}
++
++	if (enable)
++		return __prestera_rif_entry_macvlan_add(sw, e, addr);
++
++	return 0;
++}
++
++struct prestera_rif_entry *
++prestera_rif_entry_find(const struct prestera_switch *sw,
++			const struct prestera_rif_entry_key *k)
++{
++	struct prestera_rif_entry *rif_entry;
++	struct prestera_rif_entry_key lk; /* lookup key */
++
++	if (__prestera_rif_entry_key_copy(k, &lk))
++		return NULL;
++
++	list_for_each_entry(rif_entry, &sw->router->rif_entry_list,
++			    router_node) {
++		if (!memcmp(k, &rif_entry->key, sizeof(*k)))
++			return rif_entry;
++	}
++
++	return NULL;
++}
++
++void prestera_rif_entry_destroy(struct prestera_switch *sw,
++				struct prestera_rif_entry *e)
++{
++	struct prestera_iface iface;
++
++	list_del(&e->router_node);
++
++	__prestera_rif_entry_macvlan_flush(sw, e);
++
++	memcpy(&iface, &e->key.iface, sizeof(iface));
++	iface.vr_id = e->vr->hw_vr_id;
++	prestera_hw_rif_delete(sw, e->hw_id, &iface);
++
++	e->vr->ref_cnt--;
++	prestera_vr_put(sw, e->vr);
++	kfree(e);
++}
++
++struct prestera_rif_entry *
++prestera_rif_entry_create(struct prestera_switch *sw,
++			  struct prestera_rif_entry_key *k,
++			  u32 tb_id, unsigned char *addr)
++{
++	int err;
++	struct prestera_rif_entry *e;
++	struct prestera_iface iface;
++
++	e = kzalloc(sizeof(*e), GFP_KERNEL);
++	if (!e)
++		goto err_kzalloc;
++
++	if (__prestera_rif_entry_key_copy(k, &e->key))
++		goto err_key_copy;
++
++	e->vr = prestera_vr_get(sw, tb_id, NULL);
++	if (IS_ERR(e->vr))
++		goto err_vr_get;
++
++	e->vr->ref_cnt++;
++	memcpy(&e->addr, addr, sizeof(e->addr));
++
++	/* HW */
++	memcpy(&iface, &e->key.iface, sizeof(iface));
++	iface.vr_id = e->vr->hw_vr_id;
++	err = prestera_hw_rif_create(sw, &iface, e->addr, &e->hw_id);
++	if (err)
++		goto err_hw_create;
++
++	INIT_LIST_HEAD(&e->macvlan_list);
++
++	list_add(&e->router_node, &sw->router->rif_entry_list);
++
++	return e;
++
++err_hw_create:
++	e->vr->ref_cnt--;
++	prestera_vr_put(sw, e->vr);
++err_vr_get:
++err_key_copy:
++	kfree(e);
++err_kzalloc:
++	return NULL;
++}
++
++static void __prestera_nh_neigh_destroy(struct prestera_switch *sw,
++					struct prestera_nh_neigh *neigh)
++{
++	rhashtable_remove_fast(&sw->router->nh_neigh_ht,
++			       &neigh->ht_node,
++			       __prestera_nh_neigh_ht_params);
++	kfree(neigh);
++}
++
++static struct prestera_nh_neigh *
++__prestera_nh_neigh_create(struct prestera_switch *sw,
++			   struct prestera_nh_neigh_key *key)
++{
++	struct prestera_nh_neigh *neigh;
++	int err;
++
++	neigh = kzalloc(sizeof(*neigh), GFP_KERNEL);
++	if (!neigh)
++		goto err_kzalloc;
++
++	memcpy(&neigh->key, key, sizeof(*key));
++	neigh->info.connected = false;
++	INIT_LIST_HEAD(&neigh->nexthop_group_list);
++	INIT_LIST_HEAD(&neigh->nh_mangle_entry_list);
++	err = rhashtable_insert_fast(&sw->router->nh_neigh_ht,
++				     &neigh->ht_node,
++				     __prestera_nh_neigh_ht_params);
++	if (err)
++		goto err_rhashtable_insert;
++
++	return neigh;
++
++err_rhashtable_insert:
++	kfree(neigh);
++err_kzalloc:
++	return NULL;
++}
++
++struct prestera_nh_neigh *
++prestera_nh_neigh_find(struct prestera_switch *sw,
++		       struct prestera_nh_neigh_key *key)
++{
++	struct prestera_nh_neigh *nh_neigh;
++
++	nh_neigh = rhashtable_lookup_fast(&sw->router->nh_neigh_ht,
++					  key, __prestera_nh_neigh_ht_params);
++	return IS_ERR(nh_neigh) ? NULL : nh_neigh;
++}
++
++struct prestera_nh_neigh *
++prestera_nh_neigh_get(struct prestera_switch *sw,
++		      struct prestera_nh_neigh_key *key)
++{
++	struct prestera_nh_neigh *neigh;
++
++	neigh = prestera_nh_neigh_find(sw, key);
++	if (!neigh)
++		return __prestera_nh_neigh_create(sw, key);
++
++	return neigh;
++}
++
++void prestera_nh_neigh_put(struct prestera_switch *sw,
++			   struct prestera_nh_neigh *neigh)
++{
++	if (list_empty(&neigh->nexthop_group_list) &&
++	    list_empty(&neigh->nh_mangle_entry_list))
++		__prestera_nh_neigh_destroy(sw, neigh);
++}
++
++/* Updates new prestera_neigh_info */
++int prestera_nh_neigh_set(struct prestera_switch *sw,
++			  struct prestera_nh_neigh *neigh)
++{
++	struct prestera_nh_neigh_head *nh_head;
++	struct prestera_nexthop_group *nh_grp;
++	struct prestera_nh_mangle_entry *nm;
++	int err;
++
++	list_for_each_entry(nh_head, &neigh->nexthop_group_list, head) {
++		nh_grp = nh_head->this;
++		err = prestera_nexthop_group_set(sw, nh_grp);
++		if (err)
++			return err;
++	}
++
++	list_for_each_entry(nm, &neigh->nh_mangle_entry_list, nh_neigh_head) {
++		err = prestera_nh_mangle_entry_set(sw, nm);
++		if (err)
++			return err;
++	}
++
++	return 0;
++}
++
++bool prestera_nh_neigh_util_hw_state(struct prestera_switch *sw,
++				     struct prestera_nh_neigh *nh_neigh)
++{
++	bool state;
++	struct prestera_nh_neigh_head *nh_head, *tmp;
++	struct prestera_nh_mangle_entry  *nm, *nm_tmp;
++
++	state = false;
++	list_for_each_entry_safe(nh_head, tmp,
++				 &nh_neigh->nexthop_group_list, head) {
++		state = prestera_nexthop_group_util_hw_state(sw, nh_head->this);
++		if (state)
++			goto out;
++	}
++	list_for_each_entry_safe(nm, nm_tmp, &nh_neigh->nh_mangle_entry_list,
++				 nh_neigh_head) {
++		state = prestera_nh_mangle_entry_util_hw_state(sw, nm);
++		if (state)
++			goto out;
++	}
++
++out:
++	return state;
++}
++
++static struct prestera_nexthop_group *
++__prestera_nexthop_group_create(struct prestera_switch *sw,
++				struct prestera_nexthop_group_key *key)
++{
++	struct prestera_nexthop_group *nh_grp;
++	struct prestera_nh_neigh *nh_neigh;
++	int nh_cnt, err, gid;
++
++	nh_grp = kzalloc(sizeof(*nh_grp), GFP_KERNEL);
++	if (!nh_grp)
++		goto err_kzalloc;
++
++	memcpy(&nh_grp->key, key, sizeof(*key));
++	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
++		if (!prestera_nh_neigh_key_is_valid(&nh_grp->key.neigh[nh_cnt]))
++			break;
++
++		nh_neigh = prestera_nh_neigh_get(sw,
++						 &nh_grp->key.neigh[nh_cnt]);
++		if (!nh_neigh)
++			goto err_nh_neigh_get;
++
++		nh_grp->nh_neigh_head[nh_cnt].neigh = nh_neigh;
++		nh_grp->nh_neigh_head[nh_cnt].this = nh_grp;
++		list_add(&nh_grp->nh_neigh_head[nh_cnt].head,
++			 &nh_neigh->nexthop_group_list);
++	}
++
++	err = prestera_nh_group_create(sw, nh_cnt, &nh_grp->grp_id);
++	if (err)
++		goto err_nh_group_create;
++
++	err = prestera_nexthop_group_set(sw, nh_grp);
++	if (err)
++		goto err_nexthop_group_set;
++
++	err = rhashtable_insert_fast(&sw->router->nexthop_group_ht,
++				     &nh_grp->ht_node,
++				     __prestera_nexthop_group_ht_params);
++	if (err)
++		goto err_ht_insert;
++
++	/* reset cache for created group */
++	gid = nh_grp->grp_id;
++	sw->router->nhgrp_hw_state_cache[gid / 8] &= ~BIT(gid % 8);
++
++	return nh_grp;
++
++err_ht_insert:
++err_nexthop_group_set:
++	prestera_nh_group_delete(sw, nh_cnt, nh_grp->grp_id);
++err_nh_group_create:
++err_nh_neigh_get:
++	for (nh_cnt--; nh_cnt >= 0; nh_cnt--) {
++		list_del(&nh_grp->nh_neigh_head[nh_cnt].head);
++		prestera_nh_neigh_put(sw, nh_grp->nh_neigh_head[nh_cnt].neigh);
++	}
++
++	kfree(nh_grp);
++err_kzalloc:
++	return NULL;
++}
++
++static void
++__prestera_nexthop_group_destroy(struct prestera_switch *sw,
++				 struct prestera_nexthop_group *nh_grp)
++{
++	struct prestera_nh_neigh *nh_neigh;
++	int nh_cnt;
++
++	rhashtable_remove_fast(&sw->router->nexthop_group_ht,
++			       &nh_grp->ht_node,
++			       __prestera_nexthop_group_ht_params);
++
++	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
++		nh_neigh = nh_grp->nh_neigh_head[nh_cnt].neigh;
++		if (!nh_neigh)
++			break;
++
++		list_del(&nh_grp->nh_neigh_head[nh_cnt].head);
++		prestera_nh_neigh_put(sw, nh_neigh);
++	}
++
++	prestera_nh_group_delete(sw, nh_cnt, nh_grp->grp_id);
++	kfree(nh_grp);
++}
++
++static struct prestera_nexthop_group *
++prestera_nexthop_group_find(struct prestera_switch *sw,
++			    struct prestera_nexthop_group_key *key)
++{
++	struct prestera_nexthop_group *nh_grp;
++
++	nh_grp = rhashtable_lookup_fast(&sw->router->nexthop_group_ht,
++					key, __prestera_nexthop_group_ht_params);
++	return IS_ERR(nh_grp) ? NULL : nh_grp;
++}
++
++static struct prestera_nexthop_group *
++prestera_nexthop_group_get(struct prestera_switch *sw,
++			   struct prestera_nexthop_group_key *key)
++{
++	struct prestera_nexthop_group *nh_grp;
++
++	nh_grp = prestera_nexthop_group_find(sw, key);
++	if (!nh_grp)
++		return __prestera_nexthop_group_create(sw, key);
++
++	return nh_grp;
++}
++
++static void prestera_nexthop_group_put(struct prestera_switch *sw,
++				       struct prestera_nexthop_group *nh_grp)
++{
++	if (!nh_grp->ref_cnt)
++		__prestera_nexthop_group_destroy(sw, nh_grp);
++}
++
++/* Updates with new nh_neigh's info */
++static int prestera_nexthop_group_set(struct prestera_switch *sw,
++				      struct prestera_nexthop_group *nh_grp)
++{
++	struct prestera_neigh_info info[PRESTERA_NHGR_SIZE_MAX];
++	struct prestera_nh_neigh *neigh;
++	int nh_cnt;
++
++	memset(&info[0], 0, sizeof(info));
++	for (nh_cnt = 0; nh_cnt < PRESTERA_NHGR_SIZE_MAX; nh_cnt++) {
++		neigh = nh_grp->nh_neigh_head[nh_cnt].neigh;
++		if (!neigh)
++			break;
++
++		memcpy(&info[nh_cnt], &neigh->info, sizeof(neigh->info));
++	}
++
++	return prestera_nh_entries_set(sw, nh_cnt, &info[0], nh_grp->grp_id);
++}
++
++static bool
++prestera_nexthop_group_util_hw_state(struct prestera_switch *sw,
++				     struct prestera_nexthop_group *nh_grp)
++{
++	int err;
++	u32 buf_size = sw->size_tbl_router_nexthop / 8 + 1;
++	u32 gid = nh_grp->grp_id;
++	u8 *cache = sw->router->nhgrp_hw_state_cache;
++
++	/* Antijitter
++	 * Prevent situation, when we read state of nh_grp twice in short time,
++	 * and state bit is still cleared on second call. So just stuck active
++	 * state for PRESTERA_NH_ACTIVE_JIFFER_FILTER, after last occurred.
++	 */
++	if (!time_before(jiffies, sw->router->nhgrp_hw_cache_kick +
++			msecs_to_jiffies(PRESTERA_NH_ACTIVE_JIFFER_FILTER))) {
++		err = prestera_nhgrp_blk_get(sw, cache, buf_size);
++		if (err) {
++			MVSW_LOG_ERROR("Failed to get hw state nh_grp's");
++			return false;
++		}
++
++		sw->router->nhgrp_hw_cache_kick = jiffies;
++	}
++
++	if (cache[gid / 8] & BIT(gid % 8))
++		return true;
++
++	return false;
++}
++
++/* TODO: Move fibs to another file (hw_match.c?) */
++struct prestera_fib_node *
++prestera_fib_node_find(struct prestera_switch *sw, struct prestera_fib_key *key)
++{
++	struct prestera_fib_node *fib_node;
++
++	fib_node = rhashtable_lookup_fast(&sw->router->fib_ht, key,
++					  __prestera_fib_ht_params);
++	return IS_ERR(fib_node) ? NULL : fib_node;
++}
++
++static void __prestera_fib_node_destruct(struct prestera_switch *sw,
++					 struct prestera_fib_node *fib_node)
++{
++	struct prestera_vr *vr;
++
++	vr = fib_node->info.vr;
++	prestera_lpm_del(sw, vr->hw_vr_id, &fib_node->key.addr,
++			 fib_node->key.prefix_len);
++	switch (fib_node->info.type) {
++	case PRESTERA_FIB_TYPE_UC_NH:
++		fib_node->info.nh_grp->ref_cnt--;
++		prestera_nexthop_group_put(sw, fib_node->info.nh_grp);
++		break;
++	case PRESTERA_FIB_TYPE_TRAP:
++		break;
++	case PRESTERA_FIB_TYPE_DROP:
++		break;
++	default:
++	      MVSW_LOG_ERROR("Unknown fib_node->info.type = %d",
++			     fib_node->info.type);
++	}
++
++	vr->ref_cnt--;
++	prestera_vr_put(sw, vr);
++}
++
++void prestera_fib_node_destroy(struct prestera_switch *sw,
++			       struct prestera_fib_node *fib_node)
++{
++	__prestera_fib_node_destruct(sw, fib_node);
++	rhashtable_remove_fast(&sw->router->fib_ht, &fib_node->ht_node,
++			       __prestera_fib_ht_params);
++	kfree(fib_node);
++}
++
++void prestera_fib_node_destroy_ht(struct prestera_switch *sw)
++{
++	struct prestera_fib_node *node, *tnode;
++	struct rhashtable_iter iter;
++
++	tnode = NULL;
++	rhashtable_walk_enter(&sw->router->fib_ht, &iter);
++	rhashtable_walk_start(&iter);
++	while (1) {
++		node = rhashtable_walk_next(&iter);
++		if (tnode) {
++			rhashtable_remove_fast(&sw->router->fib_ht,
++					       &tnode->ht_node,
++					       __prestera_fib_ht_params);
++			kfree(tnode);
++			tnode = NULL;
++		}
++
++		if (!node)
++			break;
++
++		if (IS_ERR(node))
++			continue;
++
++		rhashtable_walk_stop(&iter);
++		__prestera_fib_node_destruct(sw, node);
++		rhashtable_walk_start(&iter);
++		tnode = node;
++	}
++	rhashtable_walk_stop(&iter);
++	rhashtable_walk_exit(&iter);
++}
++
++/* nh_grp_key valid only if fib_type == MVSW_PR_FIB_TYPE_UC_NH */
++struct prestera_fib_node *
++prestera_fib_node_create(struct prestera_switch *sw,
++			 struct prestera_fib_key *key,
++			 enum prestera_fib_type fib_type,
++			 struct prestera_nexthop_group_key *nh_grp_key)
++{
++	struct prestera_fib_node *fib_node;
++	u32 grp_id;
++	struct prestera_vr *vr;
++	int err;
++
++	fib_node = kzalloc(sizeof(*fib_node), GFP_KERNEL);
++	if (!fib_node)
++		goto err_kzalloc;
++
++	memcpy(&fib_node->key, key, sizeof(*key));
++	fib_node->info.type = fib_type;
++
++	vr = prestera_vr_get(sw, key->tb_id, NULL);
++	if (IS_ERR(vr))
++		goto err_vr_get;
++
++	fib_node->info.vr = vr;
++	vr->ref_cnt++;
++
++	switch (fib_type) {
++	case PRESTERA_FIB_TYPE_TRAP:
++		grp_id = PRESTERA_NHGR_UNUSED;
++		break;
++	case PRESTERA_FIB_TYPE_DROP:
++		grp_id = PRESTERA_NHGR_DROP;
++		break;
++	case PRESTERA_FIB_TYPE_UC_NH:
++		fib_node->info.nh_grp = prestera_nexthop_group_get(sw,
++								   nh_grp_key);
++		if (!fib_node->info.nh_grp)
++			goto err_nh_grp_get;
++
++		fib_node->info.nh_grp->ref_cnt++;
++		grp_id = fib_node->info.nh_grp->grp_id;
++		break;
++	default:
++		MVSW_LOG_ERROR("Unsupported fib_type %d", fib_type);
++		goto err_nh_grp_get;
++	}
++
++	err = prestera_lpm_add(sw, vr->hw_vr_id, &key->addr,
++			       key->prefix_len, grp_id);
++	if (err)
++		goto err_lpm_add;
++
++	err = rhashtable_insert_fast(&sw->router->fib_ht, &fib_node->ht_node,
++				     __prestera_fib_ht_params);
++	if (err)
++		goto err_ht_insert;
++
++	return fib_node;
++
++err_ht_insert:
++	prestera_lpm_del(sw, vr->hw_vr_id, &key->addr, key->prefix_len);
++err_lpm_add:
++	if (fib_type == PRESTERA_FIB_TYPE_UC_NH) {
++		fib_node->info.nh_grp->ref_cnt--;
++		prestera_nexthop_group_put(sw, fib_node->info.nh_grp);
++	}
++err_nh_grp_get:
++	vr->ref_cnt--;
++	prestera_vr_put(sw, vr);
++err_vr_get:
++	kfree(fib_node);
++err_kzalloc:
++	return NULL;
++}
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_router_hw.h b/drivers/net/ethernet/marvell/prestera/prestera_router_hw.h
+new file mode 100644
+index 0000000..224bd07
+--- /dev/null
++++ b/drivers/net/ethernet/marvell/prestera/prestera_router_hw.h
+@@ -0,0 +1,119 @@
++/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
++/* Copyright (c) 2019-2021 Marvell International Ltd. All rights reserved. */
++
++#ifndef _PRESTERA_ROUTER_HW_H_
++#define _PRESTERA_ROUTER_HW_H_
++
++/* TODO: move structures, that not used from external to .c file */
++
++struct prestera_vr {
++	u16 hw_vr_id;			/* virtual router ID */
++	u32 tb_id;			/* key (kernel fib table id) */
++	struct list_head router_node;
++	unsigned int ref_cnt;
++};
++
++struct prestera_rif_macvlan_list_node {
++	struct list_head head;
++	unsigned char addr[ETH_ALEN];
++};
++
++/* Add port to vlan + FDB ... or only FDB for vlan */
++struct prestera_rif_entry {
++	struct prestera_rif_entry_key {
++		struct prestera_iface iface;
++	} key;
++	struct prestera_vr *vr;
++	unsigned char addr[ETH_ALEN];
++	struct list_head macvlan_list;
++	u16 hw_id; /* rif_id */
++	struct list_head router_node; /* ht */
++};
++
++struct prestera_nexthop_group {
++	struct prestera_nexthop_group_key key;
++	/* Store intermediate object here.
++	 * This prevent overhead kzalloc call.
++	 */
++	/* nh_neigh is used only to notify nexthop_group */
++	struct prestera_nh_neigh_head {
++		struct prestera_nexthop_group *this;
++		struct list_head head;
++		/* ptr to neigh is not necessary.
++		 * It used to prevent lookup of nh_neigh by key (n) on destroy
++		 */
++		struct prestera_nh_neigh *neigh;
++	} nh_neigh_head[PRESTERA_NHGR_SIZE_MAX];
++	u32 grp_id; /* hw */
++	struct rhash_head ht_node; /* node of prestera_vr */
++	unsigned int ref_cnt;
++};
++
++struct prestera_fib_key {
++	struct prestera_ip_addr addr;
++	u32 prefix_len;
++	u32 tb_id;
++};
++
++struct prestera_fib_info {
++	struct prestera_vr *vr;
++	struct list_head vr_node;
++	enum prestera_fib_type {
++		PRESTERA_FIB_TYPE_INVALID = 0,
++		/* must be pointer to nh_grp id */
++		PRESTERA_FIB_TYPE_UC_NH,
++		/* It can be connected route
++		 * and will be overlapped with neighbours
++		 */
++		PRESTERA_FIB_TYPE_TRAP,
++		PRESTERA_FIB_TYPE_DROP
++	} type;
++	/* Valid only if type = UC_NH*/
++	struct prestera_nexthop_group *nh_grp;
++};
++
++struct prestera_fib_node {
++	struct rhash_head ht_node; /* node of prestera_vr */
++	struct prestera_fib_key key;
++	struct prestera_fib_info info; /* action related info */
++};
++
++int prestera_rif_entry_set_macvlan(const struct prestera_switch *sw,
++				   struct prestera_rif_entry *e,
++				   bool enable, const char *addr);
++struct prestera_rif_entry *
++prestera_rif_entry_find(const struct prestera_switch *sw,
++			const struct prestera_rif_entry_key *k);
++void prestera_rif_entry_destroy(struct prestera_switch *sw,
++				struct prestera_rif_entry *e);
++struct prestera_rif_entry *
++prestera_rif_entry_create(struct prestera_switch *sw,
++			  struct prestera_rif_entry_key *k,
++			  u32 tb_id, unsigned char *addr);
++void prestera_vr_util_hw_abort(struct prestera_switch *sw);
++int prestera_router_hw_init(struct prestera_switch *sw);
++void prestera_router_hw_fini(struct prestera_switch *sw);
++struct prestera_nh_neigh *
++prestera_nh_neigh_find(struct prestera_switch *sw,
++		       struct prestera_nh_neigh_key *key);
++struct prestera_nh_neigh *
++prestera_nh_neigh_get(struct prestera_switch *sw,
++		      struct prestera_nh_neigh_key *key);
++void prestera_nh_neigh_put(struct prestera_switch *sw,
++			   struct prestera_nh_neigh *neigh);
++int prestera_nh_neigh_set(struct prestera_switch *sw,
++			  struct prestera_nh_neigh *neigh);
++bool prestera_nh_neigh_util_hw_state(struct prestera_switch *sw,
++				     struct prestera_nh_neigh *nh_neigh);
++struct prestera_fib_node *
++prestera_fib_node_find(struct prestera_switch *sw, struct prestera_fib_key *key);
++void prestera_fib_node_destroy(struct prestera_switch *sw,
++			       struct prestera_fib_node *fib_node);
++void prestera_fib_node_destroy_ht(struct prestera_switch *sw);
++struct prestera_fib_node *
++prestera_fib_node_create(struct prestera_switch *sw,
++			 struct prestera_fib_key *key,
++			 enum prestera_fib_type fib_type,
++			 struct prestera_nexthop_group_key *nh_grp_key);
++
++#endif /* _PRESTERA_ROUTER_HW_H_ */
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_rxtx.c b/drivers/net/ethernet/marvell/prestera/prestera_rxtx.c
+index 8c877aa..38aed5d 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_rxtx.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_rxtx.c
+@@ -684,7 +684,7 @@ static void mvsw_rxtx_handle_event(struct prestera_switch *sw,
+ {
+ 	struct mvsw_pr_rxtx_sdma *sdma = arg;
+ 
+-	if (evt->id != MVSW_RXTX_EVENT_RCV_PKT)
++	if (evt->id != PRESTERA_RXTX_EVENT_RCV_PKT)
+ 		return;
+ 
+ 	mvsw_reg_write(sdma->sw, SDMA_RX_INTR_MASK_REG, 0);
+@@ -709,7 +709,7 @@ int prestera_rxtx_switch_init(struct prestera_switch *sw)
+ 
+ 	sdma = &sw->rxtx->sdma;
+ 
+-	err = mvsw_pr_hw_rxtx_init(sw, true, &sdma->map_addr);
++	err = prestera_hw_rxtx_init(sw, true, &sdma->map_addr);
+ 	if (err) {
+ 		dev_err(sw->dev->dev, "failed to init rxtx by hw\n");
+ 		goto err_hw_rxtx_init;
+@@ -737,8 +737,8 @@ int prestera_rxtx_switch_init(struct prestera_switch *sw)
+ 		goto err_tx_init;
+ 	}
+ 
+-	err = mvsw_pr_hw_event_handler_register(sw, MVSW_EVENT_TYPE_RXTX,
+-						mvsw_rxtx_handle_event, sdma);
++	err = prestera_hw_event_handler_register(sw, PRESTERA_EVENT_TYPE_RXTX,
++						 mvsw_rxtx_handle_event, sdma);
+ 	if (err)
+ 		goto err_evt_register;
+ 
+@@ -768,7 +768,7 @@ void prestera_rxtx_switch_fini(struct prestera_switch *sw)
+ {
+ 	struct mvsw_pr_rxtx_sdma *sdma = &sw->rxtx->sdma;
+ 
+-	mvsw_pr_hw_event_handler_unregister(sw, MVSW_EVENT_TYPE_RXTX);
++	prestera_hw_event_handler_unregister(sw, PRESTERA_EVENT_TYPE_RXTX);
+ 	napi_disable(&sdma->rx_napi);
+ 	netif_napi_del(&sdma->rx_napi);
+ 	mvsw_sdma_rx_fini(sdma);
+@@ -878,7 +878,7 @@ netdev_tx_t prestera_rxtx_xmit(struct sk_buff *skb, struct prestera_port *port)
+ 
+ 	from_cpu->dst_iface.dev_port.port_num = port->hw_id;
+ 	from_cpu->dst_iface.dev_port.hw_dev_num = port->dev_id;
+-	from_cpu->dst_iface.type = MVSW_IF_PORT_E;
++	from_cpu->dst_iface.type = PRESTERA_IF_PORT_E;
+ 
+ 	/* epmorary removing due to issue with vlan sub interface
+ 	 * on 1.Q bridge
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_storm_control.c b/drivers/net/ethernet/marvell/prestera/prestera_storm_control.c
+index 173339b..3ddfd86 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_storm_control.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_storm_control.c
+@@ -69,26 +69,26 @@ static ssize_t storm_control_attr_store(struct device *dev,
+ 
+ 	if (!strcmp(attr->attr.name, "broadcast_kbyte_per_sec_rate")) {
+ 		attr_to_change = &sc_attr->bc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_BC;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_BC;
+ 	}
+ 
+ 	if (!strcmp(attr->attr.name, "unknown_unicast_kbyte_per_sec_rate")) {
+ 		attr_to_change = &sc_attr->unknown_uc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_UC_UNK;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_UC_UNK;
+ 	}
+ 
+ 	if (!strcmp(attr->attr.name,
+ 		    "unregistered_multicast_kbyte_per_sec_rate")) {
+ 		attr_to_change = &sc_attr->unreg_mc_kbyte_per_sec_rate;
+-		storm_type = MVSW_PORT_STORM_CTL_TYPE_MC;
++		storm_type = PRESTERA_PORT_STORM_CTL_TYPE_MC;
+ 	}
+ 
+ 	if (!attr_to_change)
+ 		return -EINVAL;
+ 
+ 	if (kbyte_per_sec_rate != *attr_to_change)
+-		ret = mvsw_pr_hw_port_storm_control_cfg_set(port, storm_type,
+-							    kbyte_per_sec_rate);
++		ret = prestera_hw_port_storm_control_cfg_set(port, storm_type,
++							     kbyte_per_sec_rate);
+ 	else
+ 		return size;
+ 
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_switchdev.c b/drivers/net/ethernet/marvell/prestera/prestera_switchdev.c
+index 7605203..5e635cd 100644
+--- a/drivers/net/ethernet/marvell/prestera/prestera_switchdev.c
++++ b/drivers/net/ethernet/marvell/prestera/prestera_switchdev.c
+@@ -13,18 +13,22 @@
+ #include <net/vxlan.h>
+ 
+ #include "prestera.h"
++#include "prestera_switchdev.h"
++#include "prestera_hw.h"
+ 
+-#define MVSW_PR_VID_ALL (0xffff)
++#define PRESTERA_VID_ALL (0xffff)
+ #define PRESTERA_DEFAULT_ISOLATION_SRCID 1 /* source_id */
+ 
+-struct prestera_bridge {
+-	struct prestera_switch *sw;
++struct prestera_switchdev {
++	struct notifier_block swdev_n;
++	struct notifier_block swdev_blocking_n;
++
+ 	u32 ageing_time;
+ 	struct list_head bridge_list;
+ 	bool bridge_8021q_exists;
+ };
+ 
+-struct prestera_bridge_device {
++struct prestera_bridge {
+ 	struct net_device *dev;
+ 	struct list_head bridge_node;
+ 	struct list_head port_list;
+@@ -36,65 +40,64 @@ struct prestera_bridge_device {
+ 
+ struct prestera_bridge_port {
+ 	struct net_device *dev;
+-	struct prestera_bridge_device *bridge_device;
+-	struct list_head bridge_device_node;
++	struct prestera_bridge *bridge;
++	struct list_head bridge_node;
+ 	struct list_head vlan_list;
+ 	unsigned int ref_count;
+ 	u8 stp_state;
+ 	unsigned long flags;
+ };
+ 
+-struct mvsw_pr_bridge_vlan {
++struct prestera_bridge_vlan {
+ 	struct list_head bridge_port_node;
+ 	struct list_head port_vlan_list;
+ 	u16 vid;
+ };
+ 
+-struct mvsw_pr_event_work {
++struct prestera_swdev_work {
+ 	struct work_struct work;
+ 	struct switchdev_notifier_fdb_info fdb_info;
+ 	struct net_device *dev;
+ 	unsigned long event;
+ };
+ 
+-static struct workqueue_struct *mvsw_owq;
++static struct workqueue_struct *swdev_owq;
+ 
+ static struct prestera_bridge_port *
+-mvsw_pr_bridge_port_get(struct prestera_bridge *bridge,
+-			struct net_device *brport_dev);
++prestera_bridge_port_get(struct prestera_switch *sw,
++			 struct net_device *brport_dev);
+ 
+-static void mvsw_pr_bridge_port_put(struct prestera_bridge *bridge,
+-				    struct prestera_bridge_port *br_port);
++static void prestera_bridge_port_put(struct prestera_switch *sw,
++				     struct prestera_bridge_port *br_port);
+ 
+-struct prestera_bridge_device *
+-prestera_bridge_device_find(const struct prestera_bridge *bridge,
+-			    const struct net_device *br_dev)
++static struct prestera_bridge *
++prestera_bridge_find(const struct prestera_switch *sw,
++		     const struct net_device *br_dev)
+ {
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 
+-	list_for_each_entry(bridge_device, &bridge->bridge_list,
++	list_for_each_entry(bridge, &sw->swdev->bridge_list,
+ 			    bridge_node)
+-		if (bridge_device->dev == br_dev)
+-			return bridge_device;
++		if (bridge->dev == br_dev)
++			return bridge;
+ 
+ 	return NULL;
+ }
+ 
+-static bool
+-mvsw_pr_bridge_device_is_offloaded(const struct prestera_switch *sw,
+-				   const struct net_device *br_dev)
++bool prestera_bridge_is_offloaded(const struct prestera_switch *sw,
++				  const struct net_device *br_dev)
+ {
+-	return !!prestera_bridge_device_find(sw->bridge, br_dev);
++	return !!prestera_bridge_find(sw, br_dev);
+ }
+ 
+ static struct prestera_bridge_port *
+-__mvsw_pr_bridge_port_find(const struct prestera_bridge_device *bridge_device,
+-			   const struct net_device *brport_dev)
++__prestera_bridge_port_find(const struct prestera_bridge *bridge,
++			    const struct net_device *brport_dev)
+ {
+ 	struct prestera_bridge_port *br_port;
+ 
+-	list_for_each_entry(br_port, &bridge_device->port_list,
+-			    bridge_device_node) {
++	list_for_each_entry(br_port, &bridge->port_list,
++			    bridge_node) {
+ 		if (br_port->dev == brport_dev)
+ 			return br_port;
+ 	}
+@@ -103,20 +106,20 @@ __mvsw_pr_bridge_port_find(const struct prestera_bridge_device *bridge_device,
+ }
+ 
+ static struct prestera_bridge_port *
+-mvsw_pr_bridge_port_find(struct prestera_bridge *bridge,
+-			 struct net_device *brport_dev)
++prestera_bridge_port_find(struct prestera_switch *sw,
++			  struct net_device *brport_dev)
+ {
+ 	struct net_device *br_dev = netdev_master_upper_dev_get(brport_dev);
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 
+ 	if (!br_dev)
+ 		return NULL;
+ 
+-	bridge_device = prestera_bridge_device_find(bridge, br_dev);
+-	if (!bridge_device)
++	bridge = prestera_bridge_find(sw, br_dev);
++	if (!bridge)
+ 		return NULL;
+ 
+-	return __mvsw_pr_bridge_port_find(bridge_device, brport_dev);
++	return __prestera_bridge_port_find(bridge, brport_dev);
+ }
+ 
+ static void
+@@ -132,11 +135,11 @@ prestera_br_port_flags_reset(struct prestera_bridge_port *br_port,
+ static int prestera_br_port_flags_set(struct prestera_bridge_port *br_port,
+ 				      struct prestera_port *port)
+ {
+-	struct prestera_bridge_device *br_dev;
++	struct prestera_bridge *br_dev;
+ 	u32 iso_srcid;
+ 	int err;
+ 
+-	br_dev = br_port->bridge_device;
++	br_dev = br_port->bridge;
+ 
+ 	err = prestera_port_uc_flood_set(port, br_port->flags & BR_FLOOD);
+ 	if (err)
+@@ -163,10 +166,10 @@ static int prestera_br_port_flags_set(struct prestera_bridge_port *br_port,
+ 	return err;
+ }
+ 
+-static struct mvsw_pr_bridge_vlan *
+-mvsw_pr_bridge_vlan_find(const struct prestera_bridge_port *br_port, u16 vid)
++static struct prestera_bridge_vlan *
++prestera_bridge_vlan_find(const struct prestera_bridge_port *br_port, u16 vid)
+ {
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_bridge_vlan *br_vlan;
+ 
+ 	list_for_each_entry(br_vlan, &br_port->vlan_list, bridge_port_node) {
+ 		if (br_vlan->vid == vid)
+@@ -176,20 +179,20 @@ mvsw_pr_bridge_vlan_find(const struct prestera_bridge_port *br_port, u16 vid)
+ 	return NULL;
+ }
+ 
+-u16 prestera_vlan_dev_vlan_id(struct prestera_bridge *bridge,
++u16 prestera_vlan_dev_vlan_id(struct prestera_switch *sw,
+ 			      struct net_device *dev)
+ {
+-	struct prestera_bridge_device *bridge_dev;
++	struct prestera_bridge *bridge_dev;
+ 
+-	bridge_dev = prestera_bridge_device_find(bridge, dev);
++	bridge_dev = prestera_bridge_find(sw, dev);
+ 
+ 	return bridge_dev ? bridge_dev->bridge_id : 0;
+ }
+ 
+-static struct mvsw_pr_bridge_vlan *
+-mvsw_pr_bridge_vlan_create(struct prestera_bridge_port *br_port, u16 vid)
++static struct prestera_bridge_vlan *
++prestera_bridge_vlan_create(struct prestera_bridge_port *br_port, u16 vid)
+ {
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_bridge_vlan *br_vlan;
+ 
+ 	br_vlan = kzalloc(sizeof(*br_vlan), GFP_KERNEL);
+ 	if (!br_vlan)
+@@ -203,38 +206,38 @@ mvsw_pr_bridge_vlan_create(struct prestera_bridge_port *br_port, u16 vid)
+ }
+ 
+ static void
+-mvsw_pr_bridge_vlan_destroy(struct mvsw_pr_bridge_vlan *br_vlan)
++prestera_bridge_vlan_destroy(struct prestera_bridge_vlan *br_vlan)
+ {
+ 	list_del(&br_vlan->bridge_port_node);
+ 	WARN_ON(!list_empty(&br_vlan->port_vlan_list));
+ 	kfree(br_vlan);
+ }
+ 
+-static struct mvsw_pr_bridge_vlan *
+-mvsw_pr_bridge_vlan_get(struct prestera_bridge_port *br_port, u16 vid)
++static struct prestera_bridge_vlan *
++prestera_bridge_vlan_get(struct prestera_bridge_port *br_port, u16 vid)
+ {
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_bridge_vlan *br_vlan;
+ 
+-	br_vlan = mvsw_pr_bridge_vlan_find(br_port, vid);
++	br_vlan = prestera_bridge_vlan_find(br_port, vid);
+ 	if (br_vlan)
+ 		return br_vlan;
+ 
+-	return mvsw_pr_bridge_vlan_create(br_port, vid);
++	return prestera_bridge_vlan_create(br_port, vid);
+ }
+ 
+-static void mvsw_pr_bridge_vlan_put(struct mvsw_pr_bridge_vlan *br_vlan)
++static void prestera_bridge_vlan_put(struct prestera_bridge_vlan *br_vlan)
+ {
+ 	if (list_empty(&br_vlan->port_vlan_list))
+-		mvsw_pr_bridge_vlan_destroy(br_vlan);
++		prestera_bridge_vlan_destroy(br_vlan);
+ }
+ 
+ static int
+-mvsw_pr_port_vlan_bridge_join(struct prestera_port_vlan *port_vlan,
+-			      struct prestera_bridge_port *br_port,
+-			      struct netlink_ext_ack *extack)
++prestera_port_vlan_bridge_join(struct prestera_port_vlan *port_vlan,
++			       struct prestera_bridge_port *br_port,
++			       struct netlink_ext_ack *extack)
+ {
+-	struct prestera_port *port = port_vlan->mvsw_pr_port;
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_port *port = port_vlan->port;
++	struct prestera_bridge_vlan *br_vlan;
+ 	u16 vid = port_vlan->vid;
+ 	int err;
+ 
+@@ -249,7 +252,7 @@ mvsw_pr_port_vlan_bridge_join(struct prestera_port_vlan *port_vlan,
+ 	if (err)
+ 		goto err_port_vid_stp_set;
+ 
+-	br_vlan = mvsw_pr_bridge_vlan_get(br_port, vid);
++	br_vlan = prestera_bridge_vlan_get(br_port, vid);
+ 	if (!br_vlan) {
+ 		err = -ENOMEM;
+ 		goto err_bridge_vlan_get;
+@@ -257,7 +260,7 @@ mvsw_pr_port_vlan_bridge_join(struct prestera_port_vlan *port_vlan,
+ 
+ 	list_add(&port_vlan->bridge_vlan_node, &br_vlan->port_vlan_list);
+ 
+-	mvsw_pr_bridge_port_get(port->sw->bridge, br_port->dev);
++	prestera_bridge_port_get(port->sw, br_port->dev);
+ 	port_vlan->bridge_port = br_port;
+ 
+ 	return 0;
+@@ -271,15 +274,14 @@ mvsw_pr_port_vlan_bridge_join(struct prestera_port_vlan *port_vlan,
+ }
+ 
+ static int
+-mvsw_pr_bridge_vlan_port_count_get(struct prestera_bridge_device *bridge_device,
+-				   u16 vid)
++prestera_bridge_vlan_port_count_get(struct prestera_bridge *bridge,
++				    u16 vid)
+ {
+ 	int count = 0;
+ 	struct prestera_bridge_port *br_port;
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_bridge_vlan *br_vlan;
+ 
+-	list_for_each_entry(br_port, &bridge_device->port_list,
+-			    bridge_device_node) {
++	list_for_each_entry(br_port, &bridge->port_list, bridge_node) {
+ 		list_for_each_entry(br_vlan, &br_port->vlan_list,
+ 				    bridge_port_node) {
+ 			if (br_vlan->vid == vid) {
+@@ -292,12 +294,42 @@ mvsw_pr_bridge_vlan_port_count_get(struct prestera_bridge_device *bridge_device,
+ 	return count;
+ }
+ 
++static int prestera_fdb_flush_vlan(struct prestera_switch *sw, u16 vid,
++				   enum prestera_fdb_flush_mode mode)
++{
++	return prestera_hw_fdb_flush_vlan(sw, vid, mode);
++}
++
++static int prestera_fdb_flush_port_vlan(struct prestera_port *port, u16 vid,
++					enum prestera_fdb_flush_mode mode)
++{
++	if (prestera_port_is_lag_member(port))
++		return prestera_hw_fdb_flush_lag_vlan(port->sw, port->lag_id,
++						      vid, mode);
++	else
++		return prestera_hw_fdb_flush_port_vlan(port, vid, mode);
++}
++
++static int prestera_fdb_flush_port(struct prestera_port *port,
++				   enum prestera_fdb_flush_mode mode)
++{
++	if (prestera_port_is_lag_member(port))
++		return prestera_hw_fdb_flush_lag(port->sw, port->lag_id, mode);
++	else
++		return prestera_hw_fdb_flush_port(port, mode);
++}
++
++int prestera_bridge_port_down(struct prestera_port *port)
++{
++	return prestera_fdb_flush_port(port, PRESTERA_FDB_FLUSH_MODE_DYNAMIC);
++}
++
+ void
+ prestera_port_vlan_bridge_leave(struct prestera_port_vlan *port_vlan)
+ {
+-	struct prestera_port *port = port_vlan->mvsw_pr_port;
+-	u32 mode = MVSW_PR_FDB_FLUSH_MODE_DYNAMIC;
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_port *port = port_vlan->port;
++	u32 mode = PRESTERA_FDB_FLUSH_MODE_DYNAMIC;
++	struct prestera_bridge_vlan *br_vlan;
+ 	struct prestera_bridge_port *br_port;
+ 	u16 vid = port_vlan->vid;
+ 	bool last_port, last_vlan;
+@@ -305,9 +337,8 @@ prestera_port_vlan_bridge_leave(struct prestera_port_vlan *port_vlan)
+ 
+ 	br_port = port_vlan->bridge_port;
+ 	last_vlan = list_is_singular(&br_port->vlan_list);
+-	port_count =
+-	    mvsw_pr_bridge_vlan_port_count_get(br_port->bridge_device, vid);
+-	br_vlan = mvsw_pr_bridge_vlan_find(br_port, vid);
++	port_count = prestera_bridge_vlan_port_count_get(br_port->bridge, vid);
++	br_vlan = prestera_bridge_vlan_find(br_port, vid);
+ 	last_port = port_count == 1;
+ 	if (last_vlan)
+ 		prestera_fdb_flush_port(port, mode);
+@@ -317,17 +348,17 @@ prestera_port_vlan_bridge_leave(struct prestera_port_vlan *port_vlan)
+ 		prestera_fdb_flush_port_vlan(port, vid, mode);
+ 
+ 	list_del(&port_vlan->bridge_vlan_node);
+-	mvsw_pr_bridge_vlan_put(br_vlan);
++	prestera_bridge_vlan_put(br_vlan);
+ 	prestera_port_vid_stp_set(port, vid, BR_STATE_FORWARDING);
+-	mvsw_pr_bridge_port_put(port->sw->bridge, br_port);
++	prestera_bridge_port_put(port->sw, br_port);
+ 	port_vlan->bridge_port = NULL;
+ }
+ 
+ static int
+-mvsw_pr_bridge_port_vlan_add(struct prestera_port *port,
+-			     struct prestera_bridge_port *br_port,
+-			     u16 vid, bool is_untagged, bool is_pvid,
+-			     struct netlink_ext_ack *extack)
++prestera_bridge_port_vlan_add(struct prestera_port *port,
++			      struct prestera_bridge_port *br_port,
++			      u16 vid, bool is_untagged, bool is_pvid,
++			      struct netlink_ext_ack *extack)
+ {
+ 	u16 pvid;
+ 	struct prestera_port_vlan *port_vlan;
+@@ -357,7 +388,7 @@ mvsw_pr_bridge_port_vlan_add(struct prestera_port *port,
+ 	if (err)
+ 		goto err_port_pvid_set;
+ 
+-	err = mvsw_pr_port_vlan_bridge_join(port_vlan, br_port, extack);
++	err = prestera_port_vlan_bridge_join(port_vlan, br_port, extack);
+ 	if (err)
+ 		goto err_port_vlan_bridge_join;
+ 
+@@ -373,16 +404,16 @@ mvsw_pr_bridge_port_vlan_add(struct prestera_port *port,
+ 	return err;
+ }
+ 
+-static int mvsw_pr_port_vlans_add(struct prestera_port *port,
+-				  const struct switchdev_obj_port_vlan *vlan,
+-				  struct switchdev_trans *trans,
+-				  struct netlink_ext_ack *extack)
++static int prestera_port_vlans_add(struct prestera_port *port,
++				   const struct switchdev_obj_port_vlan *vlan,
++				   struct switchdev_trans *trans,
++				   struct netlink_ext_ack *extack)
+ {
+ 	bool flag_untagged = vlan->flags & BRIDGE_VLAN_INFO_UNTAGGED;
+ 	bool flag_pvid = vlan->flags & BRIDGE_VLAN_INFO_PVID;
+ 	struct net_device *orig_dev = vlan->obj.orig_dev;
+ 	struct prestera_bridge_port *br_port;
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 	struct prestera_switch *sw = port->sw;
+ 	u16 vid;
+ 
+@@ -392,34 +423,34 @@ static int mvsw_pr_port_vlans_add(struct prestera_port *port,
+ 	if (switchdev_trans_ph_commit(trans))
+ 		return 0;
+ 
+-	br_port = mvsw_pr_bridge_port_find(sw->bridge, orig_dev);
++	br_port = prestera_bridge_port_find(sw, orig_dev);
+ 	if (WARN_ON(!br_port))
+ 		return -EINVAL;
+ 
+-	bridge_device = br_port->bridge_device;
+-	if (!bridge_device->vlan_enabled)
++	bridge = br_port->bridge;
++	if (!bridge->vlan_enabled)
+ 		return 0;
+ 
+ 	for (vid = vlan->vid_begin; vid <= vlan->vid_end; vid++) {
+ 		int err;
+ 
+-		err = mvsw_pr_bridge_port_vlan_add(port, br_port,
+-						   vid, flag_untagged,
+-						   flag_pvid, extack);
++		err = prestera_bridge_port_vlan_add(port, br_port,
++						    vid, flag_untagged,
++						    flag_pvid, extack);
+ 		if (err)
+ 			return err;
+ 	}
+ 
+-	if (list_is_singular(&bridge_device->port_list))
+-		prestera_rif_enable(port->sw, bridge_device->dev, true);
++	if (list_is_singular(&bridge->port_list))
++		prestera_rif_enable(port->sw, bridge->dev, true);
+ 
+ 	return 0;
+ }
+ 
+-static int mvsw_pr_port_obj_add(struct net_device *dev,
+-				const struct switchdev_obj *obj,
+-				struct switchdev_trans *trans,
+-				struct netlink_ext_ack *extack)
++static int prestera_port_obj_add(struct net_device *dev,
++				 const struct switchdev_obj *obj,
++				 struct switchdev_trans *trans,
++				 struct netlink_ext_ack *extack)
+ {
+ 	int err = 0;
+ 	struct prestera_port *port = netdev_priv(dev);
+@@ -428,7 +459,7 @@ static int mvsw_pr_port_obj_add(struct net_device *dev,
+ 	switch (obj->id) {
+ 	case SWITCHDEV_OBJ_ID_PORT_VLAN:
+ 		vlan = SWITCHDEV_OBJ_PORT_VLAN(obj);
+-		err = mvsw_pr_port_vlans_add(port, vlan, trans, extack);
++		err = prestera_port_vlans_add(port, vlan, trans, extack);
+ 		break;
+ 	default:
+ 		err = -EOPNOTSUPP;
+@@ -438,8 +469,8 @@ static int mvsw_pr_port_obj_add(struct net_device *dev,
+ }
+ 
+ static void
+-mvsw_pr_bridge_port_vlan_del(struct prestera_port *port,
+-			     struct prestera_bridge_port *br_port, u16 vid)
++prestera_bridge_port_vlan_del(struct prestera_port *port,
++			      struct prestera_bridge_port *br_port, u16 vid)
+ {
+ 	u16 pvid = port->pvid == vid ? 0 : port->pvid;
+ 	struct prestera_port_vlan *port_vlan;
+@@ -453,8 +484,8 @@ mvsw_pr_bridge_port_vlan_del(struct prestera_port *port,
+ 	prestera_port_vlan_destroy(port_vlan);
+ }
+ 
+-static int mvsw_pr_port_vlans_del(struct prestera_port *port,
+-				  const struct switchdev_obj_port_vlan *vlan)
++static int prestera_port_vlans_del(struct prestera_port *port,
++				   const struct switchdev_obj_port_vlan *vlan)
+ {
+ 	struct prestera_switch *sw = port->sw;
+ 	struct net_device *orig_dev = vlan->obj.orig_dev;
+@@ -464,29 +495,29 @@ static int mvsw_pr_port_vlans_del(struct prestera_port *port,
+ 	if (netif_is_bridge_master(orig_dev))
+ 		return -EOPNOTSUPP;
+ 
+-	br_port = mvsw_pr_bridge_port_find(sw->bridge, orig_dev);
++	br_port = prestera_bridge_port_find(sw, orig_dev);
+ 	if (WARN_ON(!br_port))
+ 		return -EINVAL;
+ 
+-	if (!br_port->bridge_device->vlan_enabled)
++	if (!br_port->bridge->vlan_enabled)
+ 		return 0;
+ 
+ 	for (vid = vlan->vid_begin; vid <= vlan->vid_end; vid++)
+-		mvsw_pr_bridge_port_vlan_del(port, br_port, vid);
++		prestera_bridge_port_vlan_del(port, br_port, vid);
+ 
+ 	return 0;
+ }
+ 
+-static int mvsw_pr_port_obj_del(struct net_device *dev,
+-				const struct switchdev_obj *obj)
++static int prestera_port_obj_del(struct net_device *dev,
++				 const struct switchdev_obj *obj)
+ {
+ 	int err = 0;
+ 	struct prestera_port *port = netdev_priv(dev);
+ 
+ 	switch (obj->id) {
+ 	case SWITCHDEV_OBJ_ID_PORT_VLAN:
+-		err = mvsw_pr_port_vlans_del(port,
+-					     SWITCHDEV_OBJ_PORT_VLAN(obj));
++		err = prestera_port_vlans_del(port,
++					      SWITCHDEV_OBJ_PORT_VLAN(obj));
+ 		break;
+ 	default:
+ 		err = -EOPNOTSUPP;
+@@ -496,40 +527,40 @@ static int mvsw_pr_port_obj_del(struct net_device *dev,
+ 	return err;
+ }
+ 
+-static int mvsw_pr_port_attr_br_vlan_set(struct prestera_port *port,
+-					 struct switchdev_trans *trans,
+-					 struct net_device *orig_dev,
+-					 bool vlan_enabled)
++static int prestera_port_attr_br_vlan_set(struct prestera_port *port,
++					  struct switchdev_trans *trans,
++					  struct net_device *orig_dev,
++					  bool vlan_enabled)
+ {
+ 	struct prestera_switch *sw = port->sw;
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 
+ 	if (!switchdev_trans_ph_prepare(trans))
+ 		return 0;
+ 
+-	bridge_device = prestera_bridge_device_find(sw->bridge, orig_dev);
+-	if (WARN_ON(!bridge_device))
++	bridge = prestera_bridge_find(sw, orig_dev);
++	if (WARN_ON(!bridge))
+ 		return -EINVAL;
+ 
+-	if (bridge_device->vlan_enabled == vlan_enabled)
++	if (bridge->vlan_enabled == vlan_enabled)
+ 		return 0;
+ 
+-	netdev_err(bridge_device->dev,
++	netdev_err(bridge->dev,
+ 		   "VLAN filtering can't be changed for existing bridge\n");
+ 	return -EINVAL;
+ }
+ 
+-static int mvsw_pr_port_attr_br_flags_set(struct prestera_port *port,
+-					  struct switchdev_trans *trans,
+-					  struct net_device *orig_dev,
+-					  unsigned long flags)
++static int prestera_port_attr_br_flags_set(struct prestera_port *port,
++					   struct switchdev_trans *trans,
++					   struct net_device *orig_dev,
++					   unsigned long flags)
+ {
+ 	struct prestera_bridge_port *br_port;
+ 
+ 	if (switchdev_trans_ph_prepare(trans))
+ 		return 0;
+ 
+-	br_port = mvsw_pr_bridge_port_find(port->sw->bridge, orig_dev);
++	br_port = prestera_bridge_port_find(port->sw, orig_dev);
+ 	if (!br_port)
+ 		return 0;
+ 
+@@ -537,9 +568,15 @@ static int mvsw_pr_port_attr_br_flags_set(struct prestera_port *port,
+ 	return prestera_br_port_flags_set(br_port, port);
+ }
+ 
+-static int mvsw_pr_port_attr_br_ageing_set(struct prestera_port *port,
+-					   struct switchdev_trans *trans,
+-					   unsigned long ageing_clock_t)
++static int prestera_switch_ageing_set(struct prestera_switch *sw,
++				      u32 ageing_time)
++{
++	return prestera_hw_switch_ageing_set(sw, ageing_time / 1000);
++}
++
++static int prestera_port_attr_br_ageing_set(struct prestera_port *port,
++					    struct switchdev_trans *trans,
++					    unsigned long ageing_clock_t)
+ {
+ 	int err;
+ 	struct prestera_switch *sw = port->sw;
+@@ -556,21 +593,21 @@ static int mvsw_pr_port_attr_br_ageing_set(struct prestera_port *port,
+ 
+ 	err = prestera_switch_ageing_set(sw, ageing_time);
+ 	if (!err)
+-		sw->bridge->ageing_time = ageing_time;
++		sw->swdev->ageing_time = ageing_time;
+ 
+ 	return err;
+ }
+ 
+ static int
+-mvsw_pr_port_bridge_vlan_stp_set(struct prestera_port *port,
+-				 struct mvsw_pr_bridge_vlan *br_vlan,
+-				 u8 state)
++prestera_port_bridge_vlan_stp_set(struct prestera_port *port,
++				  struct prestera_bridge_vlan *br_vlan,
++				  u8 state)
+ {
+ 	struct prestera_port_vlan *port_vlan;
+ 
+ 	list_for_each_entry(port_vlan, &br_vlan->port_vlan_list,
+ 			    bridge_vlan_node) {
+-		if (port_vlan->mvsw_pr_port != port)
++		if (port_vlan->port != port)
+ 			continue;
+ 		return prestera_port_vid_stp_set(port, br_vlan->vid, state);
+ 	}
+@@ -578,33 +615,33 @@ mvsw_pr_port_bridge_vlan_stp_set(struct prestera_port *port,
+ 	return 0;
+ }
+ 
+-static int mvsw_pr_port_attr_stp_state_set(struct prestera_port *port,
+-					   struct switchdev_trans *trans,
+-					   struct net_device *orig_dev,
+-					   u8 state)
++static int prestera_port_attr_stp_state_set(struct prestera_port *port,
++					    struct switchdev_trans *trans,
++					    struct net_device *orig_dev,
++					    u8 state)
+ {
+ 	struct prestera_bridge_port *br_port;
+-	struct mvsw_pr_bridge_vlan *br_vlan;
++	struct prestera_bridge_vlan *br_vlan;
+ 	int err;
+ 	u16 vid;
+ 
+ 	if (switchdev_trans_ph_prepare(trans))
+ 		return 0;
+ 
+-	br_port = mvsw_pr_bridge_port_find(port->sw->bridge, orig_dev);
++	br_port = prestera_bridge_port_find(port->sw, orig_dev);
+ 	if (!br_port)
+ 		return 0;
+ 
+-	if (!br_port->bridge_device->vlan_enabled) {
+-		vid = br_port->bridge_device->bridge_id;
++	if (!br_port->bridge->vlan_enabled) {
++		vid = br_port->bridge->bridge_id;
+ 		err = prestera_port_vid_stp_set(port, vid, state);
+ 		if (err)
+ 			goto err_port_bridge_stp_set;
+ 	} else {
+ 		list_for_each_entry(br_vlan, &br_port->vlan_list,
+ 				    bridge_port_node) {
+-			err = mvsw_pr_port_bridge_vlan_stp_set(port, br_vlan,
+-							       state);
++			err = prestera_port_bridge_vlan_stp_set(port, br_vlan,
++								state);
+ 			if (err)
+ 				goto err_port_bridge_vlan_stp_set;
+ 		}
+@@ -617,8 +654,8 @@ static int mvsw_pr_port_attr_stp_state_set(struct prestera_port *port,
+ err_port_bridge_vlan_stp_set:
+ 	list_for_each_entry_continue_reverse(br_vlan, &br_port->vlan_list,
+ 					     bridge_port_node)
+-		mvsw_pr_port_bridge_vlan_stp_set(port, br_vlan,
+-						 br_port->stp_state);
++		prestera_port_bridge_vlan_stp_set(port, br_vlan,
++						  br_port->stp_state);
+ 	return err;
+ 
+ err_port_bridge_stp_set:
+@@ -627,13 +664,13 @@ static int mvsw_pr_port_attr_stp_state_set(struct prestera_port *port,
+ 	return err;
+ }
+ 
+-static int mvsw_pr_port_attr_br_mc_disabled_set(struct prestera_port *port,
+-						struct switchdev_trans *trans,
+-						struct net_device *orig_dev,
+-						bool mc_disabled)
++static int prestera_port_attr_br_mc_disabled_set(struct prestera_port *port,
++						 struct switchdev_trans *trans,
++						 struct net_device *orig_dev,
++						 bool mc_disabled)
+ {
+ 	struct prestera_switch *sw = port->sw;
+-	struct prestera_bridge_device *br_dev;
++	struct prestera_bridge *br_dev;
+ 	struct prestera_bridge_port *br_port;
+ 	bool enabled = !mc_disabled;
+ 	int err;
+@@ -641,14 +678,14 @@ static int mvsw_pr_port_attr_br_mc_disabled_set(struct prestera_port *port,
+ 	if (!switchdev_trans_ph_prepare(trans))
+ 		return 0;
+ 
+-	br_dev = prestera_bridge_device_find(sw->bridge, orig_dev);
++	br_dev = prestera_bridge_find(sw, orig_dev);
+ 	if (!br_dev)
+ 		return 0;
+ 
+ 	if (br_dev->multicast_enabled == enabled)
+ 		return 0;
+ 
+-	list_for_each_entry(br_port, &br_dev->port_list, bridge_device_node) {
++	list_for_each_entry(br_port, &br_dev->port_list, bridge_node) {
+ 		err = prestera_port_mc_flood_set(netdev_priv(br_port->dev),
+ 						 enabled);
+ 		if (err)
+@@ -660,18 +697,18 @@ static int mvsw_pr_port_attr_br_mc_disabled_set(struct prestera_port *port,
+ 	return 0;
+ }
+ 
+-static int mvsw_pr_port_obj_attr_set(struct net_device *dev,
+-				     const struct switchdev_attr *attr,
+-				     struct switchdev_trans *trans)
++static int prestera_port_obj_attr_set(struct net_device *dev,
++				      const struct switchdev_attr *attr,
++				      struct switchdev_trans *trans)
+ {
+ 	int err = 0;
+ 	struct prestera_port *port = netdev_priv(dev);
+ 
+ 	switch (attr->id) {
+ 	case SWITCHDEV_ATTR_ID_PORT_STP_STATE:
+-		err = mvsw_pr_port_attr_stp_state_set(port, trans,
+-						      attr->orig_dev,
+-						      attr->u.stp_state);
++		err = prestera_port_attr_stp_state_set(port, trans,
++						       attr->orig_dev,
++						       attr->u.stp_state);
+ 		break;
+ 	case SWITCHDEV_ATTR_ID_PORT_PRE_BRIDGE_FLAGS:
+ 		if (attr->u.brport_flags &
+@@ -679,23 +716,23 @@ static int mvsw_pr_port_obj_attr_set(struct net_device *dev,
+ 			err = -EINVAL;
+ 		break;
+ 	case SWITCHDEV_ATTR_ID_PORT_BRIDGE_FLAGS:
+-		err = mvsw_pr_port_attr_br_flags_set(port, trans,
+-						     attr->orig_dev,
+-						     attr->u.brport_flags);
++		err = prestera_port_attr_br_flags_set(port, trans,
++						      attr->orig_dev,
++						      attr->u.brport_flags);
+ 		break;
+ 	case SWITCHDEV_ATTR_ID_BRIDGE_AGEING_TIME:
+-		err = mvsw_pr_port_attr_br_ageing_set(port, trans,
+-						      attr->u.ageing_time);
++		err = prestera_port_attr_br_ageing_set(port, trans,
++						       attr->u.ageing_time);
+ 		break;
+ 	case SWITCHDEV_ATTR_ID_BRIDGE_VLAN_FILTERING:
+-		err = mvsw_pr_port_attr_br_vlan_set(port, trans,
+-						    attr->orig_dev,
+-						    attr->u.vlan_filtering);
++		err = prestera_port_attr_br_vlan_set(port, trans,
++						     attr->orig_dev,
++						     attr->u.vlan_filtering);
+ 		break;
+ 	case SWITCHDEV_ATTR_ID_BRIDGE_MC_DISABLED:
+-		err = mvsw_pr_port_attr_br_mc_disabled_set(port, trans,
+-							   attr->orig_dev,
+-							   attr->u.mc_disabled);
++		err = prestera_port_attr_br_mc_disabled_set(port, trans,
++							    attr->orig_dev,
++							    attr->u.mc_disabled);
+ 		break;
+ 	default:
+ 		err = -EOPNOTSUPP;
+@@ -704,8 +741,9 @@ static int mvsw_pr_port_obj_attr_set(struct net_device *dev,
+ 	return err;
+ }
+ 
+-static void mvsw_fdb_offload_notify(struct prestera_port *port,
+-				    struct switchdev_notifier_fdb_info *info)
++static void
++prestera_fdb_offload_notify(struct prestera_port *port,
++			    struct switchdev_notifier_fdb_info *info)
+ {
+ 	struct switchdev_notifier_fdb_info send_info;
+ 	struct net_device *net_dev = port->net_dev;
+@@ -723,27 +761,49 @@ static void mvsw_fdb_offload_notify(struct prestera_port *port,
+ 				 net_dev, &send_info.info, NULL);
+ }
+ 
++static int prestera_fdb_add(struct prestera_port *port,
++			    const unsigned char *mac,
++			    u16 vid, bool dynamic)
++{
++	if (prestera_port_is_lag_member(port))
++		return prestera_hw_lag_fdb_add(port->sw, port->lag_id,
++					       mac, vid, dynamic);
++	else
++		return prestera_hw_fdb_add(port, mac, vid, dynamic);
++}
++
++static int prestera_fdb_del(struct prestera_port *port,
++			    const unsigned char *mac, u16 vid)
++{
++	if (prestera_port_is_lag_member(port))
++		return prestera_hw_lag_fdb_del(port->sw, port->lag_id,
++					       mac, vid);
++	else
++		return prestera_hw_fdb_del(port, mac, vid);
++}
++
+ static int
+-mvsw_pr_port_fdb_set(struct prestera_port *port,
+-		     struct switchdev_notifier_fdb_info *fdb_info, bool adding)
++prestera_port_fdb_set(struct prestera_port *port,
++		      struct switchdev_notifier_fdb_info *fdb_info,
++		      bool adding)
+ {
+ 	struct prestera_switch *sw = port->sw;
+ 	struct prestera_bridge_port *br_port;
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 	struct net_device *orig_dev = fdb_info->info.dev;
+ 	int err;
+ 	u16 vid;
+ 
+-	br_port = mvsw_pr_bridge_port_find(sw->bridge, orig_dev);
++	br_port = prestera_bridge_port_find(sw, orig_dev);
+ 	if (!br_port)
+ 		return -EINVAL;
+ 
+-	bridge_device = br_port->bridge_device;
++	bridge = br_port->bridge;
+ 
+-	if (bridge_device->vlan_enabled)
++	if (bridge->vlan_enabled)
+ 		vid = fdb_info->vid;
+ 	else
+-		vid = bridge_device->bridge_id;
++		vid = bridge->bridge_id;
+ 
+ 	if (adding)
+ 		err = prestera_fdb_add(port, fdb_info->addr, vid, false);
+@@ -753,12 +813,12 @@ mvsw_pr_port_fdb_set(struct prestera_port *port,
+ 	return err;
+ }
+ 
+-static void mvsw_pr_bridge_fdb_event_work(struct work_struct *work)
++static void prestera_bridge_fdb_event_work(struct work_struct *work)
+ {
+ 	int err = 0;
+-	struct mvsw_pr_event_work *switchdev_work =
+-	    container_of(work, struct mvsw_pr_event_work, work);
+-	struct net_device *dev = switchdev_work->dev;
++	struct prestera_swdev_work *swdev_work =
++	    container_of(work, struct prestera_swdev_work, work);
++	struct net_device *dev = swdev_work->dev;
+ 	struct switchdev_notifier_fdb_info *fdb_info;
+ 	struct prestera_port *port;
+ 
+@@ -770,19 +830,19 @@ static void mvsw_pr_bridge_fdb_event_work(struct work_struct *work)
+ 	if (!port)
+ 		goto out;
+ 
+-	switch (switchdev_work->event) {
++	switch (swdev_work->event) {
+ 	case SWITCHDEV_FDB_ADD_TO_DEVICE:
+-		fdb_info = &switchdev_work->fdb_info;
++		fdb_info = &swdev_work->fdb_info;
+ 		if (!fdb_info->added_by_user)
+ 			break;
+-		err = mvsw_pr_port_fdb_set(port, fdb_info, true);
++		err = prestera_port_fdb_set(port, fdb_info, true);
+ 		if (err)
+ 			break;
+-		mvsw_fdb_offload_notify(port, fdb_info);
++		prestera_fdb_offload_notify(port, fdb_info);
+ 		break;
+ 	case SWITCHDEV_FDB_DEL_TO_DEVICE:
+-		fdb_info = &switchdev_work->fdb_info;
+-		mvsw_pr_port_fdb_set(port, fdb_info, false);
++		fdb_info = &swdev_work->fdb_info;
++		prestera_port_fdb_set(port, fdb_info, false);
+ 		break;
+ 	case SWITCHDEV_FDB_ADD_TO_BRIDGE:
+ 	case SWITCHDEV_FDB_DEL_TO_BRIDGE:
+@@ -792,8 +852,8 @@ static void mvsw_pr_bridge_fdb_event_work(struct work_struct *work)
+ 
+ out:
+ 	rtnl_unlock();
+-	kfree(switchdev_work->fdb_info.addr);
+-	kfree(switchdev_work);
++	kfree(swdev_work->fdb_info.addr);
++	kfree(swdev_work);
+ 	dev_put(dev);
+ }
+ 
+@@ -802,7 +862,7 @@ static int prestera_switchdev_event(struct notifier_block *unused,
+ {
+ 	int err = 0;
+ 	struct net_device *net_dev = switchdev_notifier_info_to_dev(ptr);
+-	struct mvsw_pr_event_work *switchdev_work;
++	struct prestera_swdev_work *swdev_work;
+ 	struct switchdev_notifier_fdb_info *fdb_info;
+ 	struct switchdev_notifier_info *info = ptr;
+ 	struct net_device *upper_br;
+@@ -810,7 +870,7 @@ static int prestera_switchdev_event(struct notifier_block *unused,
+ 	if (event == SWITCHDEV_PORT_ATTR_SET) {
+ 		err = switchdev_handle_port_attr_set(net_dev, ptr,
+ 						     prestera_netdev_check,
+-						     mvsw_pr_port_obj_attr_set);
++						     prestera_port_obj_attr_set);
+ 		return notifier_from_errno(err);
+ 	}
+ 
+@@ -821,12 +881,12 @@ static int prestera_switchdev_event(struct notifier_block *unused,
+ 	if (!netif_is_bridge_master(upper_br))
+ 		return NOTIFY_DONE;
+ 
+-	switchdev_work = kzalloc(sizeof(*switchdev_work), GFP_ATOMIC);
+-	if (!switchdev_work)
++	swdev_work = kzalloc(sizeof(*swdev_work), GFP_ATOMIC);
++	if (!swdev_work)
+ 		return NOTIFY_BAD;
+ 
+-	switchdev_work->dev = net_dev;
+-	switchdev_work->event = event;
++	swdev_work->dev = net_dev;
++	swdev_work->event = event;
+ 
+ 	switch (event) {
+ 	case SWITCHDEV_FDB_ADD_TO_DEVICE:
+@@ -837,13 +897,13 @@ static int prestera_switchdev_event(struct notifier_block *unused,
+ 					struct switchdev_notifier_fdb_info,
+ 					info);
+ 
+-		INIT_WORK(&switchdev_work->work, mvsw_pr_bridge_fdb_event_work);
+-		memcpy(&switchdev_work->fdb_info, ptr,
+-		       sizeof(switchdev_work->fdb_info));
+-		switchdev_work->fdb_info.addr = kzalloc(ETH_ALEN, GFP_ATOMIC);
+-		if (!switchdev_work->fdb_info.addr)
++		INIT_WORK(&swdev_work->work, prestera_bridge_fdb_event_work);
++		memcpy(&swdev_work->fdb_info, ptr,
++		       sizeof(swdev_work->fdb_info));
++		swdev_work->fdb_info.addr = kzalloc(ETH_ALEN, GFP_ATOMIC);
++		if (!swdev_work->fdb_info.addr)
+ 			goto out;
+-		ether_addr_copy((u8 *)switchdev_work->fdb_info.addr,
++		ether_addr_copy((u8 *)swdev_work->fdb_info.addr,
+ 				fdb_info->addr);
+ 		dev_hold(net_dev);
+ 
+@@ -851,14 +911,14 @@ static int prestera_switchdev_event(struct notifier_block *unused,
+ 	case SWITCHDEV_VXLAN_FDB_ADD_TO_DEVICE:
+ 	case SWITCHDEV_VXLAN_FDB_DEL_TO_DEVICE:
+ 	default:
+-		kfree(switchdev_work);
++		kfree(swdev_work);
+ 		return NOTIFY_DONE;
+ 	}
+ 
+-	queue_work(mvsw_owq, &switchdev_work->work);
++	queue_work(swdev_owq, &swdev_work->work);
+ 	return NOTIFY_DONE;
+ out:
+-	kfree(switchdev_work);
++	kfree(swdev_work);
+ 	return NOTIFY_BAD;
+ }
+ 
+@@ -875,7 +935,7 @@ static int prestera_switchdev_blocking_event(struct notifier_block *unused,
+ 		} else {
+ 			err = switchdev_handle_port_obj_add
+ 			    (net_dev, ptr, prestera_netdev_check,
+-			     mvsw_pr_port_obj_add);
++			     prestera_port_obj_add);
+ 		}
+ 		break;
+ 	case SWITCHDEV_PORT_OBJ_DEL:
+@@ -884,13 +944,13 @@ static int prestera_switchdev_blocking_event(struct notifier_block *unused,
+ 		} else {
+ 			err = switchdev_handle_port_obj_del
+ 			    (net_dev, ptr, prestera_netdev_check,
+-			     mvsw_pr_port_obj_del);
++			     prestera_port_obj_del);
+ 		}
+ 		break;
+ 	case SWITCHDEV_PORT_ATTR_SET:
+ 		err = switchdev_handle_port_attr_set
+ 		    (net_dev, ptr, prestera_netdev_check,
+-		    mvsw_pr_port_obj_attr_set);
++		    prestera_port_obj_attr_set);
+ 		break;
+ 	default:
+ 		err = -EOPNOTSUPP;
+@@ -899,87 +959,83 @@ static int prestera_switchdev_blocking_event(struct notifier_block *unused,
+ 	return notifier_from_errno(err);
+ }
+ 
+-static struct prestera_bridge_device *
+-mvsw_pr_bridge_device_create(struct prestera_bridge *bridge,
+-			     struct net_device *br_dev)
++static struct prestera_bridge *
++prestera_bridge_create(struct prestera_switch *sw, struct net_device *br_dev)
+ {
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 	bool vlan_enabled = br_vlan_enabled(br_dev);
+ 	u16 bridge_id;
+ 	int err;
+ 
+-	if (vlan_enabled && bridge->bridge_8021q_exists) {
++	if (vlan_enabled && sw->swdev->bridge_8021q_exists) {
+ 		netdev_err(br_dev, "Only one VLAN-aware bridge is supported\n");
+ 		return ERR_PTR(-EINVAL);
+ 	}
+ 
+-	bridge_device = kzalloc(sizeof(*bridge_device), GFP_KERNEL);
+-	if (!bridge_device)
++	bridge = kzalloc(sizeof(*bridge), GFP_KERNEL);
++	if (!bridge)
+ 		return ERR_PTR(-ENOMEM);
+ 
+ 	if (vlan_enabled) {
+-		bridge->bridge_8021q_exists = true;
++		sw->swdev->bridge_8021q_exists = true;
+ 	} else {
+-		err = prestera_8021d_bridge_create(bridge->sw, &bridge_id);
++		err = prestera_hw_bridge_create(sw, &bridge_id);
+ 		if (err) {
+-			kfree(bridge_device);
++			kfree(bridge);
+ 			return ERR_PTR(err);
+ 		}
+ 
+-		bridge_device->bridge_id = bridge_id;
++		bridge->bridge_id = bridge_id;
+ 	}
+ 
+-	bridge_device->dev = br_dev;
+-	bridge_device->vlan_enabled = vlan_enabled;
+-	bridge_device->isolation_srcid = PRESTERA_DEFAULT_ISOLATION_SRCID;
+-	bridge_device->multicast_enabled = br_multicast_enabled(br_dev);
+-	bridge_device->mrouter = br_multicast_router(br_dev);
+-	INIT_LIST_HEAD(&bridge_device->port_list);
++	bridge->dev = br_dev;
++	bridge->vlan_enabled = vlan_enabled;
++	bridge->isolation_srcid = PRESTERA_DEFAULT_ISOLATION_SRCID;
++	bridge->multicast_enabled = br_multicast_enabled(br_dev);
++	bridge->mrouter = br_multicast_router(br_dev);
++	INIT_LIST_HEAD(&bridge->port_list);
+ 
+-	list_add(&bridge_device->bridge_node, &bridge->bridge_list);
++	list_add(&bridge->bridge_node, &sw->swdev->bridge_list);
+ 
+-	return bridge_device;
++	return bridge;
+ }
+ 
+ static void
+-mvsw_pr_bridge_device_destroy(struct prestera_bridge *bridge,
+-			      struct prestera_bridge_device *bridge_device)
++prestera_bridge_destroy(struct prestera_switch *sw,
++			struct prestera_bridge *bridge)
+ {
+-	list_del(&bridge_device->bridge_node);
+-	if (bridge_device->vlan_enabled)
+-		bridge->bridge_8021q_exists = false;
++	list_del(&bridge->bridge_node);
++	if (bridge->vlan_enabled)
++		sw->swdev->bridge_8021q_exists = false;
+ 	else
+-		prestera_8021d_bridge_delete(bridge->sw,
+-					     bridge_device->bridge_id);
++		prestera_hw_bridge_delete(sw, bridge->bridge_id);
+ 
+-	WARN_ON(!list_empty(&bridge_device->port_list));
+-	kfree(bridge_device);
++	WARN_ON(!list_empty(&bridge->port_list));
++	kfree(bridge);
+ }
+ 
+-static struct prestera_bridge_device *
+-mvsw_pr_bridge_device_get(struct prestera_bridge *bridge,
+-			  struct net_device *br_dev)
++static struct prestera_bridge *
++prestera_bridge_get(struct prestera_switch *sw, struct net_device *br_dev)
+ {
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 
+-	bridge_device = prestera_bridge_device_find(bridge, br_dev);
+-	if (bridge_device)
+-		return bridge_device;
++	bridge = prestera_bridge_find(sw, br_dev);
++	if (bridge)
++		return bridge;
+ 
+-	return mvsw_pr_bridge_device_create(bridge, br_dev);
++	return prestera_bridge_create(sw, br_dev);
+ }
+ 
+ static void
+-mvsw_pr_bridge_device_put(struct prestera_bridge *bridge,
+-			  struct prestera_bridge_device *bridge_device)
++prestera_bridge_put(struct prestera_switch *sw, struct prestera_bridge *bridge)
+ {
+-	if (list_empty(&bridge_device->port_list))
+-		mvsw_pr_bridge_device_destroy(bridge, bridge_device);
++	if (list_empty(&bridge->port_list))
++		prestera_bridge_destroy(sw, bridge);
+ }
+ 
+ static struct prestera_bridge_port *
+-mvsw_pr_bridge_port_create(struct prestera_bridge_device *bridge_device,
+-			   struct net_device *brport_dev)
++prestera_bridge_port_create(struct prestera_bridge *bridge,
++			    struct net_device *brport_dev)
+ {
+ 	struct prestera_bridge_port *br_port;
+ 	struct prestera_port *port;
+@@ -991,45 +1047,44 @@ mvsw_pr_bridge_port_create(struct prestera_bridge_device *bridge_device,
+ 	port = prestera_port_dev_lower_find(brport_dev);
+ 
+ 	br_port->dev = brport_dev;
+-	br_port->bridge_device = bridge_device;
++	br_port->bridge = bridge;
+ 	br_port->stp_state = BR_STATE_DISABLED;
+ 	br_port->flags = BR_LEARNING | BR_FLOOD | BR_LEARNING_SYNC |
+ 				BR_MCAST_FLOOD;
+ 	INIT_LIST_HEAD(&br_port->vlan_list);
+-	list_add(&br_port->bridge_device_node, &bridge_device->port_list);
++	list_add(&br_port->bridge_node, &bridge->port_list);
+ 	br_port->ref_count = 1;
+ 
+ 	return br_port;
+ }
+ 
+ static void
+-mvsw_pr_bridge_port_destroy(struct prestera_bridge_port *br_port)
++prestera_bridge_port_destroy(struct prestera_bridge_port *br_port)
+ {
+-	list_del(&br_port->bridge_device_node);
++	list_del(&br_port->bridge_node);
+ 	WARN_ON(!list_empty(&br_port->vlan_list));
+ 	kfree(br_port);
+ }
+ 
+ static struct prestera_bridge_port *
+-mvsw_pr_bridge_port_get(struct prestera_bridge *bridge,
+-			struct net_device *brport_dev)
++prestera_bridge_port_get(struct prestera_switch *sw, struct net_device *dev)
+ {
+-	struct net_device *br_dev = netdev_master_upper_dev_get(brport_dev);
+-	struct prestera_bridge_device *bridge_device;
++	struct net_device *br_dev = netdev_master_upper_dev_get(dev);
++	struct prestera_bridge *bridge;
+ 	struct prestera_bridge_port *br_port;
+ 	int err;
+ 
+-	br_port = mvsw_pr_bridge_port_find(bridge, brport_dev);
++	br_port = prestera_bridge_port_find(sw, dev);
+ 	if (br_port) {
+ 		br_port->ref_count++;
+ 		return br_port;
+ 	}
+ 
+-	bridge_device = mvsw_pr_bridge_device_get(bridge, br_dev);
+-	if (IS_ERR(bridge_device))
+-		return ERR_CAST(bridge_device);
++	bridge = prestera_bridge_get(sw, br_dev);
++	if (IS_ERR(bridge))
++		return ERR_CAST(bridge);
+ 
+-	br_port = mvsw_pr_bridge_port_create(bridge_device, brport_dev);
++	br_port = prestera_bridge_port_create(bridge, dev);
+ 	if (!br_port) {
+ 		err = -ENOMEM;
+ 		goto err_brport_create;
+@@ -1038,32 +1093,32 @@ mvsw_pr_bridge_port_get(struct prestera_bridge *bridge,
+ 	return br_port;
+ 
+ err_brport_create:
+-	mvsw_pr_bridge_device_put(bridge, bridge_device);
++	prestera_bridge_put(sw, bridge);
+ 	return ERR_PTR(err);
+ }
+ 
+-static void mvsw_pr_bridge_port_put(struct prestera_bridge *bridge,
+-				    struct prestera_bridge_port *br_port)
++static void prestera_bridge_port_put(struct prestera_switch *sw,
++				     struct prestera_bridge_port *br_port)
+ {
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 
+ 	if (--br_port->ref_count != 0)
+ 		return;
+-	bridge_device = br_port->bridge_device;
+-	mvsw_pr_bridge_port_destroy(br_port);
+-	if (list_empty(&bridge_device->port_list)) {
+-		prestera_rif_enable(bridge->sw, bridge_device->dev, false);
+-		prestera_bridge_device_rifs_destroy(bridge->sw,
+-						    bridge_device->dev);
++
++	bridge = br_port->bridge;
++	prestera_bridge_port_destroy(br_port);
++	if (list_empty(&bridge->port_list)) {
++		prestera_rif_enable(sw, bridge->dev, false);
++		prestera_bridge_rifs_destroy(sw, bridge->dev);
+ 	}
+-	mvsw_pr_bridge_device_put(bridge, bridge_device);
++	prestera_bridge_put(sw, bridge);
+ }
+ 
+ static int
+-mvsw_pr_bridge_8021q_port_join(struct prestera_bridge_device *bridge_device,
+-			       struct prestera_bridge_port *br_port,
+-			       struct prestera_port *port,
+-			       struct netlink_ext_ack *extack)
++prestera_bridge_8021q_port_join(struct prestera_bridge *bridge,
++				struct prestera_bridge_port *br_port,
++				struct prestera_port *port,
++				struct netlink_ext_ack *extack)
+ {
+ 	if (is_vlan_dev(br_port->dev)) {
+ 		NL_SET_ERR_MSG_MOD(extack,
+@@ -1075,10 +1130,10 @@ mvsw_pr_bridge_8021q_port_join(struct prestera_bridge_device *bridge_device,
+ }
+ 
+ static int
+-mvsw_pr_bridge_8021d_port_join(struct prestera_bridge_device *bridge_device,
+-			       struct prestera_bridge_port *br_port,
+-			       struct prestera_port *port,
+-			       struct netlink_ext_ack *extack)
++prestera_bridge_8021d_port_join(struct prestera_bridge *bridge,
++				struct prestera_bridge_port *br_port,
++				struct prestera_port *port,
++				struct netlink_ext_ack *extack)
+ {
+ 	int err;
+ 
+@@ -1087,7 +1142,7 @@ mvsw_pr_bridge_8021d_port_join(struct prestera_bridge_device *bridge_device,
+ 				   "Enslaving of a VLAN device is not supported");
+ 		return -ENOTSUPP;
+ 	}
+-	err = prestera_8021d_bridge_port_add(port, bridge_device->bridge_id);
++	err = prestera_hw_bridge_port_add(port, bridge->bridge_id);
+ 	if (err)
+ 		return err;
+ 
+@@ -1095,42 +1150,42 @@ mvsw_pr_bridge_8021d_port_join(struct prestera_bridge_device *bridge_device,
+ 	if (err)
+ 		goto err_flags2port_set;
+ 
+-	if (list_is_singular(&bridge_device->port_list))
+-		prestera_rif_enable(port->sw, bridge_device->dev, true);
++	if (list_is_singular(&bridge->port_list))
++		prestera_rif_enable(port->sw, bridge->dev, true);
+ 
+ 	return err;
+ 
+ err_flags2port_set:
+-	prestera_8021d_bridge_port_delete(port, bridge_device->bridge_id);
++	prestera_hw_bridge_port_delete(port, bridge->bridge_id);
+ 	return err;
+ }
+ 
+-static int mvsw_pr_port_bridge_join(struct prestera_port *port,
+-				    struct net_device *brport_dev,
+-				    struct net_device *br_dev,
+-				    struct netlink_ext_ack *extack)
++int prestera_port_bridge_join(struct prestera_port *port,
++			      struct net_device *brport_dev,
++			      struct net_device *br_dev,
++			      struct netlink_ext_ack *extack)
+ {
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 	struct prestera_switch *sw = port->sw;
+ 	struct prestera_bridge_port *br_port;
+ 	int err;
+ 
+-	br_port = mvsw_pr_bridge_port_get(sw->bridge, brport_dev);
++	br_port = prestera_bridge_port_get(sw, brport_dev);
+ 	if (IS_ERR(br_port))
+ 		return PTR_ERR(br_port);
+ 
+-	bridge_device = br_port->bridge_device;
++	bridge = br_port->bridge;
+ 
+ 	/* Enslaved port is not usable as a router interface */
+ 	if (prestera_rif_exists(sw, port->net_dev))
+ 		prestera_rif_enable(sw, port->net_dev, false);
+ 
+-	if (bridge_device->vlan_enabled) {
+-		err = mvsw_pr_bridge_8021q_port_join(bridge_device, br_port,
+-						     port, extack);
++	if (bridge->vlan_enabled) {
++		err = prestera_bridge_8021q_port_join(bridge, br_port,
++						      port, extack);
+ 	} else {
+-		err = mvsw_pr_bridge_8021d_port_join(bridge_device, br_port,
+-						     port, extack);
++		err = prestera_bridge_8021d_port_join(bridge, br_port,
++						      port, extack);
+ 	}
+ 
+ 	if (err)
+@@ -1139,51 +1194,51 @@ static int mvsw_pr_port_bridge_join(struct prestera_port *port,
+ 	return 0;
+ 
+ err_port_join:
+-	mvsw_pr_bridge_port_put(sw->bridge, br_port);
++	prestera_bridge_port_put(sw, br_port);
+ 	return err;
+ }
+ 
+ static void
+-mvsw_pr_bridge_8021d_port_leave(struct prestera_bridge_device *bridge_device,
+-				struct prestera_bridge_port *br_port,
+-				struct prestera_port *port)
++prestera_bridge_8021d_port_leave(struct prestera_bridge *bridge,
++				 struct prestera_bridge_port *br_port,
++				 struct prestera_port *port)
+ {
+-	prestera_fdb_flush_port(port, MVSW_PR_FDB_FLUSH_MODE_ALL);
+-	prestera_8021d_bridge_port_delete(port, bridge_device->bridge_id);
++	prestera_fdb_flush_port(port, PRESTERA_FDB_FLUSH_MODE_ALL);
++	prestera_hw_bridge_port_delete(port, bridge->bridge_id);
+ }
+ 
+ static void
+-mvsw_pr_bridge_8021q_port_leave(struct prestera_bridge_device *bridge_device,
+-				struct prestera_bridge_port *br_port,
+-				struct prestera_port *port)
++prestera_bridge_8021q_port_leave(struct prestera_bridge *bridge,
++				 struct prestera_bridge_port *br_port,
++				 struct prestera_port *port)
+ {
+-	prestera_fdb_flush_port(port, MVSW_PR_FDB_FLUSH_MODE_ALL);
++	prestera_fdb_flush_port(port, PRESTERA_FDB_FLUSH_MODE_ALL);
+ 	prestera_port_pvid_set(port, PRESTERA_DEFAULT_VID);
+ }
+ 
+-static void mvsw_pr_port_bridge_leave(struct prestera_port *port,
+-				      struct net_device *brport_dev,
+-				      struct net_device *br_dev)
++void prestera_port_bridge_leave(struct prestera_port *port,
++				struct net_device *brport_dev,
++				struct net_device *br_dev)
+ {
+ 	struct prestera_switch *sw = port->sw;
+-	struct prestera_bridge_device *bridge_device;
++	struct prestera_bridge *bridge;
+ 	struct prestera_bridge_port *br_port;
+ 
+-	bridge_device = prestera_bridge_device_find(sw->bridge, br_dev);
+-	if (!bridge_device)
++	bridge = prestera_bridge_find(sw, br_dev);
++	if (!bridge)
+ 		return;
+-	br_port = __mvsw_pr_bridge_port_find(bridge_device, brport_dev);
++	br_port = __prestera_bridge_port_find(bridge, brport_dev);
+ 	if (!br_port)
+ 		return;
+ 
+-	if (bridge_device->vlan_enabled)
+-		mvsw_pr_bridge_8021q_port_leave(bridge_device, br_port, port);
++	if (bridge->vlan_enabled)
++		prestera_bridge_8021q_port_leave(bridge, br_port, port);
+ 	else
+-		mvsw_pr_bridge_8021d_port_leave(bridge_device, br_port, port);
++		prestera_bridge_8021d_port_leave(bridge, br_port, port);
+ 
+ 	prestera_br_port_flags_reset(br_port, port);
+-	prestera_port_vid_stp_set(port, MVSW_PR_VID_ALL, BR_STATE_FORWARDING);
+-	mvsw_pr_bridge_port_put(sw->bridge, br_port);
++	prestera_port_vid_stp_set(port, PRESTERA_VID_ALL, BR_STATE_FORWARDING);
++	prestera_bridge_port_put(sw, br_port);
+ 
+ 	/* Offload rif that was previosly disabled */
+ 	if (prestera_rif_exists(sw, port->net_dev))
+@@ -1191,348 +1246,7 @@ static void mvsw_pr_port_bridge_leave(struct prestera_port *port,
+ 
+ }
+ 
+-static bool
+-prestera_lag_master_check(struct prestera_switch *sw,
+-			  struct net_device *lag_dev,
+-			  struct netdev_lag_upper_info *upper_info,
+-			  struct netlink_ext_ack *ext_ack)
+-{
+-	u16 lag_id;
+-
+-	if (prestera_lag_id_find(sw, lag_dev, &lag_id)) {
+-		NL_SET_ERR_MSG_MOD(ext_ack,
+-				   "Exceeded max supported LAG devices");
+-		return false;
+-	}
+-	if (upper_info->tx_type != NETDEV_LAG_TX_TYPE_HASH) {
+-		NL_SET_ERR_MSG_MOD(ext_ack, "Unsupported LAG Tx type");
+-		return false;
+-	}
+-	return true;
+-}
+-
+-static void mvsw_pr_port_lag_clean(struct prestera_port *port,
+-				   struct net_device *lag_dev)
+-{
+-	struct net_device *br_dev = netdev_master_upper_dev_get(lag_dev);
+-	struct prestera_port_vlan *port_vlan, *tmp;
+-	struct net_device *upper_dev;
+-	struct list_head *iter;
+-
+-	list_for_each_entry_safe(port_vlan, tmp, &port->vlans_list, list) {
+-		prestera_port_vlan_bridge_leave(port_vlan);
+-		prestera_port_vlan_destroy(port_vlan);
+-	}
+-
+-	if (netif_is_bridge_port(lag_dev))
+-		mvsw_pr_port_bridge_leave(port, lag_dev, br_dev);
+-
+-	netdev_for_each_upper_dev_rcu(lag_dev, upper_dev, iter) {
+-		if (!netif_is_bridge_port(upper_dev))
+-			continue;
+-		br_dev = netdev_master_upper_dev_get(upper_dev);
+-		mvsw_pr_port_bridge_leave(port, upper_dev, br_dev);
+-	}
+-
+-	prestera_port_pvid_set(port, PRESTERA_DEFAULT_VID);
+-}
+-
+-static int mvsw_pr_port_lag_join(struct prestera_port *port,
+-				 struct net_device *lag_dev)
+-{
+-	u16 lag_id;
+-	int err;
+-
+-	err = prestera_lag_id_find(port->sw, lag_dev, &lag_id);
+-	if (err)
+-		return err;
+-
+-	err = prestera_lag_member_add(port, lag_dev, lag_id);
+-		return err;
+-
+-	/* TODO: Port should no be longer usable as a router interface */
+-
+-	return 0;
+-}
+-
+-static void mvsw_pr_port_lag_leave(struct prestera_port *port,
+-				   struct net_device *lag_dev)
+-{
+-	prestera_router_lag_member_leave(port, lag_dev);
+-
+-	if (prestera_lag_member_del(port))
+-		return;
+-
+-	mvsw_pr_port_lag_clean(port, lag_dev);
+-}
+-
+-static int mvsw_pr_netdevice_port_upper_event(struct net_device *lower_dev,
+-					      struct net_device *dev,
+-					      unsigned long event, void *ptr)
+-{
+-	struct netdev_notifier_changeupper_info *info;
+-	struct prestera_port *port;
+-	struct netlink_ext_ack *extack;
+-	struct net_device *upper_dev;
+-	struct prestera_switch *sw;
+-	int err = 0;
+-
+-	port = netdev_priv(dev);
+-	sw = port->sw;
+-	info = ptr;
+-	extack = netdev_notifier_info_to_extack(&info->info);
+-
+-	switch (event) {
+-	case NETDEV_PRECHANGEUPPER:
+-		upper_dev = info->upper_dev;
+-		if (!netif_is_bridge_master(upper_dev) &&
+-		    !netif_is_lag_master(upper_dev) &&
+-		    !netif_is_macvlan(upper_dev)) {
+-			NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
+-			return -EINVAL;
+-		}
+-		if (!info->linking)
+-			break;
+-		if (netdev_has_any_upper_dev(upper_dev) &&
+-		    (!netif_is_bridge_master(upper_dev) ||
+-		     !mvsw_pr_bridge_device_is_offloaded(sw, upper_dev))) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "Enslaving a port to a device that already has an upper device is not supported");
+-			return -EINVAL;
+-		}
+-		if (netif_is_lag_master(upper_dev) &&
+-		    !prestera_lag_master_check(sw, upper_dev,
+-					      info->upper_info, extack))
+-			return -EINVAL;
+-		if (netif_is_lag_master(upper_dev) && vlan_uses_dev(dev)) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "Master device is a LAG master and port has a VLAN");
+-			return -EINVAL;
+-		}
+-		if (netif_is_lag_port(dev) && is_vlan_dev(upper_dev) &&
+-		    !netif_is_lag_master(vlan_dev_real_dev(upper_dev))) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "Can not put a VLAN on a LAG port");
+-			return -EINVAL;
+-		}
+-		if (netif_is_macvlan(upper_dev) &&
+-		    !prestera_rif_exists(sw, lower_dev)) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "macvlan is only supported on top of router interfaces");
+-			return -EOPNOTSUPP;
+-		}
+-		break;
+-	case NETDEV_CHANGEUPPER:
+-		upper_dev = info->upper_dev;
+-		if (netif_is_bridge_master(upper_dev)) {
+-			if (info->linking)
+-				err = mvsw_pr_port_bridge_join(port,
+-							       lower_dev,
+-							       upper_dev,
+-							       extack);
+-			else
+-				mvsw_pr_port_bridge_leave(port,
+-							  lower_dev,
+-							  upper_dev);
+-		} else if (netif_is_lag_master(upper_dev)) {
+-			if (info->linking)
+-				err = mvsw_pr_port_lag_join(port,
+-							    upper_dev);
+-			else
+-				mvsw_pr_port_lag_leave(port,
+-						       upper_dev);
+-		}
+-		break;
+-	}
+-
+-	return err;
+-}
+-
+-static int mvsw_pr_netdevice_port_lower_event(struct net_device *dev,
+-					      unsigned long event, void *ptr)
+-{
+-	struct netdev_notifier_changelowerstate_info *info = ptr;
+-	struct netdev_lag_lower_state_info *lower_state_info;
+-	struct prestera_port *port = netdev_priv(dev);
+-	bool enabled;
+-
+-	if (event != NETDEV_CHANGELOWERSTATE)
+-		return 0;
+-	if (!netif_is_lag_port(dev))
+-		return 0;
+-	if (!prestera_port_is_lag_member(port))
+-		return 0;
+-
+-	lower_state_info = info->lower_state_info;
+-	enabled = lower_state_info->tx_enabled;
+-	return prestera_lag_member_enable(port, enabled);
+-}
+-
+-static int mvsw_pr_netdevice_port_event(struct net_device *lower_dev,
+-					struct net_device *port_dev,
+-					unsigned long event, void *ptr)
+-{
+-	switch (event) {
+-	case NETDEV_PRECHANGEUPPER:
+-	case NETDEV_CHANGEUPPER:
+-		return mvsw_pr_netdevice_port_upper_event(lower_dev, port_dev,
+-							  event, ptr);
+-	case NETDEV_CHANGELOWERSTATE:
+-		return mvsw_pr_netdevice_port_lower_event(port_dev,
+-							  event, ptr);
+-	}
+-
+-	return 0;
+-}
+-
+-static int mvsw_pr_netdevice_bridge_event(struct net_device *br_dev,
+-					  unsigned long event, void *ptr)
+-{
+-	struct prestera_switch *sw = prestera_switch_get(br_dev);
+-	struct netdev_notifier_changeupper_info *info = ptr;
+-	struct netlink_ext_ack *extack;
+-	struct net_device *upper_dev;
+-
+-	if (!sw)
+-		return 0;
+-
+-	extack = netdev_notifier_info_to_extack(&info->info);
+-
+-	switch (event) {
+-	case NETDEV_PRECHANGEUPPER:
+-		upper_dev = info->upper_dev;
+-		if (!is_vlan_dev(upper_dev) && !netif_is_macvlan(upper_dev)) {
+-			NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
+-			return -EOPNOTSUPP;
+-		}
+-		if (!info->linking)
+-			break;
+-		if (netif_is_macvlan(upper_dev) &&
+-		    !prestera_rif_exists(sw, br_dev)) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "macvlan is only supported on top of router interfaces");
+-			return -EOPNOTSUPP;
+-		}
+-		break;
+-	case NETDEV_CHANGEUPPER:
+-		/* TODO:  */
+-		break;
+-	}
+-
+-	return 0;
+-}
+-
+-static int mvsw_pr_netdevice_macvlan_event(struct net_device *macvlan_dev,
+-					   unsigned long event, void *ptr)
+-{
+-	struct prestera_switch *sw = prestera_switch_get(macvlan_dev);
+-	struct netdev_notifier_changeupper_info *info = ptr;
+-	struct netlink_ext_ack *extack;
+-
+-	if (!sw || event != NETDEV_PRECHANGEUPPER)
+-		return 0;
+-
+-	extack = netdev_notifier_info_to_extack(&info->info);
+-
+-	NL_SET_ERR_MSG_MOD(extack, "Unknown upper device type");
+-
+-	return -EOPNOTSUPP;
+-}
+-
+-static bool mvsw_pr_is_vrf_event(unsigned long event, void *ptr)
+-{
+-	struct netdev_notifier_changeupper_info *info = ptr;
+-
+-	if (event != NETDEV_PRECHANGEUPPER && event != NETDEV_CHANGEUPPER)
+-		return false;
+-
+-	return netif_is_l3_master(info->upper_dev);
+-}
+-
+-static int mvsw_pr_netdevice_lag_event(struct net_device *lag_dev,
+-				       unsigned long event, void *ptr)
+-{
+-	struct net_device *dev;
+-	struct list_head *iter;
+-	int err;
+-
+-	netdev_for_each_lower_dev(lag_dev, dev, iter) {
+-		if (prestera_netdev_check(dev)) {
+-			err = mvsw_pr_netdevice_port_event(lag_dev, dev, event,
+-							   ptr);
+-			if (err)
+-				return err;
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+-static int mvsw_pr_netdevice_vlan_event(struct net_device *vlan_dev,
+-					unsigned long event, void *ptr)
+-{
+-	struct net_device *real_dev = vlan_dev_real_dev(vlan_dev);
+-	struct prestera_switch *sw = prestera_switch_get(real_dev);
+-	struct netdev_notifier_changeupper_info *info = ptr;
+-	struct netlink_ext_ack *extack;
+-	struct net_device *upper_dev;
+-
+-	if (!sw)
+-		return 0;
+-
+-	extack = netdev_notifier_info_to_extack(&info->info);
+-
+-	switch (event) {
+-	case NETDEV_PRECHANGEUPPER:
+-		upper_dev = info->upper_dev;
+-
+-		if (!info->linking)
+-			break;
+-
+-		if (mvsw_pr_bridge_device_is_offloaded(sw, real_dev) &&
+-		    netif_is_bridge_master(upper_dev)) {
+-			NL_SET_ERR_MSG_MOD(extack,
+-					   "Enslaving offloaded bridge to a bridge is not supported");
+-			return -EOPNOTSUPP;
+-		}
+-		break;
+-	case NETDEV_CHANGEUPPER:
+-		/* empty */
+-		break;
+-	}
+-
+-	return 0;
+-}
+-
+-static int mvsw_pr_netdevice_event(struct notifier_block *nb,
+-				   unsigned long event, void *ptr)
+-{
+-	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
+-	struct prestera_switch *sw;
+-	int err = 0;
+-
+-	sw = container_of(nb, struct prestera_switch, netdevice_nb);
+-
+-	if (event == NETDEV_PRE_CHANGEADDR ||
+-	    event == NETDEV_CHANGEADDR)
+-		err = prestera_netdevice_router_port_event(dev, event, ptr);
+-	else if (mvsw_pr_is_vrf_event(event, ptr))
+-		err = prestera_netdevice_vrf_event(dev, event, ptr);
+-	else if (prestera_netdev_check(dev))
+-		err = mvsw_pr_netdevice_port_event(dev, dev, event, ptr);
+-	else if (netif_is_bridge_master(dev))
+-		err = mvsw_pr_netdevice_bridge_event(dev, event, ptr);
+-	else if (netif_is_lag_master(dev))
+-		err = mvsw_pr_netdevice_lag_event(dev, event, ptr);
+-	else if (is_vlan_dev(dev))
+-		err = mvsw_pr_netdevice_vlan_event(dev, event, ptr);
+-	else if (netif_is_macvlan(dev))
+-		err = mvsw_pr_netdevice_macvlan_event(dev, event, ptr);
+-
+-	return notifier_from_errno(err);
+-}
+-
+-static int mvsw_pr_fdb_init(struct prestera_switch *sw)
++static int prestera_fdb_init(struct prestera_switch *sw)
+ {
+ 	int err;
+ 
+@@ -1543,34 +1257,24 @@ static int mvsw_pr_fdb_init(struct prestera_switch *sw)
+ 	return 0;
+ }
+ 
+-static int prestera_switchdev_init(struct prestera_switch *sw)
++int prestera_switchdev_init(struct prestera_switch *sw)
+ {
+-	int err = 0;
+ 	struct prestera_switchdev *swdev;
+-	struct prestera_bridge *bridge;
++	int err = 0;
+ 
+-	if (sw->switchdev)
++	if (sw->swdev)
+ 		return -EPERM;
+ 
+-	bridge = kzalloc(sizeof(*sw->bridge), GFP_KERNEL);
+-	if (!bridge)
++	swdev = kzalloc(sizeof(*sw->swdev), GFP_KERNEL);
++	if (!swdev)
+ 		return -ENOMEM;
+ 
+-	swdev = kzalloc(sizeof(*sw->switchdev), GFP_KERNEL);
+-	if (!swdev) {
+-		kfree(bridge);
+-		return -ENOMEM;
+-	}
+-
+-	sw->bridge = bridge;
+-	bridge->sw = sw;
+-	sw->switchdev = swdev;
+-	swdev->sw = sw;
++	sw->swdev = swdev;
+ 
+-	INIT_LIST_HEAD(&sw->bridge->bridge_list);
++	INIT_LIST_HEAD(&sw->swdev->bridge_list);
+ 
+-	mvsw_owq = alloc_ordered_workqueue("%s_ordered", 0, "prestera_sw");
+-	if (!mvsw_owq) {
++	swdev_owq = alloc_ordered_workqueue("%s_ordered", 0, "prestera_sw");
++	if (!swdev_owq) {
+ 		err = -ENOMEM;
+ 		goto err_alloc_workqueue;
+ 	}
+@@ -1586,84 +1290,29 @@ static int prestera_switchdev_init(struct prestera_switch *sw)
+ 	if (err)
+ 		goto err_register_block_switchdev_notifier;
+ 
+-	mvsw_pr_fdb_init(sw);
++	prestera_fdb_init(sw);
+ 
+ 	return 0;
+ 
+ err_register_block_switchdev_notifier:
+ 	unregister_switchdev_notifier(&swdev->swdev_n);
+ err_register_switchdev_notifier:
+-	destroy_workqueue(mvsw_owq);
++	destroy_workqueue(swdev_owq);
+ err_alloc_workqueue:
+ 	kfree(swdev);
+-	kfree(bridge);
+ 	return err;
+ }
+ 
+-static void prestera_switchdev_fini(struct prestera_switch *sw)
++void prestera_switchdev_fini(struct prestera_switch *sw)
+ {
+-	if (!sw->switchdev)
++	if (!sw->swdev)
+ 		return;
+ 
+-	unregister_switchdev_notifier(&sw->switchdev->swdev_n);
++	unregister_switchdev_notifier(&sw->swdev->swdev_n);
+ 	unregister_switchdev_blocking_notifier
+-	    (&sw->switchdev->swdev_blocking_n);
+-	flush_workqueue(mvsw_owq);
+-	destroy_workqueue(mvsw_owq);
+-	kfree(sw->switchdev);
+-	sw->switchdev = NULL;
+-	kfree(sw->bridge);
+-}
+-
+-static int mvsw_pr_netdev_init(struct prestera_switch *sw)
+-{
+-	int err = 0;
+-
+-	if (sw->netdevice_nb.notifier_call)
+-		return -EPERM;
+-
+-	sw->netdevice_nb.notifier_call = mvsw_pr_netdevice_event;
+-	err = register_netdevice_notifier(&sw->netdevice_nb);
+-	return err;
+-}
+-
+-static void mvsw_pr_netdev_fini(struct prestera_switch *sw)
+-{
+-	if (sw->netdevice_nb.notifier_call)
+-		unregister_netdevice_notifier(&sw->netdevice_nb);
+-}
+-
+-int prestera_switchdev_register(struct prestera_switch *sw)
+-{
+-	int err;
+-
+-	err = prestera_switchdev_init(sw);
+-	if (err)
+-		return err;
+-
+-	err = prestera_router_init(sw);
+-
+-	if (err) {
+-		pr_err("Failed to initialize fib notifier\n");
+-		goto err_fib_notifier;
+-	}
+-
+-	err = mvsw_pr_netdev_init(sw);
+-	if (err)
+-		goto err_netdevice_notifier;
+-
+-	return 0;
+-
+-err_netdevice_notifier:
+-	prestera_router_fini(sw);
+-err_fib_notifier:
+-	prestera_switchdev_fini(sw);
+-	return err;
+-}
+-
+-void prestera_switchdev_unregister(struct prestera_switch *sw)
+-{
+-	mvsw_pr_netdev_fini(sw);
+-	prestera_router_fini(sw);
+-	prestera_switchdev_fini(sw);
++	    (&sw->swdev->swdev_blocking_n);
++	flush_workqueue(swdev_owq);
++	destroy_workqueue(swdev_owq);
++	kfree(sw->swdev);
++	sw->swdev = NULL;
+ }
+diff --git a/drivers/net/ethernet/marvell/prestera/prestera_switchdev.h b/drivers/net/ethernet/marvell/prestera/prestera_switchdev.h
+new file mode 100644
+index 0000000..0963c63
+--- /dev/null
++++ b/drivers/net/ethernet/marvell/prestera/prestera_switchdev.h
+@@ -0,0 +1,24 @@
++/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
++/* Copyright (c) 2019-2020 Marvell International Ltd. All rights reserved. */
++
++#ifndef _PRESTERA_SWITCHDEV_H_
++#define _PRESTERA_SWITCHDEV_H_
++
++int prestera_switchdev_init(struct prestera_switch *sw);
++void prestera_switchdev_fini(struct prestera_switch *sw);
++
++int prestera_port_bridge_join(struct prestera_port *port,
++			      struct net_device *brport_dev,
++			      struct net_device *br_dev,
++			      struct netlink_ext_ack *extack);
++
++void prestera_port_bridge_leave(struct prestera_port *port,
++				struct net_device *brport_dev,
++				struct net_device *br_dev);
++
++bool prestera_bridge_is_offloaded(const struct prestera_switch *sw,
++				  const struct net_device *br_dev);
++
++int prestera_bridge_port_down(struct prestera_port *port);
++
++#endif /* _PRESTERA_SWITCHDEV_H_ */

--- a/packages/base/any/kernels/5.10-lts/patches/series.arm64
+++ b/packages/base/any/kernels/5.10-lts/patches/series.arm64
@@ -35,3 +35,4 @@
 0039-net-sched-fix-infinite-loop-when-trying-to-create-tc.patch
 0040-prestera-switchdev-prestera.patch
 0041-net-prestera-Enable-autoneg-for-1000BASE-X.patch
+0042-switchdev-prestera-v3.1.0-rc1.patch


### PR DESCRIPTION
 - AC5X A1 support
 - additional AC5X IDs support
 - L1: enable AN bypass from 1000Base-X
 - AC5X/SIP6 ledstream config support
 - SERDER TX config from XML
 - SFP support w/o phylink

Signed-off-by: Volodymyr Mytnyk <volodymyr.mytnyk@plvision.eu>