### PR TITLE
Fix to build with Debian 9 "stretch" moved to archive.debian.org

### DIFF
--- a/builds/any/rootfs/stretch/standard/standard.yml
+++ b/builds/any/rootfs/stretch/standard/standard.yml
@@ -57,14 +57,14 @@ Multistrap:
 
   Security:
     packages: *Packages
-    source: http://security.debian.org/debian-security
+    source: http://archive.debian.org/debian-security
     suite: stretch/updates
     omitdebsrc: true
     arches: amd64, arm64, armel
 
   Security-Local:
     packages: *Packages
-    source: http://${APT_CACHE}security.debian.org/debian-security
+    source: http://${APT_CACHE}archive.debian.org/debian-security
     suite: stretch/updates
     omitdebsrc: true
     arches: amd64, arm64, armel

--- a/tools/onlrfs.py
+++ b/tools/onlrfs.py
@@ -321,6 +321,12 @@ class OnlRfsBuilder(object):
         # This will need a cleaner fix.
         if arch == 'powerpc':
             self.DEFAULTS['DEBIAN_MIRROR'] = 'archive.debian.org/debian/'
+        else:
+            cmd = ('lsb_release', '-c', '-s',)
+            codename = subprocess.check_output(cmd,
+                                               universal_newlines=True).strip()
+            if codename == 'stretch':
+                self.DEFAULTS['DEBIAN_MIRROR'] = 'archive.debian.org/debian/'
 
         self.kwargs.update(self.DEFAULTS)
         self.__load(config)


### PR DESCRIPTION
Build with "stretch" fails because of the recent move to archive.debian.org (see https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html).  This change fixes the build with "stretch" from the correct archive.