### PR TITLE
Add stress-ng package to arm64 build

### DIFF
--- a/builds/any/rootfs/stretch/common/arm64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/arm64-base-packages.yml
@@ -14,4 +14,4 @@
 - mrvl-fw-image
 - keepalived
 - hostapd
-
+- stress-ng


### PR DESCRIPTION
This package is needed by dent test framework