### PR TITLE
Enable dhcp on ma1

### DIFF
--- a/builds/any/rootfs/stretch/common/overlay/etc/network/interfaces
+++ b/builds/any/rootfs/stretch/common/overlay/etc/network/interfaces
@@ -1,0 +1,6 @@
+# interfaces(5) file used by ifup(8) and ifdown(8)
+auto lo
+iface lo inet loopback
+
+auto ma1
+iface ma1 inet dhcp


### PR DESCRIPTION
Set default config to get IP on ma1 using dhcp
resolves #185 
Signed-off-by: Taras Chornyi <taras.chornyi@plvision.eu>