### PR TITLE
dent-artifacts: Add custom hostapd package

### DIFF
--- a/builds/any/rootfs/stretch/common/arm64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/arm64-base-packages.yml
@@ -13,3 +13,5 @@
 - mft
 - mrvl-fw-image
 - keepalived
+- hostapd
+


### PR DESCRIPTION
This change pulls in a custom flavour of the hostapd package with wired IEEE 802.1x authentication support for the arm64 platforms. This package is built for the Debian 9 "stretch" release.

Acked-by: Jakov Petrina <jakov.petrina@sartura.hr>
Signed-off-by: Alen Jelavic <alen.jelavic@sartura.hr>

Reference: https://github.com/dentproject/dent-artifacts/pull/18