### PR TITLE
buster: delete broken udev rules

### DIFF
--- a/builds/any/rootfs/buster/common/overlay/etc/udev/rules.d/60-block.rules
+++ b/builds/any/rootfs/buster/common/overlay/etc/udev/rules.d/60-block.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="block", RUN+="/sbin/initblockdev $kernel $env{ACTION}"

--- a/builds/any/rootfs/buster/common/overlay/etc/udev/rules.d/60-net.rules
+++ b/builds/any/rootfs/buster/common/overlay/etc/udev/rules.d/60-net.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="net", RUN+="/sbin/initnetdev $kernel $env{ACTION}"


### PR DESCRIPTION
The udev rules 60-block.rules and 60-net.rules try to call binaries that do not exist at these paths in the main rootfs, so always fail. Since neither of them do anything useful outside of the initrd (where udev isn't used), drop the udev rules trying to call them instead of trying to fix them up.

Silences errors like:

```
root@localhost:/# journalctl -b | grep "failed with exit code"
Sep 15 09:18:55 localhost systemd-udevd[573]: Process '/sbin/initnetdev ma1 add' failed with exit code 1.
Sep 15 09:18:55 localhost systemd-udevd[574]: Process '/sbin/initblockdev mtdblock0 add' failed with exit code 1.
Sep 15 09:18:55 localhost systemd-udevd[557]: Process '/sbin/initblockdev mtdblock1 add' failed with exit code 1.
Sep 15 09:18:55 localhost systemd-udevd[567]: Process '/sbin/initblockdev mtdblock2 add' failed with exit code 1.
Sep 15 09:18:56 localhost systemd-udevd[555]: Process '/sbin/initblockdev sda add' failed with exit code 1.
Sep 15 09:18:56 localhost systemd-udevd[553]: Process '/sbin/initnetdev eth1 add' failed with exit code 1.
Sep 15 09:18:56 localhost systemd-udevd[586]: Process '/sbin/initnetdev eth11 add' failed with exit code 1.
Sep 15 09:18:56 localhost systemd-udevd[555]: Process '/sbin/initblockdev sda1 add' failed with exit code 1.
...
root@localhost:/# journalctl -b | grep "failed with exit code" | wc -l
141
```