### PR TITLE
Fix ports not coming up sometimes on AS4564

### DIFF
--- a/packages/platforms/accton/arm64/as4564-26p/platform-config/r0/src/python/arm64_accton_as4564_26p_r0/__init__.py
+++ b/packages/platforms/accton/arm64/as4564-26p/platform-config/r0/src/python/arm64_accton_as4564_26p_r0/__init__.py
@@ -50,8 +50,8 @@ class OnlPlatform_arm64_accton_as4564_26p_r0(OnlPlatformAccton,
         self.modprobe('prestera_pci')
 
         # set up systemctl rules
-        #for swp in range(1, 27):
-        #    cmd = "systemctl enable switchdev-online@swp%d" % swp
-        #    subprocess.check_call(cmd, shell=True)
+        for swp in range(1, 27):
+            cmd = "systemctl enable switchdev-online@swp%d" % swp
+            subprocess.check_call(cmd, shell=True)
 
         return True


### PR DESCRIPTION
Fix ports not coming up sometimes on AS4564. 
There is an existing mechanism for other Accton platform to prevent a race condition between the ifupdown2 script and the creation and renaming of the ports by the udev script, which was disabled for AS4564.
Enable this for AS4564 as well.

Signed-off-by: Elad Nachman <enachman@marvell.com>