### PR TITLE
import dts(i) files from kernel tree

### DIFF
--- a/make/kbuild.mk
+++ b/make/kbuild.mk
@@ -145,6 +145,9 @@ ksource: $(K_SOURCE_DIR)/Makefile
 # The patched kernel sources
 #
 $(K_SOURCE_DIR)/.PATCHED: $(K_SOURCE_DIR)/Makefile
+ifdef K_FILES_DIR
+	cp -fpR $(K_FILES_DIR)/* $(K_SOURCE_DIR)
+endif
 	$(ONL)/tools/scripts/apply-patches.sh $(K_SOURCE_DIR) $(K_PATCH_DIR) $(K_PATCH_SERIES_FILE)
 	touch $(K_SOURCE_DIR)/.PATCHED
 

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb-sdk.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb-sdk.dts
@@ -1,0 +1,69 @@
+/*
+ * Device Tree Include file for Freescale Layerscape-1043A family SoC.
+ *
+ * Copyright 2014-2015 Freescale Semiconductor, Inc.
+ *
+ * Mingkai Hu <Mingkai.hu@freescale.com>
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fsl-ls1043a-rdb.dts"
+
+&bman_fbpr {
+	compatible = "fsl,bman-fbpr";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+&qman_fqd {
+	compatible = "fsl,qman-fqd";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+&qman_pfdr {
+	compatible = "fsl,qman-pfdr";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+
+&soc {
+#include "qoriq-dpaa-eth.dtsi"
+#include "qoriq-fman3-0-6oh.dtsi"
+};
+
+&fman0 {
+	compatible = "fsl,fman", "simple-bus";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb-usdpaa.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1043a-rdb-usdpaa.dts
@@ -1,0 +1,117 @@
+/*
+ * Device Tree Include file for Freescale Layerscape-1043A family SoC.
+ *
+ * Copyright 2014-2015 Freescale Semiconductor, Inc.
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2.  This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+#include "fsl-ls1043a-rdb-sdk.dts"
+
+&soc {
+	bp7: buffer-pool@7 {
+		compatible = "fsl,p4080-bpool", "fsl,bpool";
+		fsl,bpid = <7>;
+		fsl,bpool-ethernet-cfg = <0 0 0 192 0 0xdeadbeef>;
+		fsl,bpool-thresholds = <0x400 0xc00 0x0 0x0>;
+	};
+
+	bp8: buffer-pool@8 {
+		compatible = "fsl,p4080-bpool", "fsl,bpool";
+		fsl,bpid = <8>;
+		fsl,bpool-ethernet-cfg = <0 0 0 576 0 0xabbaf00d>;
+		fsl,bpool-thresholds = <0x100 0x300 0x0 0x0>;
+	};
+
+	bp9: buffer-pool@9 {
+		compatible = "fsl,p4080-bpool", "fsl,bpool";
+		fsl,bpid = <9>;
+		fsl,bpool-ethernet-cfg = <0 0 0 2048 0 0xfeedabba>;
+		fsl,bpool-thresholds = <0x100 0x300 0x0 0x0>;
+	};
+
+	fsl,dpaa {
+		compatible = "fsl,ls1043a", "fsl,dpaa", "simple-bus";
+
+		ethernet@0 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x50 1 0x51 1>;
+			fsl,qman-frame-queues-tx = <0x70 1 0x71 1>;
+		};
+
+		ethernet@1 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x52 1 0x53 1>;
+			fsl,qman-frame-queues-tx = <0x72 1 0x73 1>;
+		};
+
+		ethernet@2 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x54 1 0x55 1>;
+			fsl,qman-frame-queues-tx = <0x74 1 0x75 1>;
+		};
+
+		ethernet@3 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x56 1 0x57 1>;
+			fsl,qman-frame-queues-tx = <0x76 1 0x77 1>;
+		};
+
+		ethernet@4 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x58 1 0x59 1>;
+			fsl,qman-frame-queues-tx = <0x78 1 0x79 1>;
+		};
+
+		ethernet@5 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x60 1 0x61 1>;
+			fsl,qman-frame-queues-tx = <0x80 1 0x81 1>;
+		};
+
+		ethernet@8 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x5c 1 0x5d 1>;
+			fsl,qman-frame-queues-tx = <0x7c 1 0x7d 1>;
+
+		};
+		dpa-fman0-oh@2 {
+			compatible = "fsl,dpa-oh";
+			/* Define frame queues for the OH port*/
+			/* <OH Rx error, OH Rx default> */
+			fsl,qman-frame-queues-oh = <0x5a 1 0x5b 1>;
+			fsl,fman-oh-port = <&fman0_oh2>;
+		};
+	};
+};
+/ {
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		usdpaa_mem: usdpaa_mem {
+			compatible = "fsl,usdpaa-mem";
+			alloc-ranges = <0 0 0x10000 0>;
+			size = <0 0x10000000>;
+			alignment = <0 0x10000000>;
+		};
+	};
+};
+
+&fman0 {
+	fman0_oh2: port@83000 {
+		cell-index = <1>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x83000 0x1000>;
+	};
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb-sdk.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb-sdk.dts
@@ -1,0 +1,76 @@
+/*
+ * Device Tree Include file for Freescale Layerscape-1046A family SoC.
+ *
+ * Copyright 2014-2015 Freescale Semiconductor, Inc.
+ *
+ * Mingkai Hu <Mingkai.hu@freescale.com>
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fsl-ls1046a-rdb.dts"
+
+&bman_fbpr {
+	compatible = "fsl,bman-fbpr";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+&qman_fqd {
+	compatible = "fsl,qman-fqd";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+&qman_pfdr {
+	compatible = "fsl,qman-pfdr";
+	alloc-ranges = <0 0 0x10000 0>;
+};
+
+&soc {
+#include "qoriq-dpaa-eth.dtsi"
+#include "qoriq-fman3-0-6oh.dtsi"
+};
+
+&fsldpaa {
+	ethernet@9 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet7>;
+	};
+};
+
+&fman0 {
+	compatible = "fsl,fman", "simple-bus";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb-usdpaa.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/fsl-ls1046a-rdb-usdpaa.dts
@@ -1,0 +1,110 @@
+/*
+ * Device Tree Include file for Freescale Layerscape-1046A family SoC.
+ *
+ * Copyright 2016 Freescale Semiconductor, Inc.
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2.  This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+#include "fsl-ls1046a-rdb-sdk.dts"
+
+&soc {
+	bp7: buffer-pool@7 {
+		compatible = "fsl,ls1046a-bpool", "fsl,bpool";
+		fsl,bpid = <7>;
+		fsl,bpool-ethernet-cfg = <0 0 0 192 0 0xdeadbeef>;
+		fsl,bpool-thresholds = <0x400 0xc00 0x0 0x0>;
+	};
+
+	bp8: buffer-pool@8 {
+		compatible = "fsl,ls1046a-bpool", "fsl,bpool";
+		fsl,bpid = <8>;
+		fsl,bpool-ethernet-cfg = <0 0 0 576 0 0xabbaf00d>;
+		fsl,bpool-thresholds = <0x100 0x300 0x0 0x0>;
+	};
+
+	bp9: buffer-pool@9 {
+		compatible = "fsl,ls1046a-bpool", "fsl,bpool";
+		fsl,bpid = <9>;
+		fsl,bpool-ethernet-cfg = <0 0 0 2048 0 0xfeedabba>;
+		fsl,bpool-thresholds = <0x100 0x300 0x0 0x0>;
+	};
+
+	fsl,dpaa {
+		compatible = "fsl,ls1046a", "fsl,dpaa", "simple-bus";
+
+		ethernet@2 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x54 1 0x55 1>;
+			fsl,qman-frame-queues-tx = <0x74 1 0x75 1>;
+		};
+
+		ethernet@3 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x56 1 0x57 1>;
+			fsl,qman-frame-queues-tx = <0x76 1 0x77 1>;
+		};
+
+		ethernet@4 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x58 1 0x59 1>;
+			fsl,qman-frame-queues-tx = <0x78 1 0x79 1>;
+		};
+
+		ethernet@5 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x5a 1 0x5b 1>;
+			fsl,qman-frame-queues-tx = <0x7a 1 0x7b 1>;
+		};
+
+		ethernet@8 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x5c 1 0x5d 1>;
+			fsl,qman-frame-queues-tx = <0x7c 1 0x7d 1>;
+		};
+
+		ethernet@9 {
+			compatible = "fsl,dpa-ethernet-init";
+			fsl,bman-buffer-pools = <&bp7 &bp8 &bp9>;
+			fsl,qman-frame-queues-rx = <0x5e 1 0x5f 1>;
+			fsl,qman-frame-queues-tx = <0x7e 1 0x7f 1>;
+		};
+
+		dpa-fman0-oh@2 {
+			compatible = "fsl,dpa-oh";
+			/* Define frame queues for the OH port*/
+			/* <OH Rx error, OH Rx default> */
+			fsl,qman-frame-queues-oh = <0x60 1 0x61 1>;
+			fsl,fman-oh-port = <&fman0_oh2>;
+		};
+	};
+};
+/ {
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		usdpaa_mem: usdpaa_mem {
+			compatible = "fsl,usdpaa-mem";
+			alloc-ranges = <0 0 0x10000 0>;
+			size = <0 0x10000000>;
+			alignment = <0 0x10000000>;
+		};
+	};
+};
+
+&fman0 {
+	fman0_oh2: port@83000 {
+		cell-index = <1>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x83000 0x1000>;
+	};
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/qoriq-dpaa-eth.dtsi
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/qoriq-dpaa-eth.dtsi
@@ -1,0 +1,66 @@
+/*
+ * QorIQ FMan v3 10g port #1 device tree stub [ controller @ offset 0x400000 ]
+ *
+ * Copyright 2012 - 2015 Freescale Semiconductor Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Freescale Semiconductor nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *
+ * ALTERNATIVELY, this software may be distributed under the terms of the
+ * GNU General Public License ("GPL") as published by the Free Software
+ * Foundation, either version 2 of that License or (at your option) any
+ * later version.
+ *
+ * THIS SOFTWARE IS PROVIDED BY Freescale Semiconductor ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Freescale Semiconductor BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+fsldpaa: fsl,dpaa {
+	compatible = "fsl,ls1043a-dpaa", "simple-bus", "fsl,dpaa";
+	ethernet@0 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet0>;
+	};
+	ethernet@1 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet1>;
+	};
+	ethernet@2 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet2>;
+	};
+	ethernet@3 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet3>;
+	};
+	ethernet@4 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet4>;
+	};
+	ethernet@5 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet5>;
+	};
+	ethernet@8 {
+		compatible = "fsl,dpa-ethernet";
+		fsl,fman-mac = <&enet6>;
+	};
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/qoriq-fman3-0-6oh.dtsi
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/freescale/qoriq-fman3-0-6oh.dtsi
@@ -1,0 +1,47 @@
+/*
+ * QorIQ FMan v3 OH ports device tree
+ *
+ * Copyright 2012-2015 Freescale Semiconductor Inc.
+ *
+ * SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+ */
+
+fman@1a00000 {
+
+	fman0_oh1: port@82000 {
+		cell-index = <0>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x82000 0x1000>;
+	};
+
+	fman0_oh2: port@83000 {
+		cell-index = <1>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x83000 0x1000>;
+	};
+
+	fman0_oh3: port@84000 {
+		cell-index = <2>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x84000 0x1000>;
+	};
+
+	fman0_oh4: port@85000 {
+		cell-index = <3>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x85000 0x1000>;
+	};
+
+	fman0_oh5: port@86000 {
+		cell-index = <4>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x86000 0x1000>;
+	};
+
+	fman0_oh6: port@87000 {
+		cell-index = <5>;
+		compatible = "fsl,fman-port-oh";
+		reg = <0x87000 0x1000>;
+	};
+
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5-4gb.dtsi
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5-4gb.dtsi
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+/*#include <dt-bindings/phy/phy-utmi-mvebu.h>*/
+
+/ {
+	model = "Marvell AC5x board";
+	compatible = "marvell,armada3700";
+	interrupt-parent = <&gic>;
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	aliases {
+		serial0 = &uart0;
+		spiflash0 = &spiflash0;
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 8 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 10 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 7 IRQ_TYPE_LEVEL_HIGH>;
+		//clock-frequency = <10020>;
+		//clock-frequency = <110400>;
+		//clock-frequency = <110020>;
+		clock-frequency = <25000000>;
+	};
+
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <GIC_PPI 12 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	soc {
+		compatible = "simple-bus";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		dma-ranges;
+
+		internal-regs@7f000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			/* 16M internal register @ 0x7f00_0000 */
+			ranges = <0x0 0x0 0x7f000000 0x1000000>;
+			dma-coherent;
+
+			uart0: serial@12000 {
+				compatible = "snps,dw-apb-uart";
+				reg = <0x12000 0x100>;
+				reg-shift = <2>;
+				interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
+				reg-io-width = <1>;
+				clock-frequency = <328000000>;
+				status = "okay";
+			};
+
+			mdio: mdio@20000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "marvell,orion-mdio";
+				reg = <0x22004 0x4>;
+				clocks = <&core_clock>;
+				phy0: ethernet-phy@0 {
+					reg = < 0 0 >;
+				};
+			};
+
+			i2c0: i2c@11000{
+				compatible = "marvell,mv78230-i2c";
+				reg = <0x11000 0x20>;
+
+				clocks = <&core_clock>;
+				clock-names = "core";
+				interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
+				clock-frequency=<100000>;
+				status="okay";
+			};
+
+			i2c1: i2c@11100{
+				compatible = "marvell,mv78230-i2c";
+				reg = <0x11100 0x20>;
+
+				clocks = <&core_clock>;
+				clock-names = "core";
+				interrupts = <GIC_SPI 88 IRQ_TYPE_LEVEL_HIGH>;
+				clock-frequency=<100000>;
+				status="okay";
+			};
+		};
+
+		/* Dedicated section for devices behind 32bit controllers so we
+		 * can configure specific DMA mapping for them
+		 */
+		behind-32bit-controller@7f000000 {
+			compatible = "simple-bus";
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			ranges = <0x0 0x0 0x0 0x7f000000 0x0 0x1000000>;
+			/* Host addresses starts at 0x2000000 */
+			dma-ranges = <0x0 0x0 0x2 0x0 0x1 0x0>;
+			dma-coherent;
+
+			eth0: ethernet@20000 {
+				compatible = "marvell,armada-ac5-neta";
+				reg = <0x0 0x20000 0x0 0x4000>;
+				interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&core_clock>;
+				status = "disabled";
+				phy-mode = "sgmii";
+				memory-region = <&reserved>;
+			};
+
+			eth1: ethernet@24000 {
+				compatible = "marvell,armada-ac5-neta";
+				reg = <0x0 0x24000 0x0 0x4000>;
+				interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&core_clock>;
+				status = "disabled";
+				phy-mode = "sgmii";
+				memory-region = <&reserved>;
+				fixed-link {
+					speed = <100>;
+					full-duplex;
+				};
+			};
+
+			/* A dummy entry used for chipidea phy init */
+			usb1phy: usbphy {
+				compatible = "usb-nop-xceiv";
+				#phy-cells = <0>;
+			};
+
+			/* USB0 is a host USB */
+			usb0: usb@80000 {
+				compatible = "marvell,ac5-ehci", "marvell,orion-ehci";
+				reg = <0x0 0x80000 0x0 0x500>;
+				interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH>;
+				memory-region = <&reserved>;
+				status = "okay";
+			};
+
+			/* USB1 is a peripheral USB */
+			usb1: usb@A0000 {
+				reg = <0x0 0xA0000 0x0 0x500>;
+				interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL_HIGH>;
+				memory-region = <&reserved>;
+				status = "okay";
+			};
+		};
+
+		pcie0: pcie@800a0000 {
+			compatible = "marvell,ac5-pcie", "snps,dw-pcie";
+			reg = <0 0x800a0000 0 0x20000>, <0 0x3fff0000 0 0x10000>;
+			reg-names = "ctrl", "config";
+			#address-cells = <3>;
+			#size-cells = <2>;
+			#interrupt-cells = <1>;
+			device_type = "pci";
+			dma-coherent;
+			bus-range = <0 0xff>;
+			/* ranges for the PCI memory and I/O regions */
+			ranges = <0x82000000 0 0x30000000 0 0x30000000 0 0xfff0000>;
+
+			interrupt-map-mask = <0 0 0 1>;
+			interrupt-map = <0 0 0 1 &gic GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>;
+
+			interrupts = <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>;
+
+			num-lanes = <1>;
+			status = "disabled";
+
+			clocks = <&core_clock>;
+		};
+
+		core_clock: core_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <400000000>;
+		};
+
+		axi_clock: axi_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <325000000>;
+		};
+
+		spi_clock: spi_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <200000000>;
+		};
+
+		spi@805a0000 {
+			compatible = "marvell,armada-3700-spi";
+			reg = <0x0 0x805a0000 0x0 0x50>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			clocks = <&spi_clock>;
+			interrupts = <GIC_SPI 90 IRQ_TYPE_LEVEL_HIGH>;
+			num-cs = <1>;
+			status = "okay";
+
+			spiflash0: spi-flash@0 {
+				compatible = "spi-nor";
+				spi-max-frequency = <50000000>;
+				spi-tx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
+				spi-rx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "spi_flash_part0";
+					reg = <0x0 0x800000>;
+				};
+
+				parition@1 {
+					label = "spi_flash_part1";
+					reg = <0x800000 0x700000>;
+				};
+
+				parition@2 {
+					label = "spi_flash_part2";
+					reg = <0xF00000 0x100000>;
+				};
+			};
+		};
+
+		spi@805a8000 {
+			compatible = "marvell,armada-3700-spi";
+			reg = <0x0 0x805a8000 0x0 0x50>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			clocks = <&spi_clock>;
+			interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
+			num-cs = <1>;
+			status = "disabled";
+		};
+
+		sdhci@805c0000 {
+			compatible = "marvell,ac5-sdhci", "marvell,armada-ap806-sdhci";
+			reg = <0x0 0x805c0000 0x0 0x300>;
+			interrupts = <GIC_SPI 92 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&core_clock>;
+			clock-names = "core";
+			status = "okay";
+			bus-width = <8>;
+			//marvell,xenon-phy-slow-mode;
+			non-removable;
+			mmc-ddr-1_8v;
+			mmc-hs200-1_8v;
+			mmc-hs400-1_8v;
+			memory-region = <&reserved>;
+		};
+
+		nand@805b00 {
+			compatible = "marvell,ac5-nand-controller";
+			reg =  <0x0 0x805b0000 0x0 0x00000054
+				0x0 0x840F8204 0x0 0x00000004
+				0x0 0x80013010 0x0 0x00000020>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			interrupts = <GIC_SPI 89 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&core_clock>;
+			/*marvell,system-controller = <0x15>*/
+			status = "okay";
+			nand-timing-mode = <1>;
+
+			nand@0 {
+				reg = <0x0>;
+				label = "main-storage";
+				nand-rb = <0>;
+				nand-ecc-mode = "hw";
+				nand-ecc-strength = <12>;
+				nand-ecc-step-size = <512>;
+			};
+		};
+
+		prestera: pack-processor@0 {
+			compatible = "marvell,armada-ac5-switch", "marvell,prestera";
+			interrupts = <GIC_SPI 0x23 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+	};
+
+	gic: interrupt-controller@80600000 {
+		compatible = "arm,gic-v3";
+		#interrupt-cells = <3>;
+		interrupt-controller;
+		/*#redistributor-regions = <1>;*/
+		redistributor-stride = <0x0 0x20000>;	// 128kB stride
+		reg = <0x0 0x80600000 0x0 0x10000>, /* GICD */
+			  <0x0 0x80660000 0x0 0x40000>; /* GICR */
+		interrupts = <GIC_PPI 6 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	cpus {
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&CPU0>;
+				};
+				core1 {
+					cpu = <&CPU1>;
+				};
+			};
+		};
+
+		CPU0:cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x0>;
+			enable-method = "psci";
+			next-level-cache = <&L2_0>;
+		};
+
+		CPU1:cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x100>;
+			enable-method = "psci";
+			next-level-cache = <&L2_0>;
+		};
+
+		L2_0: l2-cache0 {
+			compatible = "cache";
+		};
+	};
+
+	memory@00000000 {
+		device_type = "memory";
+		reg = <0x2 0x00000000 0x1 0x00000000>;
+		linux,usable-memory = <0x2 0x00000000 0x1 0x00000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved: buffer@0 {
+		/*
+		 * to be used as a shared pool of DMA buffers
+		 * for a set of devices.
+		 * No one other than devices registered for that mem,
+		 * may use this area.
+		 * reusable - OS can use the memory in this region with
+		 * the limitation that the device driver(s).
+		 * owning the region need to be able to reclaim it back.
+		 */
+			compatible = "shared-dma-pool";
+			no-map;
+			reg = <0x2 0x0 0x0 0x1000000>;
+		};
+	};
+
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5.dtsi
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5.dtsi
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+/*#include <dt-bindings/phy/phy-utmi-mvebu.h>*/
+
+/ {
+	model = "Marvell AC5x board";
+	compatible = "marvell,armada3700";
+	interrupt-parent = <&gic>;
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	aliases {
+		serial0 = &uart0;
+		spiflash0 = &spiflash0;
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 8 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 10 IRQ_TYPE_LEVEL_HIGH>,
+				 <GIC_PPI 7 IRQ_TYPE_LEVEL_HIGH>;
+		//clock-frequency = <10020>;
+		//clock-frequency = <110400>;
+		//clock-frequency = <110020>;
+		clock-frequency = <25000000>;
+	};
+
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupts = <GIC_PPI 12 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	soc {
+		compatible = "simple-bus";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+		dma-ranges;
+
+		internal-regs@7f000000 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "simple-bus";
+			/* 16M internal register @ 0x7f00_0000 */
+			ranges = <0x0 0x0 0x7f000000 0x1000000>;
+			dma-coherent;
+
+			uart0: serial@12000 {
+				compatible = "snps,dw-apb-uart";
+				reg = <0x12000 0x100>;
+				reg-shift = <2>;
+				interrupts = <GIC_SPI 83 IRQ_TYPE_LEVEL_HIGH>;
+				reg-io-width = <1>;
+				clock-frequency = <328000000>;
+				status = "okay";
+			};
+
+			mdio: mdio@20000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				compatible = "marvell,orion-mdio";
+				reg = <0x22004 0x4>;
+				clocks = <&core_clock>;
+				phy0: ethernet-phy@0 {
+					reg = < 0 0 >;
+				};
+			};
+
+			i2c0: i2c@11000{
+				compatible = "marvell,mv78230-i2c";
+				reg = <0x11000 0x20>;
+
+				clocks = <&core_clock>;
+				clock-names = "core";
+				interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
+				clock-frequency=<100000>;
+				status="okay";
+			};
+
+			i2c1: i2c@11100{
+				compatible = "marvell,mv78230-i2c";
+				reg = <0x11100 0x20>;
+
+				clocks = <&core_clock>;
+				clock-names = "core";
+				interrupts = <GIC_SPI 88 IRQ_TYPE_LEVEL_HIGH>;
+				clock-frequency=<100000>;
+				status="okay";
+			};
+		};
+
+		/* Dedicated section for devices behind 32bit controllers so we
+		 * can configure specific DMA mapping for them
+		 */
+		behind-32bit-controller@7f000000 {
+			compatible = "simple-bus";
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			ranges = <0x0 0x0 0x0 0x7f000000 0x0 0x1000000>;
+			/* Host addresses starts at 0x2000000 */
+			dma-ranges = <0x0 0x0 0x2 0x0 0x1 0x0>;
+			dma-coherent;
+
+			eth0: ethernet@20000 {
+				compatible = "marvell,armada-ac5-neta";
+				reg = <0x0 0x20000 0x0 0x4000>;
+				interrupts = <GIC_SPI 45 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&core_clock>;
+				status = "disabled";
+				phy-mode = "sgmii";
+				memory-region = <&reserved>;
+			};
+
+			eth1: ethernet@24000 {
+				compatible = "marvell,armada-ac5-neta";
+				reg = <0x0 0x24000 0x0 0x4000>;
+				interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&core_clock>;
+				status = "disabled";
+				phy-mode = "sgmii";
+				memory-region = <&reserved>;
+				fixed-link {
+					speed = <100>;
+					full-duplex;
+				};
+			};
+
+			/* A dummy entry used for chipidea phy init */
+			usb1phy: usbphy {
+				compatible = "usb-nop-xceiv";
+				#phy-cells = <0>;
+			};
+
+			/* USB0 is a host USB */
+			usb0: usb@80000 {
+				compatible = "marvell,ac5-ehci", "marvell,orion-ehci";
+				reg = <0x0 0x80000 0x0 0x500>;
+				interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH>;
+				memory-region = <&reserved>;
+				status = "okay";
+			};
+
+			/* USB1 is a peripheral USB */
+			usb1: usb@A0000 {
+				reg = <0x0 0xA0000 0x0 0x500>;
+				interrupts = <GIC_SPI 69 IRQ_TYPE_LEVEL_HIGH>;
+				memory-region = <&reserved>;
+				status = "okay";
+			};
+		};
+
+		pcie0: pcie@800a0000 {
+			compatible = "marvell,ac5-pcie", "snps,dw-pcie";
+			reg = <0 0x800a0000 0 0x20000>, <0 0x3fff0000 0 0x10000>;
+			reg-names = "ctrl", "config";
+			#address-cells = <3>;
+			#size-cells = <2>;
+			#interrupt-cells = <1>;
+			device_type = "pci";
+			dma-coherent;
+			bus-range = <0 0xff>;
+			/* ranges for the PCI memory and I/O regions */
+			ranges = <0x82000000 0 0x30000000 0 0x30000000 0 0xfff0000>;
+
+			interrupt-map-mask = <0 0 0 1>;
+			interrupt-map = <0 0 0 1 &gic GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>;
+
+			interrupts = <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH>;
+
+			num-lanes = <1>;
+			status = "disabled";
+
+			clocks = <&core_clock>;
+		};
+
+		core_clock: core_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <400000000>;
+		};
+
+		axi_clock: axi_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <325000000>;
+		};
+
+		spi_clock: spi_clock@0 {
+			compatible = "fixed-clock";
+			#clock-cells = <0>;
+			clock-frequency = <200000000>;
+		};
+
+		spi@805a0000 {
+			compatible = "marvell,armada-3700-spi";
+			reg = <0x0 0x805a0000 0x0 0x50>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			clocks = <&spi_clock>;
+			interrupts = <GIC_SPI 90 IRQ_TYPE_LEVEL_HIGH>;
+			num-cs = <1>;
+			status = "okay";
+
+			spiflash0: spi-flash@0 {
+				compatible = "spi-nor";
+				spi-max-frequency = <50000000>;
+				spi-tx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
+				spi-rx-bus-width = <1>; /* 1-single, 2-dual, 4-quad */
+				reg = <0>;
+
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "spi_flash_part0";
+					reg = <0x0 0x800000>;
+				};
+
+				parition@1 {
+					label = "spi_flash_part1";
+					reg = <0x800000 0x700000>;
+				};
+
+				parition@2 {
+					label = "spi_flash_part2";
+					reg = <0xF00000 0x100000>;
+				};
+			};
+		};
+
+		spi@805a8000 {
+			compatible = "marvell,armada-3700-spi";
+			reg = <0x0 0x805a8000 0x0 0x50>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			clocks = <&spi_clock>;
+			interrupts = <GIC_SPI 91 IRQ_TYPE_LEVEL_HIGH>;
+			num-cs = <1>;
+			status = "disabled";
+		};
+
+		sdhci@805c0000 {
+			compatible = "marvell,ac5-sdhci", "marvell,armada-ap806-sdhci";
+			reg = <0x0 0x805c0000 0x0 0x300>;
+			interrupts = <GIC_SPI 92 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&core_clock>;
+			clock-names = "core";
+			status = "okay";
+			bus-width = <8>;
+			//marvell,xenon-phy-slow-mode;
+			non-removable;
+			mmc-ddr-1_8v;
+			mmc-hs200-1_8v;
+			mmc-hs400-1_8v;
+			memory-region = <&reserved>;
+		};
+
+		nand@805b00 {
+			compatible = "marvell,ac5-nand-controller";
+			reg =  <0x0 0x805b0000 0x0 0x00000054
+				0x0 0x840F8204 0x0 0x00000004
+				0x0 0x80013010 0x0 0x00000020>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			interrupts = <GIC_SPI 89 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&core_clock>;
+			/*marvell,system-controller = <0x15>*/
+			status = "okay";
+			nand-timing-mode = <1>;
+
+			nand@0 {
+				reg = <0x0>;
+				label = "main-storage";
+				nand-rb = <0>;
+				nand-ecc-mode = "hw";
+				nand-ecc-strength = <12>;
+				nand-ecc-step-size = <512>;
+			};
+		};
+
+		prestera: pack-processor@0 {
+			compatible = "marvell,armada-ac5-switch", "marvell,prestera";
+			interrupts = <GIC_SPI 0x23 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+	};
+
+	gic: interrupt-controller@80600000 {
+		compatible = "arm,gic-v3";
+		#interrupt-cells = <3>;
+		interrupt-controller;
+		/*#redistributor-regions = <1>;*/
+		redistributor-stride = <0x0 0x20000>;	// 128kB stride
+		reg = <0x0 0x80600000 0x0 0x10000>, /* GICD */
+			  <0x0 0x80660000 0x0 0x40000>; /* GICR */
+		interrupts = <GIC_PPI 6 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	cpus {
+		#address-cells = <2>;
+		#size-cells = <0>;
+
+		cpu-map {
+			cluster0 {
+				core0 {
+					cpu = <&CPU0>;
+				};
+				core1 {
+					cpu = <&CPU1>;
+				};
+			};
+		};
+
+		CPU0:cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x0>;
+			enable-method = "psci";
+			next-level-cache = <&L2_0>;
+		};
+
+		CPU1:cpu@1 {
+			device_type = "cpu";
+			compatible = "arm,armv8";
+			reg = <0x0 0x100>;
+			enable-method = "psci";
+			next-level-cache = <&L2_0>;
+		};
+
+		L2_0: l2-cache0 {
+			compatible = "cache";
+		};
+	};
+
+	memory@00000000 {
+		device_type = "memory";
+		reg = <0x2 0x00000000 0x0 0x40000000>;
+		// linux,usable-memory = <0x2 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		reserved: buffer@0 {
+		/*
+		 * to be used as a shared pool of DMA buffers
+		 * for a set of devices.
+		 * No one other than devices registered for that mem,
+		 * may use this area.
+		 * reusable - OS can use the memory in this region with
+		 * the limitation that the device driver(s).
+		 * owning the region need to be able to reclaim it back.
+		 */
+
+			compatible = "shared-dma-pool";
+			no-map;
+			reg = <0x2 0x0 0x0 0x1000000>;
+		};
+	};
+
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_as4564_trampoline.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_as4564_trampoline.dts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5_db.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell Alleycat 5 development board
+ * This board file supports the B configuration of the board
+ */
+#include "ac5-4gb.dtsi"
+
+/ {
+	sfp25: sfp-25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp0>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp26: sfp-26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp1>;
+		maximum-power-milliwatt = <2000>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+	i2cmux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	i2c-mux-idle-disconnect;
+
+		i2c0_sfp0: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp1: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&usb1 {
+	compatible = "chipidea,usb2";
+	phys = <&usb1phy>;
+	phy-names = "usb-phy";
+	dr_mode = "peripheral";
+};
+
+&prestera {
+	compatible = "marvell,prestera";
+	status = "okay";
+	reg = <0x0 0x7F900000 0x0 0x40000>;
+	ports {
+		port25 {
+			prestera,port-num = <25>;
+			sfp = <&sfp25>;
+		};
+		port26 {
+			prestera,port-num = <26>;
+			sfp = <&sfp26>;
+		};
+	};
+};
+
+&sfp25 {
+	status = "okay";
+};
+
+&sfp26 {
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_comexpress.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_comexpress.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5 comExpress.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell AC5 comExpress development board
+ * This board file supports the B configuration of the board
+ */
+
+#include "ac5.dtsi"
+
+&eth0 {
+	status = "okay";
+	phy = <&phy0>;
+};
+
+&usb1 {
+	compatible = "chipidea,usb2";
+	phys = <&usb1phy>;
+	phy-names = "usb-phy";
+	dr_mode = "peripheral";
+};
+
+&pcie0 {
+	status = "okay";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_db.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_db.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5_db.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell Alleycat 5 development board
+ * This board file supports the B configuration of the board
+ */
+
+#include "ac5.dtsi"
+
+&eth0 {
+	status = "okay";
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&usb1 {
+	compatible = "chipidea,usb2";
+	phys = <&usb1phy>;
+	phy-names = "usb-phy";
+	dr_mode = "peripheral";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_db_trampoline.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_db_trampoline.dts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5_db.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell Alleycat 5 development board
+ * This board file supports the B configuration of the board
+ */
+#include "ac5.dtsi"
+
+/ {
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp0>;
+		maximum-power-milliwatt = <2000>;
+		los-gpio = <&pca9555_0 8 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 0 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 0 GPIO_ACTIVE_HIGH>;
+
+	};
+
+	sfp2: sfp-2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp1>;
+		los-gpio = <&pca9555_0 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 1 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp3: sfp-3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp2>;
+		los-gpio = <&pca9555_0 10 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 2 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp4: sfp-4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp3>;
+		los-gpio = <&pca9555_0 11 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 3 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp5: sfp-5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp4>;
+		los-gpio = <&pca9555_0 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 4 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp6: sfp-6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp5>;
+		los-gpio = <&pca9555_0 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 5 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp7: sfp-7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp6>;
+		los-gpio = <&pca9555_0 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 6 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 6 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	sfp8: sfp-8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_sfp7>;
+		los-gpio = <&pca9555_0 15 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&pca9555_1 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&pca9555_0 7 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+	i2cmux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	i2c-mux-idle-disconnect;
+
+		i2c0_sfp0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			pca9555_0: pca9555@20 {
+				compatible = "nxp,pca9555";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x20>;
+			};
+
+			pca9555_1: pca9555@21 {
+				compatible = "nxp,pca9555";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x21>;
+			};
+
+		};
+		i2c0_sfp1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp2: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp3: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp4: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp5: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp6: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c0_sfp7: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	phy = <&phy0>;
+};
+
+&eth1 {
+	status = "okay";
+};
+
+&usb1 {
+	compatible = "chipidea,usb2";
+	phys = <&usb1phy>;
+	phy-names = "usb-phy";
+	dr_mode = "peripheral";
+};
+
+&prestera {
+	compatible = "marvell,prestera";
+	status = "okay";
+	reg = <0x0 0x7F900000 0x0 0x40000>;
+	ports {
+		port1 {
+			prestera,port-num = <1>;
+			sfp = <&sfp1>;
+		};
+		port2 {
+			prestera,port-num = <2>;
+			sfp = <&sfp2>;
+		};
+
+		port3 {
+			prestera,port-num = <3>;
+			sfp = <&sfp3>;
+		};
+
+		port4 {
+			prestera,port-num = <4>;
+			sfp = <&sfp4>;
+		};
+
+		port5 {
+			prestera,port-num = <5>;
+			sfp = <&sfp5>;
+		};
+
+		port6 {
+			prestera,port-num = <6>;
+			sfp = <&sfp6>;
+		};
+
+		port7 {
+			prestera,port-num = <7>;
+			sfp = <&sfp7>;
+		};
+
+		port8 {
+			prestera,port-num = <8>;
+			sfp = <&sfp8>;
+		};
+
+	};
+};
+
+&sfp1 {
+	status = "okay";
+};
+
+&sfp2 {
+	status = "okay";
+};
+
+&sfp3 {
+	status = "okay";
+};
+
+&sfp4 {
+	status = "okay";
+};
+
+&sfp5 {
+	status = "okay";
+};
+
+&sfp6 {
+	status = "okay";
+};
+
+&sfp7 {
+	status = "okay";
+};
+
+&sfp8 {
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_rd.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5_rd.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5X.
+ *
+ * Copyright (C) 2016 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell Armada 7040 development board
+ * This board file supports the B configuration of the board
+ */
+
+#include "ac5.dtsi"
+
+&pcie0 {
+	status = "okay";
+};
+
+&usb1 {
+	compatible = "marvell,ac5-ehci", "marvell,orion-ehci";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5x_db.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/ac5x_db.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree For AC5X.
+ *
+ * Copyright (C) 2021 Marvell
+ *
+ */
+/*
+ * Device Tree file for Marvell Alleycat 5X development board
+ * This board file supports the B configuration of the board
+ */
+
+#include "ac5.dtsi"
+
+&eth0 {
+	status = "okay";
+	phy = <&phy0>;
+};
+
+&usb1 {
+	compatible = "chipidea,usb2";
+	phys = <&usb1phy>;
+	phy-names = "usb-phy";
+	dr_mode = "peripheral";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as4224.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as4224.dts
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * Device Tree file for Marvell Armada 7040 Development board platform
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "Accton Marvell Armada 7040 board setup";
+	compatible = "marvell,armada-7040-as4224",
+		     "marvell,armada7040", "marvell,armada-ap806-quad",
+		     "marvell,armada-ap806";
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+		i2c0 = &i2c0;
+		i2c1 = &cp0_i2c0;
+		i2c2 = &cp0_i2c1;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+		base-mac-provider = <&onie_eeprom>;
+		ports {
+			port49 {
+				prestera,port-num = <49>;
+				sfp = <&sfp49>;
+			};
+			port50 {
+				prestera,port-num = <50>;
+				sfp = <&sfp50>;
+			};
+			port51 {
+				prestera,port-num = <51>;
+				sfp = <&sfp51>;
+			};
+			port52 {
+				prestera,port-num = <52>;
+				sfp = <&sfp52>;
+			};
+		};
+	};
+
+	sfp49: sfp-49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp0>;
+
+		/*
+			The below three lines is intended to support the SFP cage interfaces:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+			To support these three signal the driver 'gpio_i2c' (Or compatible platform driver) must be enabled and supported.
+			Please refer to the 'gpio_i2c' section on this DTS file below.
+			It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+			Can be skipped in this stage.
+		*/
+		los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp50: sfp-50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+
+		los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp51: sfp-51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+
+		los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp52: sfp-52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+
+		los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	/*
+		This driver is intended to emulate GPIO interfaces on CPLD logic accessed via I2C interface.
+		It is required only if the SFP Cage interfaces will be required:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+		This driver is added as reference code and can be replaced with another Platform Drivers that enables similar mapping.
+		It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+		Can be skipped in this stage.
+	*/
+	gpio_i2c: gpio-i2c/* @40 */ {
+		compatible = "gpio-i2c";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* reg = <0x40>; */  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp0 */
+			sfp00_gpio00_loss {
+				reg-map = <0x40 (1 << 0)>; /* 0x40=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp00_gpio01_pres {
+				reg-map = <0x41 (1 << 0)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp00_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 0)>; /* reg mask */
+				gpio-num = <2>;
+			};
+
+			/* sfp1 */
+			sfp01_gpio00_sfp_loss {
+				reg-map = <0x40 (1 << 1)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp01_gpio01_sfp_pres {
+				reg-map = <0x41 (1 << 1)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 1)>; /* reg mask */
+				gpio-num = <5>;
+			};
+
+			/* sfp2 */
+			sfp02_gpio00_loss {
+				reg-map = <0x40 (1 << 2)>; /* reg mask */
+				gpio-num = <6>;
+			};
+			sfp02_gpio01_pres {
+				reg-map = <0x41 (1 << 2)>; /* reg mask */
+				gpio-num = <7>;
+			};
+			sfp02_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 2)>; /* reg mask */
+				gpio-num = <8>;
+			};
+
+			/* sfp3 */
+			sfp03_gpio01_loss {
+				reg-map = <0x40 (1 << 3)>; /* reg mask */
+				gpio-num = <9>;
+			};
+			sfp03_gpio02_sfp_pres {
+				reg-map = <0x41 (1 << 3)>; /* reg mask */
+				gpio-num = <10>;
+			};
+			sfp03_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 3)>; /* reg mask */
+				gpio-num = <11>;
+			};
+		};
+	};
+};
+
+&ap_pinctrl {
+	ap_spi0_pins: spi-pins-0 {
+		marvell,pins = "mpp0", "mpp1", "mpp2", "mpp3";
+		marvell,function = "spi0";
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_i2c1 {
+    status = "okay";
+    clock-frequency = <100000>;
+
+	i2cmux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp2: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp3: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&ap_spi0_pins>;
+	pinctrl-names = "default";
+
+
+    spidev: tpm@0 {
+       compatible = "tcg,tpm_tis-spi";
+       reg =<0>;
+       #address-cells = <1>;
+       #size-cells = <1>;
+       spi-max-frequency = <500000>;
+    };
+
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-0 = <&uart0_pins>;
+	pinctrl-names = "default";
+};
+
+
+&cp0_pinctrl {
+        cp0_ge_mdio_pins: ge-mdio-pins {
+                marvell,pins = "mpp0", "mpp1";
+                marvell,function = "ge";
+        };
+        cp0_sata0_prsnt_pin: sata0-prsnt-pins {
+                marvell,pins = "mpp29";
+                marvell,function = "sata0";
+        };
+        cp0_i2c0_pins: i2c0-pins {
+                marvell,pins = "mpp37", "mpp38";
+                marvell,function = "i2c0";
+        };
+        cp0_i2c1_pins: i2c1-pins {
+                marvell,pins = "mpp35", "mpp36";
+                marvell,function = "i2c1";
+        };
+        cp0_spi0_pins: spi0-pins {
+                marvell,pins = "mpp56", "mpp57", "mpp58", "mpp59";
+                marvell,function = "spi0";
+        };
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	expander0: pca9555@21 {
+		compatible = "nxp,pca9555";
+		pinctrl-names = "default";
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x21>;
+	};
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+		pagesize = <0x20>;
+	};
+
+	eeprom1: eeprom@57 {
+		compatible = "atmel,24c64";
+		reg = <0x57>;
+		pagesize = <0x20>;
+	};
+};
+
+&cp0_nand_controller {
+	pinctrl-names = "default";
+	pinctrl-0 = <&nand_pins &nand_rb>;
+
+	nand@0 {
+		reg = <0>;
+		label = "main-storage";
+		nand-rb = <0>;
+		nand-ecc-mode = "hw";
+		nand-on-flash-bbt;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0 0x200000>;
+			};
+			partition@200000 {
+				label = "Linux";
+				reg = <0x200000 0xd00000>;
+			};
+			partition@1000000 {
+				label = "Filesystem";
+				reg = <0x1000000 0x3f000000>;
+			};
+		};
+	};
+};
+
+&cp0_spi0 {
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&cp0_spi0_pins>;
+	status = "okay";
+	spi-flash@0 {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <108000000>;
+
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x00000000 0x00200000>;
+				label = "uboot";
+			};
+
+			partition@1 {
+				reg = <0x00200000 0x00010000>;
+				label = "uboot-env";
+				env_size = <0x00010000>;
+			};
+
+			partition@2 {
+				reg = <0x00210000 0x00df0000>;
+				label = "onie";
+			};
+		};
+	};
+};
+
+&cp0_comphy1 {
+   phy-skip-config;
+};
+
+&cp0_sata0 {
+	status = "okay";
+
+	sata-port@1 {
+		status = "okay";
+		/* Generic PHY, providing serdes lanes */
+		//phys = <&cp0_comphy1 0>;
+	};
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+	status = "okay";
+};
+
+&cp0_mdio {
+	status = "okay";
+	OOB_E1512_PHY: ethernet-phy@1 {
+                reg = <0x0>;
+        };
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy2 0>;
+	phy-mode = "2500base-x";
+	phy-speed=<2500>;
+	/* Generic PHY, providing serdes lanes */
+	fixed-link {
+	speed = <2500>;
+	full-duplex;
+	};
+};
+
+&cp0_eth1 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy3 1>;
+	phy-mode = "1000base-x";
+	fixed-link {
+	      speed = <1000>;
+	      full-duplex;
+	};
+};
+
+&cp0_eth2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "okay";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as4564-26p.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as4564-26p.dts
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * Device Tree file for Marvell Armada 7040 Development board platform
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "Accton Marvell Armada 7040 board setup";
+	compatible = "marvell,armada-7040-as4564",
+		     "marvell,armada7040", "marvell,armada-ap806-quad",
+		     "marvell,armada-ap806";
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+		i2c0 = &i2c0;
+		i2c1 = &cp0_i2c0;
+		i2c2 = &cp0_i2c1;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+		base-mac-provider = <&onie_eeprom>;
+		ports {
+			port25 {
+				prestera,port-num = <25>;
+				sfp = <&sfp25>;
+			};
+			port26 {
+				prestera,port-num = <26>;
+				sfp = <&sfp26>;
+			};
+		};
+	};
+
+	sfp25: sfp-25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp0>;
+
+		/*
+			The below three lines is intended to support the SFP cage interfaces:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+			To support these three signal the driver 'gpio_i2c' (Or compatible platform driver) must be enabled and supported.
+			Please refer to the 'gpio_i2c' section on this DTS file below.
+			It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+			Can be skipped in this stage.
+		*/
+		los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp26: sfp-26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+
+		los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	/*
+		This driver is intended to emulate GPIO interfaces on CPLD logic accessed via I2C interface.
+		It is required only if the SFP Cage interfaces will be required:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+		This driver is added as reference code and can be replaced with another Platform Drivers that enables similar mapping.
+		It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+		Can be skipped in this stage.
+	*/
+	gpio_i2c: gpio-i2c/* @40 */ {
+		compatible = "gpio-i2c-as4564";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* reg = <0x40>; */  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp0 */
+			sfp00_gpio00_loss {
+				reg-map = <0x40 (1 << 2)>; /* 0x40=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp00_gpio01_pres {
+				reg-map = <0x41 (1 << 2)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp00_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 2)>; /* reg mask */
+				gpio-num = <2>;
+			};
+
+			/* sfp1 */
+			sfp01_gpio00_sfp_loss {
+				reg-map = <0x40 (1 << 3)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp01_gpio01_sfp_pres {
+				reg-map = <0x41 (1 << 3)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0x42 (1 << 3)>; /* reg mask */
+				gpio-num = <5>;
+			};
+		};
+	};
+};
+
+&ap_pinctrl {
+	ap_spi0_pins: spi-pins-0 {
+		marvell,pins = "mpp0", "mpp1", "mpp2", "mpp3";
+		marvell,function = "spi0";
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_i2c1 {
+    status = "okay";
+    clock-frequency = <100000>;
+
+	i2cmux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp0: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp1: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&ap_spi0_pins>;
+	pinctrl-names = "default";
+
+
+    spidev: tpm@0 {
+       compatible = "tcg,tpm_tis-spi";
+       reg =<0>;
+       #address-cells = <1>;
+       #size-cells = <1>;
+       spi-max-frequency = <500000>;
+    };
+
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-0 = <&uart0_pins>;
+	pinctrl-names = "default";
+};
+
+
+&cp0_pinctrl {
+        cp0_ge_mdio_pins: ge-mdio-pins {
+                marvell,pins = "mpp0", "mpp1";
+                marvell,function = "ge";
+        };
+        cp0_sata0_prsnt_pin: sata0-prsnt-pins {
+                marvell,pins = "mpp29";
+                marvell,function = "sata0";
+        };
+        cp0_i2c0_pins: i2c0-pins {
+                marvell,pins = "mpp37", "mpp38";
+                marvell,function = "i2c0";
+        };
+        cp0_i2c1_pins: i2c1-pins {
+                marvell,pins = "mpp35", "mpp36";
+                marvell,function = "i2c1";
+        };
+        cp0_spi0_pins: spi0-pins {
+                marvell,pins = "mpp56", "mpp57", "mpp58", "mpp59";
+                marvell,function = "spi0";
+        };
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x0 0x0 0x0 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x1800000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	reg = <0x00 0xf2600000 0x00 0x10000 0x00 0xf7800000 0x00 0x80000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	expander0: pca9555@21 {
+		compatible = "nxp,pca9555";
+		pinctrl-names = "default";
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x21>;
+	};
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+		pagesize = <0x20>;
+	};
+
+	eeprom1: eeprom@57 {
+		compatible = "atmel,24c64";
+		reg = <0x57>;
+		pagesize = <0x20>;
+	};
+};
+
+&cp0_nand_controller {
+	pinctrl-names = "default";
+	pinctrl-0 = <&nand_pins &nand_rb>;
+
+	nand@0 {
+		reg = <0>;
+		label = "main-storage";
+		nand-rb = <0>;
+		nand-ecc-mode = "hw";
+		nand-on-flash-bbt;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0 0x200000>;
+			};
+			partition@200000 {
+				label = "Linux";
+				reg = <0x200000 0xd00000>;
+			};
+			partition@1000000 {
+				label = "Filesystem";
+				reg = <0x1000000 0x3f000000>;
+			};
+		};
+	};
+};
+
+&cp0_spi0 {
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&cp0_spi0_pins>;
+	status = "okay";
+	spi-flash@0 {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <108000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x00000000 0x00200000>;
+				label = "uboot";
+			};
+
+			partition@1 {
+				reg = <0x00200000 0x00010000>;
+				label = "uboot-env";
+				env_size = <0x00010000>;
+			};
+
+			partition@2 {
+				reg = <0x00210000 0x00df0000>;
+				label = "onie";
+			};
+		};
+	};
+};
+
+&cp0_comphy1 {
+   phy-skip-config;
+};
+
+&cp0_sata0 {
+	status = "okay";
+
+	sata-port@1 {
+		status = "okay";
+		/* Generic PHY, providing serdes lanes */
+		//phys = <&cp0_comphy1 0>;
+	};
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+	status = "okay";
+};
+
+&cp0_mdio {
+	status = "okay";
+	OOB_E1512_PHY: ethernet-phy@1 {
+                reg = <0x0>;
+        };
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy2 0>;
+	phy-mode = "2500base-x";
+	phy-speed=<2500>;
+	/* Generic PHY, providing serdes lanes */
+	fixed-link {
+	speed = <2500>;
+	full-duplex;
+	};
+};
+
+&cp0_eth1 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy3 1>;
+	phy-mode = "1000base-x";
+	fixed-link {
+	      speed = <1000>;
+	      full-duplex;
+	};
+};
+
+&cp0_eth2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "okay";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as5114.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/accton-as5114.dts
@@ -1,0 +1,1917 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * Device Tree file for Marvell Armada 7040 Development board platform
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "Accton Marvell Armada 7040 board setup";
+	compatible = "marvell,armada-7040-as4224",
+		     "marvell,armada7040", "marvell,armada-ap806-quad",
+		     "marvell,armada-ap806";
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+		i2c0 = &i2c0;
+		i2c1 = &cp0_i2c0;
+		i2c2 = &cp0_i2c1;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+		base-mac-provider = <&onie_eeprom>;
+		ports {
+			port1 {
+				prestera,port-num = <1>;
+				sfp = <&sfp1>;
+			};
+			port2 {
+				prestera,port-num = <2>;
+				sfp = <&sfp2>;
+			};
+			port3 {
+				prestera,port-num = <3>;
+				sfp = <&sfp3>;
+			};
+			port4 {
+				prestera,port-num = <4>;
+				sfp = <&sfp4>;
+			};
+			port5 {
+				prestera,port-num = <5>;
+				sfp = <&sfp5>;
+			};
+			port6 {
+				prestera,port-num = <6>;
+				sfp = <&sfp6>;
+			};
+			port7 {
+				prestera,port-num = <7>;
+				sfp = <&sfp7>;
+			};
+			port8 {
+				prestera,port-num = <8>;
+				sfp = <&sfp8>;
+			};
+			port9 {
+				prestera,port-num = <9>;
+				sfp = <&sfp9>;
+			};
+			port10 {
+				prestera,port-num = <10>;
+				sfp = <&sfp10>;
+			};
+			port11 {
+				prestera,port-num = <11>;
+				sfp = <&sfp11>;
+			};
+			port12 {
+				prestera,port-num = <12>;
+				sfp = <&sfp12>;
+			};
+			port13 {
+				prestera,port-num = <13>;
+				sfp = <&sfp13>;
+			};
+			port14 {
+				prestera,port-num = <14>;
+				sfp = <&sfp14>;
+			};
+			port15 {
+				prestera,port-num = <15>;
+				sfp = <&sfp15>;
+			};
+			port16 {
+				prestera,port-num = <16>;
+				sfp = <&sfp16>;
+			};
+			port17 {
+				prestera,port-num = <17>;
+				sfp = <&sfp17>;
+			};
+			port18 {
+				prestera,port-num = <18>;
+				sfp = <&sfp18>;
+			};
+			port19 {
+				prestera,port-num = <19>;
+				sfp = <&sfp19>;
+			};
+			port20 {
+				prestera,port-num = <20>;
+				sfp = <&sfp20>;
+			};
+			port21 {
+				prestera,port-num = <21>;
+				sfp = <&sfp21>;
+			};
+			port22 {
+				prestera,port-num = <22>;
+				sfp = <&sfp22>;
+			};
+			port23 {
+				prestera,port-num = <23>;
+				sfp = <&sfp23>;
+			};
+			port24 {
+				prestera,port-num = <24>;
+				sfp = <&sfp24>;
+			};
+			port25 {
+				prestera,port-num = <25>;
+				sfp = <&sfp25>;
+			};
+			port26 {
+				prestera,port-num = <26>;
+				sfp = <&sfp26>;
+			};
+			port27 {
+				prestera,port-num = <27>;
+				sfp = <&sfp27>;
+			};
+			port28 {
+				prestera,port-num = <28>;
+				sfp = <&sfp28>;
+			};
+			port29 {
+				prestera,port-num = <29>;
+				sfp = <&sfp29>;
+			};
+			port30 {
+				prestera,port-num = <30>;
+				sfp = <&sfp30>;
+			};
+			port31 {
+				prestera,port-num = <31>;
+				sfp = <&sfp31>;
+			};
+			port32 {
+				prestera,port-num = <32>;
+				sfp = <&sfp32>;
+			};
+			port33 {
+				prestera,port-num = <33>;
+				sfp = <&sfp33>;
+			};
+			port34 {
+				prestera,port-num = <34>;
+				sfp = <&sfp34>;
+			};
+			port35 {
+				prestera,port-num = <35>;
+				sfp = <&sfp35>;
+			};
+			port36 {
+				prestera,port-num = <36>;
+				sfp = <&sfp36>;
+			};
+			port37 {
+				prestera,port-num = <37>;
+				sfp = <&sfp37>;
+			};
+			port38 {
+				prestera,port-num = <38>;
+				sfp = <&sfp38>;
+			};
+			port39 {
+				prestera,port-num = <39>;
+				sfp = <&sfp39>;
+			};
+			port40 {
+				prestera,port-num = <40>;
+				sfp = <&sfp40>;
+			};
+			port41 {
+				prestera,port-num = <41>;
+				sfp = <&sfp41>;
+			};
+			port42 {
+				prestera,port-num = <42>;
+				sfp = <&sfp42>;
+			};
+			port43 {
+				prestera,port-num = <43>;
+				sfp = <&sfp43>;
+			};
+			port44 {
+				prestera,port-num = <44>;
+				sfp = <&sfp44>;
+			};
+			port45 {
+				prestera,port-num = <45>;
+				sfp = <&sfp45>;
+			};
+			port46 {
+				prestera,port-num = <46>;
+				sfp = <&sfp46>;
+			};
+			port47 {
+				prestera,port-num = <47>;
+				sfp = <&sfp47>;
+			};
+			port48 {
+				prestera,port-num = <48>;
+				sfp = <&sfp48>;
+			};
+		};
+	};
+
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp0>;
+
+		/*
+			The below three lines is intended to support the SFP cage interfaces:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+			To support these three signal the driver 'gpio_i2c' (Or compatible platform driver) must be enabled and supported.
+			Please refer to the 'gpio_i2c' section on this DTS file below.
+			It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+			Can be skipped in this stage.
+		*/
+		los-gpio = <&gpio_i2c 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp2: sfp-2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+
+		los-gpio = <&gpio_i2c 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp3: sfp-3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+
+		los-gpio = <&gpio_i2c 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp4: sfp-4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+
+		los-gpio = <&gpio_i2c 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 11 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp5: sfp-5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+
+		los-gpio = <&gpio_i2c 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 14 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp6: sfp-6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp5>;
+
+		los-gpio = <&gpio_i2c 15 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 17 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp7: sfp-7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp6>;
+
+		los-gpio = <&gpio_i2c 18 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 19 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 20 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp8: sfp-8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp7>;
+
+		los-gpio = <&gpio_i2c 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 23 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp9: sfp-9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp8>;
+
+		los-gpio = <&gpio_i2c 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 26 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp10: sfp-10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp9>;
+
+		los-gpio = <&gpio_i2c 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 29 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp11: sfp-11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp10>;
+
+		los-gpio = <&gpio_i2c 30 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 31 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 32 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp12: sfp-12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp11>;
+
+		los-gpio = <&gpio_i2c 33 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 34 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 35 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp13: sfp-13 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp12>;
+
+		los-gpio = <&gpio_i2c 36 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 37 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 38 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp14: sfp-14 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp13>;
+
+		los-gpio = <&gpio_i2c 39 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 40 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 41 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp15: sfp-15 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp14>;
+
+		los-gpio = <&gpio_i2c 42 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 43 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 44 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp16: sfp-16 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp15>;
+
+		los-gpio = <&gpio_i2c 45 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 46 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 47 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp17: sfp-17 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp16>;
+
+		los-gpio = <&gpio_i2c 48 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 49 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 50 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp18: sfp-18 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp17>;
+
+		los-gpio = <&gpio_i2c 51 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 52 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 53 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp19: sfp-19 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp18>;
+
+		los-gpio = <&gpio_i2c 54 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 55 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 56 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp20: sfp-20 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp19>;
+
+		los-gpio = <&gpio_i2c 57 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 58 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 59 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp21: sfp-21 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp20>;
+
+		los-gpio = <&gpio_i2c 60 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 61 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 62 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp22: sfp-22 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp21>;
+
+		los-gpio = <&gpio_i2c 63 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 64 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 65 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp23: sfp-23 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp22>;
+
+		los-gpio = <&gpio_i2c 66 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 67 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 68 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp24: sfp-24 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp23>;
+
+		los-gpio = <&gpio_i2c 69 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 70 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 71 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp25: sfp-25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp24>;
+
+		los-gpio = <&gpio_i2c 72 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 73 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 74 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp26: sfp-26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp25>;
+
+		los-gpio = <&gpio_i2c 75 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 76 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 77 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp27: sfp-27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp26>;
+
+		los-gpio = <&gpio_i2c 78 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 79 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 80 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp28: sfp-28 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp27>;
+
+		los-gpio = <&gpio_i2c 81 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 82 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 83 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp29: sfp-29 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp28>;
+
+		los-gpio = <&gpio_i2c 84 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 85 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 86 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp30: sfp-30 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp29>;
+
+		los-gpio = <&gpio_i2c 87 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 88 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 89 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp31: sfp-31 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp30>;
+
+		los-gpio = <&gpio_i2c 90 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 91 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 92 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp32: sfp-32 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp31>;
+
+		los-gpio = <&gpio_i2c 93 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 94 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 95 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp33: sfp-33 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp32>;
+
+		los-gpio = <&gpio_i2c 96 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 97 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 98 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp34: sfp-34 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp33>;
+
+		los-gpio = <&gpio_i2c 99 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 100 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 101 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp35: sfp-35 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp34>;
+
+		los-gpio = <&gpio_i2c 102 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 103 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 104 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp36: sfp-36 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp35>;
+
+		los-gpio = <&gpio_i2c 105 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 106 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 107 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp37: sfp-37 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp36>;
+
+		los-gpio = <&gpio_i2c 108 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 109 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 110 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp38: sfp-38 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp37>;
+
+		los-gpio = <&gpio_i2c 111 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 112 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 113 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp39: sfp-39 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp38>;
+
+		los-gpio = <&gpio_i2c 114 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 115 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 116 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp40: sfp-40 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp39>;
+
+		los-gpio = <&gpio_i2c 117 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 118 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 119 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp41: sfp-41 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp40>;
+
+		los-gpio = <&gpio_i2c 120 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 121 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 122 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp42: sfp-42 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp41>;
+
+		los-gpio = <&gpio_i2c 123 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 124 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 125 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp43: sfp-43 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp42>;
+
+		los-gpio = <&gpio_i2c 126 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 127 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 128 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp44: sfp-44 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp43>;
+
+		los-gpio = <&gpio_i2c 129 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 130 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 131 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp45: sfp-45 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp44>;
+
+		los-gpio = <&gpio_i2c 132 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 133 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 134 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp46: sfp-46 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp45>;
+
+		los-gpio = <&gpio_i2c 135 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 136 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 137 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp47: sfp-47 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp46>;
+
+		los-gpio = <&gpio_i2c 138 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 139 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 140 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+	sfp48: sfp-48 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp47>;
+
+		los-gpio = <&gpio_i2c 141 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio_i2c 142 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio_i2c 143 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+	};
+
+	/*
+		This driver is intended to emulate GPIO interfaces on CPLD logic accessed via I2C interface.
+		It is required only if the SFP Cage interfaces will be required:
+				los-gpio - RX_LOSS
+				mod-def0-gpio - PRESENT_BIT
+				tx-disable-gpio - TX_ENABLE (or DISABLE)
+		This driver is added as reference code and can be replaced with another Platform Drivers that enables similar mapping.
+		It is currently not required for Amazon 'ethtool -m' support but it is intended for future use.
+		Can be skipped in this stage.
+	*/
+	gpio_i2c: gpio-i2c/* @40 */ {
+		compatible = "gpio-i2c";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		/* reg = <0x40>; */  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp0 */
+			sfp00_gpio00_loss {
+				reg-map = <0xA6 (1 << 0)>; /* 0xA6=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp00_gpio01_pres {
+				reg-map = <0xC0 (1 << 0)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp00_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 0)>; /* reg mask */
+				gpio-num = <2>;
+			};
+
+			/* sfp1 */
+			sfp01_gpio00_sfp_loss {
+				reg-map = <0xA6 (1 << 1)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp01_gpio01_sfp_pres {
+				reg-map = <0xC0 (1 << 1)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 1)>; /* reg mask */
+				gpio-num = <5>;
+			};
+
+			/* sfp2 */
+			sfp02_gpio00_loss {
+				reg-map = <0xA6 (1 << 2)>; /* reg mask */
+				gpio-num = <6>;
+			};
+			sfp02_gpio01_pres {
+				reg-map = <0xC0 (1 << 2)>; /* reg mask */
+				gpio-num = <7>;
+			};
+			sfp02_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 2)>; /* reg mask */
+				gpio-num = <8>;
+			};
+
+			/* sfp3 */
+			sfp03_gpio01_loss {
+				reg-map = <0xA6 (1 << 3)>; /* reg mask */
+				gpio-num = <9>;
+			};
+			sfp03_gpio02_sfp_pres {
+				reg-map = <0xC0 (1 << 3)>; /* reg mask */
+				gpio-num = <10>;
+			};
+			sfp03_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 3)>; /* reg mask */
+				gpio-num = <11>;
+			};
+
+			/* sfp4 */
+			sfp04_gpio01_loss {
+				reg-map = <0xA6 (1 << 4)>; /* reg mask */
+				gpio-num = <12>;
+			};
+			sfp04_gpio02_sfp_pres {
+				reg-map = <0xC0 (1 << 4)>; /* reg mask */
+				gpio-num = <13>;
+			};
+			sfp04_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 4)>; /* reg mask */
+				gpio-num = <14>;
+			};
+
+			/* sfp5 */
+			sfp05_gpio01_loss {
+				reg-map = <0xA6 (1 << 5)>; /* reg mask */
+				gpio-num = <15>;
+			};
+			sfp05_gpio02_sfp_pres {
+				reg-map = <0xC0 (1 << 5)>; /* reg mask */
+				gpio-num = <16>;
+			};
+			sfp05_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 5)>; /* reg mask */
+				gpio-num = <17>;
+			};
+
+			/* sfp6 */
+			sfp06_gpio01_loss {
+				reg-map = <0xA6 (1 << 6)>; /* reg mask */
+				gpio-num = <18>;
+			};
+			sfp06_gpio02_sfp_pres {
+				reg-map = <0xC0 (1 << 6)>; /* reg mask */
+				gpio-num = <19>;
+			};
+			sfp06_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 6)>; /* reg mask */
+				gpio-num = <20>;
+			};
+
+			/* sfp7 */
+			sfp07_gpio01_loss {
+				reg-map = <0xA6 (1 << 7)>; /* reg mask */
+				gpio-num = <21>;
+			};
+			sfp07_gpio02_sfp_pres {
+				reg-map = <0xC0 (1 << 7)>; /* reg mask */
+				gpio-num = <22>;
+			};
+			sfp07_gpio02_tx_dis {
+				reg-map = <0xC6 (1 << 7)>; /* reg mask */
+				gpio-num = <23>;
+			};
+
+			/* sfp8 */
+			sfp08_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 0)>; /* reg mask */
+				gpio-num = <24>;
+			};
+			sfp08_gpio01_pres {
+				reg-map = <0xC1 (1 << 0)>; /* reg mask */
+				gpio-num = <25>;
+			};
+			sfp08_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 0)>; /* reg mask */
+				gpio-num = <26>;
+			};
+
+			/* sfp9 */
+			sfp09_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 1)>; /* reg mask */
+				gpio-num = <27>;
+			};
+			sfp09_gpio01_pres {
+				reg-map = <0xC1 (1 << 1)>; /* reg mask */
+				gpio-num = <28>;
+			};
+			sfp09_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 1)>; /* reg mask */
+				gpio-num = <29>;
+			};
+
+			/* sfp10 */
+			sfp10_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 2)>; /* reg mask */
+				gpio-num = <30>;
+			};
+			sfp10_gpio01_pres {
+				reg-map = <0xC1 (1 << 2)>; /* reg mask */
+				gpio-num = <31>;
+			};
+			sfp10_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 2)>; /* reg mask */
+				gpio-num = <32>;
+			};
+
+			/* sfp11 */
+			sfp11_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 3)>; /* reg mask */
+				gpio-num = <33>;
+			};
+			sfp11_gpio01_pres {
+				reg-map = <0xC1 (1 << 3)>; /* reg mask */
+				gpio-num = <34>;
+			};
+			sfp11_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 3)>; /* reg mask */
+				gpio-num = <35>;
+			};
+
+			/* sfp12 */
+			sfp12_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 4)>; /* reg mask */
+				gpio-num = <36>;
+			};
+			sfp12_gpio01_pres {
+				reg-map = <0xC1 (1 << 4)>; /* reg mask */
+				gpio-num = <37>;
+			};
+			sfp12_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 4)>; /* reg mask */
+				gpio-num = <38>;
+			};
+
+			/* sfp13 */
+			sfp13_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 5)>; /* reg mask */
+				gpio-num = <39>;
+			};
+			sfp13_gpio01_pres {
+				reg-map = <0xC1 (1 << 5)>; /* reg mask */
+				gpio-num = <40>;
+			};
+			sfp13_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 5)>; /* reg mask */
+				gpio-num = <41>;
+			};
+
+			/* sfp14 */
+			sfp14_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 6)>; /* reg mask */
+				gpio-num = <42>;
+			};
+			sfp14_gpio01_pres {
+				reg-map = <0xC1 (1 << 6)>; /* reg mask */
+				gpio-num = <43>;
+			};
+			sfp14_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 6)>; /* reg mask */
+				gpio-num = <44>;
+			};
+
+			/* sfp15 */
+			sfp15_gpio00_sfp_loss {
+				reg-map = <0xA7 (1 << 7)>; /* reg mask */
+				gpio-num = <45>;
+			};
+			sfp15_gpio01_pres {
+				reg-map = <0xC1 (1 << 7)>; /* reg mask */
+				gpio-num = <46>;
+			};
+			sfp15_gpio02_tx_dis {
+				reg-map = <0xC7 (1 << 7)>; /* reg mask */
+				gpio-num = <47>;
+			};
+
+			/* sfp16 */
+			sfp16_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 0)>; /* reg mask */
+				gpio-num = <48>;
+			};
+			sfp16_gpio01_pres {
+				reg-map = <0xC2 (1 << 0)>; /* reg mask */
+				gpio-num = <49>;
+			};
+			sfp16_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 0)>; /* reg mask */
+				gpio-num = <50>;
+			};
+
+			/* sfp17 */
+			sfp17_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 1)>; /* reg mask */
+				gpio-num = <51>;
+			};
+			sfp17_gpio01_pres {
+				reg-map = <0xC2 (1 << 1)>; /* reg mask */
+				gpio-num = <52>;
+			};
+			sfp17_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 1)>; /* reg mask */
+				gpio-num = <53>;
+			};
+
+			/* sfp18 */
+			sfp18_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 2)>; /* reg mask */
+				gpio-num = <54>;
+			};
+			sfp18_gpio01_pres {
+				reg-map = <0xC2 (1 << 2)>; /* reg mask */
+				gpio-num = <55>;
+			};
+			sfp18_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 2)>; /* reg mask */
+				gpio-num = <56>;
+			};
+
+			/* sfp19 */
+			sfp19_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 3)>; /* reg mask */
+				gpio-num = <57>;
+			};
+			sfp19_gpio01_pres {
+				reg-map = <0xC2 (1 << 3)>; /* reg mask */
+				gpio-num = <58>;
+			};
+			sfp19_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 3)>; /* reg mask */
+				gpio-num = <59>;
+			};
+
+			/* sfp20 */
+			sfp20_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 4)>; /* reg mask */
+				gpio-num = <60>;
+			};
+			sfp20_gpio01_pres {
+				reg-map = <0xC2 (1 << 4)>; /* reg mask */
+				gpio-num = <61>;
+			};
+			sfp20_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 4)>; /* reg mask */
+				gpio-num = <62>;
+			};
+
+			/* sfp21 */
+			sfp21_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 5)>; /* reg mask */
+				gpio-num = <63>;
+			};
+			sfp21_gpio01_pres {
+				reg-map = <0xC2 (1 << 5)>; /* reg mask */
+				gpio-num = <64>;
+			};
+			sfp21_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 5)>; /* reg mask */
+				gpio-num = <65>;
+			};
+
+			/* sfp22 */
+			sfp22_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 6)>; /* reg mask */
+				gpio-num = <66>;
+			};
+			sfp22_gpio01_pres {
+				reg-map = <0xC2 (1 << 6)>; /* reg mask */
+				gpio-num = <67>;
+			};
+			sfp22_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 6)>; /* reg mask */
+				gpio-num = <68>;
+			};
+
+			/* sfp23 */
+			sfp23_gpio00_sfp_loss {
+				reg-map = <0xA8 (1 << 7)>; /* reg mask */
+				gpio-num = <69>;
+			};
+			sfp23_gpio01_pres {
+				reg-map = <0xC2 (1 << 7)>; /* reg mask */
+				gpio-num = <70>;
+			};
+			sfp23_gpio02_tx_dis {
+				reg-map = <0xC8 (1 << 7)>; /* reg mask */
+				gpio-num = <71>;
+			};
+
+			/* sfp24 */
+			sfp24_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 0)>; /* reg mask */
+				gpio-num = <72>;
+			};
+			sfp24_gpio01_pres {
+				reg-map = <0xC3 (1 << 0)>; /* reg mask */
+				gpio-num = <73>;
+			};
+			sfp24_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 0)>; /* reg mask */
+				gpio-num = <74>;
+			};
+
+			/* sfp25 */
+			sfp25_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 1)>; /* reg mask */
+				gpio-num = <75>;
+			};
+			sfp25_gpio01_pres {
+				reg-map = <0xC3 (1 << 1)>; /* reg mask */
+				gpio-num = <76>;
+			};
+			sfp25_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 1)>; /* reg mask */
+				gpio-num = <77>;
+			};
+
+			/* sfp26 */
+			sfp26_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 2)>; /* reg mask */
+				gpio-num = <78>;
+			};
+			sfp26_gpio01_pres {
+				reg-map = <0xC3 (1 << 2)>; /* reg mask */
+				gpio-num = <79>;
+			};
+			sfp26_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 2)>; /* reg mask */
+				gpio-num = <80>;
+			};
+
+			/* sfp27 */
+			sfp27_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 3)>; /* reg mask */
+				gpio-num = <81>;
+			};
+			sfp27_gpio01_pres {
+				reg-map = <0xC3 (1 << 3)>; /* reg mask */
+				gpio-num = <82>;
+			};
+			sfp27_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 3)>; /* reg mask */
+				gpio-num = <83>;
+			};
+
+			/* sfp28 */
+			sfp28_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 4)>; /* reg mask */
+				gpio-num = <84>;
+			};
+			sfp28_gpio01_pres {
+				reg-map = <0xC3 (1 << 4)>; /* reg mask */
+				gpio-num = <85>;
+			};
+			sfp28_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 4)>; /* reg mask */
+				gpio-num = <86>;
+			};
+
+			/* sfp29 */
+			sfp29_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 5)>; /* reg mask */
+				gpio-num = <87>;
+			};
+			sfp29_gpio01_pres {
+				reg-map = <0xC3 (1 << 5)>; /* reg mask */
+				gpio-num = <88>;
+			};
+			sfp29_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 5)>; /* reg mask */
+				gpio-num = <89>;
+			};
+
+			/* sfp30 */
+			sfp30_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 6)>; /* reg mask */
+				gpio-num = <90>;
+			};
+			sfp30_gpio01_pres {
+				reg-map = <0xC3 (1 << 6)>; /* reg mask */
+				gpio-num = <91>;
+			};
+			sfp30_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 6)>; /* reg mask */
+				gpio-num = <92>;
+			};
+
+			/* sfp31 */
+			sfp31_gpio00_sfp_loss {
+				reg-map = <0xA9 (1 << 7)>; /* reg mask */
+				gpio-num = <93>;
+			};
+			sfp31_gpio01_pres {
+				reg-map = <0xC3 (1 << 7)>; /* reg mask */
+				gpio-num = <94>;
+			};
+			sfp31_gpio02_tx_dis {
+				reg-map = <0xC9 (1 << 7)>; /* reg mask */
+				gpio-num = <95>;
+			};
+
+			/* sfp32 */
+			sfp32_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 0)>; /* reg mask */
+				gpio-num = <96>;
+			};
+			sfp32_gpio01_pres {
+				reg-map = <0xC4 (1 << 0)>; /* reg mask */
+				gpio-num = <97>;
+			};
+			sfp32_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 0)>; /* reg mask */
+				gpio-num = <98>;
+			};
+
+			/* sfp33 */
+			sfp33_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 1)>; /* reg mask */
+				gpio-num = <99>;
+			};
+			sfp33_gpio01_pres {
+				reg-map = <0xC4 (1 << 1)>; /* reg mask */
+				gpio-num = <100>;
+			};
+			sfp33_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 1)>; /* reg mask */
+				gpio-num = <101>;
+			};
+
+			/* sfp34 */
+			sfp34_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 2)>; /* reg mask */
+				gpio-num = <102>;
+			};
+			sfp34_gpio01_pres {
+				reg-map = <0xC4 (1 << 2)>; /* reg mask */
+				gpio-num = <103>;
+			};
+			sfp34_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 2)>; /* reg mask */
+				gpio-num = <104>;
+			};
+
+			/* sfp35 */
+			sfp35_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 3)>; /* reg mask */
+				gpio-num = <105>;
+			};
+			sfp35_gpio01_pres {
+				reg-map = <0xC4 (1 << 3)>; /* reg mask */
+				gpio-num = <106>;
+			};
+			sfp35_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 3)>; /* reg mask */
+				gpio-num = <107>;
+			};
+
+			/* sfp36 */
+			sfp36_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 4)>; /* reg mask */
+				gpio-num = <108>;
+			};
+			sfp36_gpio01_pres {
+				reg-map = <0xC4 (1 << 4)>; /* reg mask */
+				gpio-num = <109>;
+			};
+			sfp36_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 4)>; /* reg mask */
+				gpio-num = <110>;
+			};
+
+			/* sfp37 */
+			sfp37_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 5)>; /* reg mask */
+				gpio-num = <111>;
+			};
+			sfp37_gpio01_pres {
+				reg-map = <0xC4 (1 << 5)>; /* reg mask */
+				gpio-num = <112>;
+			};
+			sfp37_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 5)>; /* reg mask */
+				gpio-num = <113>;
+			};
+
+			/* sfp38 */
+			sfp38_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 6)>; /* reg mask */
+				gpio-num = <114>;
+			};
+			sfp38_gpio01_pres {
+				reg-map = <0xC4 (1 << 6)>; /* reg mask */
+				gpio-num = <115>;
+			};
+			sfp38_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 6)>; /* reg mask */
+				gpio-num = <116>;
+			};
+
+			/* sfp39 */
+			sfp39_gpio00_sfp_loss {
+				reg-map = <0xAA (1 << 7)>; /* reg mask */
+				gpio-num = <117>;
+			};
+			sfp39_gpio01_pres {
+				reg-map = <0xC4 (1 << 7)>; /* reg mask */
+				gpio-num = <118>;
+			};
+			sfp39_gpio02_tx_dis {
+				reg-map = <0xCA (1 << 7)>; /* reg mask */
+				gpio-num = <119>;
+			};
+
+			/* sfp40 */
+			sfp40_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 0)>; /* reg mask */
+				gpio-num = <120>;
+			};
+			sfp40_gpio01_pres {
+				reg-map = <0xC5 (1 << 0)>; /* reg mask */
+				gpio-num = <121>;
+			};
+			sfp40_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 0)>; /* reg mask */
+				gpio-num = <122>;
+			};
+
+			/* sfp41 */
+			sfp41_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 1)>; /* reg mask */
+				gpio-num = <123>;
+			};
+			sfp41_gpio01_pres {
+				reg-map = <0xC5 (1 << 1)>; /* reg mask */
+				gpio-num = <124>;
+			};
+			sfp41_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 1)>; /* reg mask */
+				gpio-num = <125>;
+			};
+
+			/* sfp42 */
+			sfp42_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 2)>; /* reg mask */
+				gpio-num = <126>;
+			};
+			sfp42_gpio01_pres {
+				reg-map = <0xC5 (1 << 2)>; /* reg mask */
+				gpio-num = <127>;
+			};
+			sfp42_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 2)>; /* reg mask */
+				gpio-num = <128>;
+			};
+
+			/* sfp43 */
+			sfp43_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 3)>; /* reg mask */
+				gpio-num = <129>;
+			};
+			sfp43_gpio01_pres {
+				reg-map = <0xC5 (1 << 3)>; /* reg mask */
+				gpio-num = <130>;
+			};
+			sfp43_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 3)>; /* reg mask */
+				gpio-num = <131>;
+			};
+
+			/* sfp44 */
+			sfp44_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 4)>; /* reg mask */
+				gpio-num = <132>;
+			};
+			sfp44_gpio01_pres {
+				reg-map = <0xC5 (1 << 4)>; /* reg mask */
+				gpio-num = <133>;
+			};
+			sfp44_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 4)>; /* reg mask */
+				gpio-num = <134>;
+			};
+
+			/* sfp45 */
+			sfp45_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 5)>; /* reg mask */
+				gpio-num = <135>;
+			};
+			sfp45_gpio01_pres {
+				reg-map = <0xC5 (1 << 5)>; /* reg mask */
+				gpio-num = <136>;
+			};
+			sfp45_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 5)>; /* reg mask */
+				gpio-num = <137>;
+			};
+
+			/* sfp46 */
+			sfp46_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 6)>; /* reg mask */
+				gpio-num = <138>;
+			};
+			sfp46_gpio01_pres {
+				reg-map = <0xC5 (1 << 6)>; /* reg mask */
+				gpio-num = <139>;
+			};
+			sfp46_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 6)>; /* reg mask */
+				gpio-num = <140>;
+			};
+
+			/* sfp47 */
+			sfp47_gpio00_sfp_loss {
+				reg-map = <0xAB (1 << 7)>; /* reg mask */
+				gpio-num = <141>;
+			};
+			sfp47_gpio01_pres {
+				reg-map = <0xC5 (1 << 7)>; /* reg mask */
+				gpio-num = <142>;
+			};
+			sfp47_gpio02_tx_dis {
+				reg-map = <0xCB (1 << 7)>; /* reg mask */
+				gpio-num = <143>;
+			};
+		};
+	};
+};
+
+&ap_pinctrl {
+	ap_spi0_pins: spi-pins-0 {
+		marvell,pins = "mpp0", "mpp1", "mpp2", "mpp3";
+		marvell,function = "spi0";
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_i2c1 {
+    status = "okay";
+    clock-frequency = <100000>;
+
+	i2cmux@71 {
+		compatible = "nxp,pca9548";
+		reg = <0x71>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp2: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp3: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp4: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp5: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp6: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp7: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cmux@72 {
+		compatible = "nxp,pca9548";
+		reg = <0x72>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp8: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp9: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp10: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp11: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp12: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp13: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp14: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp15: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cmux@73 {
+		compatible = "nxp,pca9548";
+		reg = <0x73>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp16: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp17: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp18: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp19: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp20: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp21: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp22: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp23: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cmux@74 {
+		compatible = "nxp,pca9548";
+		reg = <0x74>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp24: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp25: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp26: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp27: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp28: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp29: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp30: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp31: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cmux@75 {
+		compatible = "nxp,pca9548";
+		reg = <0x75>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp32: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp33: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp34: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp35: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp36: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp37: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp38: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp39: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cmux@76 {
+		compatible = "nxp,pca9548";
+		reg = <0x76>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		i2c1_sfp40: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp41: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp42: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp43: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp44: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp45: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp46: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		i2c1_sfp47: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&ap_spi0_pins>;
+	pinctrl-names = "default";
+
+
+    spidev: tpm@0 {
+       compatible = "tcg,tpm_tis-spi";
+       reg =<0>;
+       #address-cells = <1>;
+       #size-cells = <1>;
+       spi-max-frequency = <500000>;
+    };
+
+};
+
+&uart0 {
+	status = "okay";
+	pinctrl-0 = <&uart0_pins>;
+	pinctrl-names = "default";
+};
+
+
+&cp0_pinctrl {
+        cp0_ge_mdio_pins: ge-mdio-pins {
+                marvell,pins = "mpp0", "mpp1";
+                marvell,function = "ge";
+        };
+        cp0_sata0_prsnt_pin: sata0-prsnt-pins {
+                marvell,pins = "mpp29";
+                marvell,function = "sata0";
+        };
+        cp0_i2c0_pins: i2c0-pins {
+                marvell,pins = "mpp37", "mpp38";
+                marvell,function = "i2c0";
+        };
+        cp0_i2c1_pins: i2c1-pins {
+                marvell,pins = "mpp35", "mpp36";
+                marvell,function = "i2c1";
+        };
+        cp0_spi0_pins: spi0-pins {
+                marvell,pins = "mpp56", "mpp57", "mpp58", "mpp59";
+                marvell,function = "spi0";
+        };
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	expander0: pca9555@21 {
+		compatible = "nxp,pca9555";
+		pinctrl-names = "default";
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x21>;
+	};
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+
+	eeprom0: eeprom@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+		pagesize = <0x20>;
+	};
+
+	eeprom1: eeprom@57 {
+		compatible = "atmel,24c64";
+		reg = <0x57>;
+		pagesize = <0x20>;
+	};
+};
+
+&cp0_nand_controller {
+	pinctrl-names = "default";
+	pinctrl-0 = <&nand_pins &nand_rb>;
+
+	nand@0 {
+		reg = <0>;
+		label = "main-storage";
+		nand-rb = <0>;
+		nand-ecc-mode = "hw";
+		nand-on-flash-bbt;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "U-Boot";
+				reg = <0 0x200000>;
+			};
+			partition@200000 {
+				label = "Linux";
+				reg = <0x200000 0xd00000>;
+			};
+			partition@1000000 {
+				label = "Filesystem";
+				reg = <0x1000000 0x3f000000>;
+			};
+		};
+	};
+};
+
+&cp0_spi0 {
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&cp0_spi0_pins>;
+	status = "okay";
+	spi-flash@0 {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <108000000>;
+
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x00000000 0x00200000>;
+				label = "uboot";
+			};
+
+			partition@1 {
+				reg = <0x00200000 0x00010000>;
+				label = "uboot-env";
+				env_size = <0x00010000>;
+			};
+
+			partition@2 {
+				reg = <0x00210000 0x00df0000>;
+				label = "onie";
+			};
+		};
+	};
+};
+
+&cp0_comphy1 {
+   phy-skip-config;
+};
+
+&cp0_sata0 {
+	status = "okay";
+
+	sata-port@1 {
+		status = "okay";
+		/* Generic PHY, providing serdes lanes */
+		//phys = <&cp0_comphy1 0>;
+	};
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+	status = "okay";
+};
+
+&cp0_mdio {
+	status = "okay";
+	OOB_E1512_PHY: ethernet-phy@1 {
+                reg = <0x0>;
+        };
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy2 0>;
+	phy-mode = "2500base-x";
+	phy-speed=<2500>;
+	/* Generic PHY, providing serdes lanes */
+	fixed-link {
+	speed = <2500>;
+	full-duplex;
+	};
+};
+
+&cp0_eth1 {
+	status = "disable";
+	/* Network PHY */
+	phys = <&cp0_comphy3 1>;
+	phy-mode = "1000base-x";
+	fixed-link {
+	      speed = <1000>;
+	      full-duplex;
+	};
+};
+
+&cp0_eth2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "okay";
+};

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn4810m-dn.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn4810m-dn.dts
@@ -1,0 +1,1706 @@
+/*
+ * Delta TN4810M-DN Device Tree Source
+ *
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "delta,tn4810m-dn";
+	compatible = "delta,tn4810m-dn";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+		los-gpio = <&tn48xxm_dn_cpld 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 2 GPIO_ACTIVE_HIGH>;
+	};
+	sfp2: sfp-2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+		los-gpio = <&tn48xxm_dn_cpld 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 5 GPIO_ACTIVE_HIGH>;
+	};
+	sfp3: sfp-3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+		los-gpio = <&tn48xxm_dn_cpld 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 8 GPIO_ACTIVE_HIGH>;
+	};
+	sfp4: sfp-4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+		los-gpio = <&tn48xxm_dn_cpld 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 11 GPIO_ACTIVE_HIGH>;
+	};
+	sfp5: sfp-5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp5>;
+		los-gpio = <&tn48xxm_dn_cpld 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 14 GPIO_ACTIVE_HIGH>;
+	};
+	sfp6: sfp-6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp6>;
+		los-gpio = <&tn48xxm_dn_cpld 15 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 17 GPIO_ACTIVE_HIGH>;
+	};
+	sfp7: sfp-7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp7>;
+		los-gpio = <&tn48xxm_dn_cpld 18 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 19 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 20 GPIO_ACTIVE_HIGH>;
+	};
+	sfp8: sfp-8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp8>;
+		los-gpio = <&tn48xxm_dn_cpld 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 23 GPIO_ACTIVE_HIGH>;
+	};
+	sfp9: sfp-9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp9>;
+		los-gpio = <&tn48xxm_dn_cpld 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 26 GPIO_ACTIVE_HIGH>;
+	};
+	sfp10: sfp-10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp10>;
+		los-gpio = <&tn48xxm_dn_cpld 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 29 GPIO_ACTIVE_HIGH>;
+	};
+	sfp11: sfp-11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp11>;
+		los-gpio = <&tn48xxm_dn_cpld 30 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 31 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 32 GPIO_ACTIVE_HIGH>;
+	};
+	sfp12: sfp-12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp12>;
+		los-gpio = <&tn48xxm_dn_cpld 33 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 34 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 35 GPIO_ACTIVE_HIGH>;
+	};
+	sfp13: sfp-13 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp13>;
+		los-gpio = <&tn48xxm_dn_cpld 36 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 37 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 38 GPIO_ACTIVE_HIGH>;
+	};
+	sfp14: sfp-14 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp14>;
+		los-gpio = <&tn48xxm_dn_cpld 39 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 40 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 41 GPIO_ACTIVE_HIGH>;
+	};
+	sfp15: sfp-15 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp15>;
+		los-gpio = <&tn48xxm_dn_cpld 42 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 43 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 44 GPIO_ACTIVE_HIGH>;
+	};
+	sfp16: sfp-16 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp16>;
+		los-gpio = <&tn48xxm_dn_cpld 45 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 46 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 47 GPIO_ACTIVE_HIGH>;
+	};
+	sfp17: sfp-17 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp17>;
+		los-gpio = <&tn48xxm_dn_cpld 48 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 49 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 50 GPIO_ACTIVE_HIGH>;
+	};
+	sfp18: sfp-18 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp18>;
+		los-gpio = <&tn48xxm_dn_cpld 51 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 52 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 53 GPIO_ACTIVE_HIGH>;
+	};
+	sfp19: sfp-19 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp19>;
+		los-gpio = <&tn48xxm_dn_cpld 54 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 55 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 56 GPIO_ACTIVE_HIGH>;
+	};
+	sfp20: sfp-20 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp20>;
+		los-gpio = <&tn48xxm_dn_cpld 57 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 58 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 59 GPIO_ACTIVE_HIGH>;
+	};
+	sfp21: sfp-21 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp21>;
+		los-gpio = <&tn48xxm_dn_cpld 60 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 61 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 62 GPIO_ACTIVE_HIGH>;
+	};
+	sfp22: sfp-22 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp22>;
+		los-gpio = <&tn48xxm_dn_cpld 63 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 64 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 65 GPIO_ACTIVE_HIGH>;
+	};
+	sfp23: sfp-23 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp23>;
+		los-gpio = <&tn48xxm_dn_cpld 66 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 67 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 68 GPIO_ACTIVE_HIGH>;
+	};
+	sfp24: sfp-24 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp24>;
+		los-gpio = <&tn48xxm_dn_cpld 69 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 70 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 71 GPIO_ACTIVE_HIGH>;
+	};
+	sfp25: sfp-25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp25>;
+		los-gpio = <&tn48xxm_dn_cpld 72 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 73 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 74 GPIO_ACTIVE_HIGH>;
+	};
+	sfp26: sfp-26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp26>;
+		los-gpio = <&tn48xxm_dn_cpld 75 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 76 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 77 GPIO_ACTIVE_HIGH>;
+	};
+	sfp27: sfp-27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp27>;
+		los-gpio = <&tn48xxm_dn_cpld 78 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 79 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 80 GPIO_ACTIVE_HIGH>;
+	};
+	sfp28: sfp-28 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp28>;
+		los-gpio = <&tn48xxm_dn_cpld 81 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 82 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 83 GPIO_ACTIVE_HIGH>;
+	};
+	sfp29: sfp-29 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp29>;
+		los-gpio = <&tn48xxm_dn_cpld 84 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 85 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 86 GPIO_ACTIVE_HIGH>;
+	};
+	sfp30: sfp-30 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp30>;
+		los-gpio = <&tn48xxm_dn_cpld 87 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 88 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 89 GPIO_ACTIVE_HIGH>;
+	};
+	sfp31: sfp-31 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp31>;
+		los-gpio = <&tn48xxm_dn_cpld 90 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 91 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 92 GPIO_ACTIVE_HIGH>;
+	};
+	sfp32: sfp-32 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp32>;
+		los-gpio = <&tn48xxm_dn_cpld 93 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 94 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 95 GPIO_ACTIVE_HIGH>;
+	};
+	sfp33: sfp-33 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp33>;
+		los-gpio = <&tn48xxm_dn_cpld 96 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 97 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 98 GPIO_ACTIVE_HIGH>;
+	};
+	sfp34: sfp-34 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp34>;
+		los-gpio = <&tn48xxm_dn_cpld 99 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 100 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 101 GPIO_ACTIVE_HIGH>;
+	};
+	sfp35: sfp-35 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp35>;
+		los-gpio = <&tn48xxm_dn_cpld 102 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 103 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 104 GPIO_ACTIVE_HIGH>;
+	};
+	sfp36: sfp-36 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp36>;
+		los-gpio = <&tn48xxm_dn_cpld 105 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 106 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 107 GPIO_ACTIVE_HIGH>;
+	};
+	sfp37: sfp-37 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp37>;
+		los-gpio = <&tn48xxm_dn_cpld 108 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 109 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 110 GPIO_ACTIVE_HIGH>;
+	};
+	sfp38: sfp-38 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp38>;
+		los-gpio = <&tn48xxm_dn_cpld 111 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 112 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 113 GPIO_ACTIVE_HIGH>;
+	};
+	sfp39: sfp-39 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp39>;
+		los-gpio = <&tn48xxm_dn_cpld 114 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 115 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 116 GPIO_ACTIVE_HIGH>;
+	};
+	sfp40: sfp-40 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp40>;
+		los-gpio = <&tn48xxm_dn_cpld 117 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 118 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 119 GPIO_ACTIVE_HIGH>;
+	};
+	sfp41: sfp-41 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp41>;
+		los-gpio = <&tn48xxm_dn_cpld 120 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 121 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 122 GPIO_ACTIVE_HIGH>;
+	};
+	sfp42: sfp-42 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp42>;
+		los-gpio = <&tn48xxm_dn_cpld 123 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 124 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 125 GPIO_ACTIVE_HIGH>;
+	};
+	sfp43: sfp-43 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp43>;
+		los-gpio = <&tn48xxm_dn_cpld 126 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 127 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 128 GPIO_ACTIVE_HIGH>;
+	};
+	sfp44: sfp-44 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp44>;
+		los-gpio = <&tn48xxm_dn_cpld 129 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 130 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 131 GPIO_ACTIVE_HIGH>;
+	};
+	sfp45: sfp-45 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp45>;
+		los-gpio = <&tn48xxm_dn_cpld 132 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 133 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 134 GPIO_ACTIVE_HIGH>;
+	};
+	sfp46: sfp-46 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp46>;
+		los-gpio = <&tn48xxm_dn_cpld 135 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 136 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 137 GPIO_ACTIVE_HIGH>;
+	};
+	sfp47: sfp-47 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp47>;
+		los-gpio = <&tn48xxm_dn_cpld 138 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 139 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 140 GPIO_ACTIVE_HIGH>;
+	};
+	sfp48: sfp-48 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp48>;
+		los-gpio = <&tn48xxm_dn_cpld 141 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 142 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 143 GPIO_ACTIVE_HIGH>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		/*
+			Marvell Switchdev driver compatible the SFP number with the front-panel number. 
+		*/
+		ports {
+			port1 {
+				prestera,port-num = <1>;
+				sfp = <&sfp1>;
+			};
+			port2 {
+				prestera,port-num = <2>;
+				sfp = <&sfp2>;
+			};
+			port3 {
+				prestera,port-num = <3>;
+				sfp = <&sfp3>;
+			};
+			port4 {
+				prestera,port-num = <4>;
+				sfp = <&sfp4>;
+			};
+			port5 {
+				prestera,port-num = <5>;
+				sfp = <&sfp5>;
+			};
+			port6 {
+				prestera,port-num = <6>;
+				sfp = <&sfp6>;
+			};
+			port7 {
+				prestera,port-num = <7>;
+				sfp = <&sfp7>;
+			};
+			port8 {
+				prestera,port-num = <8>;
+				sfp = <&sfp8>;
+			};
+			port9 {
+				prestera,port-num = <9>;
+				sfp = <&sfp9>;
+			};
+			port10 {
+				prestera,port-num = <10>;
+				sfp = <&sfp10>;
+			};
+			port11 {
+				prestera,port-num = <11>;
+				sfp = <&sfp11>;
+			};
+			port12 {
+				prestera,port-num = <12>;
+				sfp = <&sfp12>;
+			};
+			port13 {
+				prestera,port-num = <13>;
+				sfp = <&sfp13>;
+			};
+			port14 {
+				prestera,port-num = <14>;
+				sfp = <&sfp14>;
+			};
+			port15 {
+				prestera,port-num = <15>;
+				sfp = <&sfp15>;
+			};
+			port16 {
+				prestera,port-num = <16>;
+				sfp = <&sfp16>;
+			};
+			port17 {
+				prestera,port-num = <17>;
+				sfp = <&sfp17>;
+			};
+			port18 {
+				prestera,port-num = <18>;
+				sfp = <&sfp18>;
+			};
+			port19 {
+				prestera,port-num = <19>;
+				sfp = <&sfp19>;
+			};
+			port20 {
+				prestera,port-num = <20>;
+				sfp = <&sfp20>;
+			};
+			port21 {
+				prestera,port-num = <21>;
+				sfp = <&sfp21>;
+			};
+			port22 {
+				prestera,port-num = <22>;
+				sfp = <&sfp22>;
+			};
+			port23 {
+				prestera,port-num = <23>;
+				sfp = <&sfp23>;
+			};
+			port24 {
+				prestera,port-num = <24>;
+				sfp = <&sfp24>;
+			};
+			port25 {
+				prestera,port-num = <25>;
+				sfp = <&sfp25>;
+			};
+			port26 {
+				prestera,port-num = <26>;
+				sfp = <&sfp26>;
+			};
+			port27 {
+				prestera,port-num = <27>;
+				sfp = <&sfp27>;
+			};
+			port28 {
+				prestera,port-num = <28>;
+				sfp = <&sfp28>;
+			};
+			port29 {
+				prestera,port-num = <29>;
+				sfp = <&sfp29>;
+			};
+			port30 {
+				prestera,port-num = <30>;
+				sfp = <&sfp30>;
+			};
+			port31 {
+				prestera,port-num = <31>;
+				sfp = <&sfp31>;
+			};
+			port32 {
+				prestera,port-num = <32>;
+				sfp = <&sfp32>;
+			};
+			port33 {
+				prestera,port-num = <33>;
+				sfp = <&sfp33>;
+			};
+			port34 {
+				prestera,port-num = <34>;
+				sfp = <&sfp34>;
+			};
+			port35 {
+				prestera,port-num = <35>;
+				sfp = <&sfp35>;
+			};
+			port36 {
+				prestera,port-num = <36>;
+				sfp = <&sfp36>;
+			};
+			port37 {
+				prestera,port-num = <37>;
+				sfp = <&sfp37>;
+			};
+			port38 {
+				prestera,port-num = <38>;
+				sfp = <&sfp38>;
+			};
+			port39 {
+				prestera,port-num = <39>;
+				sfp = <&sfp39>;
+			};
+			port40 {
+				prestera,port-num = <40>;
+				sfp = <&sfp40>;
+			};
+			port41 {
+				prestera,port-num = <41>;
+				sfp = <&sfp41>;
+			};
+			port42 {
+				prestera,port-num = <42>;
+				sfp = <&sfp42>;
+			};
+			port43 {
+				prestera,port-num = <43>;
+				sfp = <&sfp43>;
+			};
+			port44 {
+				prestera,port-num = <44>;
+				sfp = <&sfp44>;
+			};
+			port45 {
+				prestera,port-num = <45>;
+				sfp = <&sfp45>;
+			};
+			port46 {
+				prestera,port-num = <46>;
+				sfp = <&sfp46>;
+			};
+			port47 {
+				prestera,port-num = <47>;
+				sfp = <&sfp47>;
+			};
+			port48 {
+				prestera,port-num = <48>;
+				sfp = <&sfp48>;
+			};
+		};
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		base-mac-provider = <&onie_eeprom>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	i2c-mux@77 {
+		compatible = "nxp,pca9546";
+		reg = <0x77>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+
+			tn48xxm_dn_cpld: tn48xxm-dn-cpld@41 {
+				compatible = "dni,tn4810m_dn_cpld";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x41>;  /* CPLD/MUX I2C address */
+
+				gpio-map {
+					/* sfp1 */
+					sfp01_gpio00_loss {
+						reg-map = <0x40 (1 << 0)>;
+						gpio-num = <0>;
+					};
+					sfp01_gpio01_pres {
+						reg-map = <0x3a (1 << 0)>;
+						gpio-num = <1>;
+					};
+					sfp01_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 0)>;
+						gpio-num = <2>;
+					};
+					/* sfp2 */
+					sfp02_gpio00_sfp_loss {
+						reg-map = <0x40 (1 << 1)>;
+						gpio-num = <3>;
+					};
+					sfp02_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 1)>;
+						gpio-num = <4>;
+					};
+					sfp02_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 1)>;
+						gpio-num = <5>;
+					};
+					/* sfp3 */
+					sfp03_gpio00_loss {
+						reg-map = <0x40 (1 << 2)>;
+						gpio-num = <6>;
+					};
+					sfp03_gpio01_pres {
+						reg-map = <0x3a (1 << 2)>;
+						gpio-num = <7>;
+					};
+					sfp03_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 2)>;
+						gpio-num = <8>;
+					};
+					/* sfp4 */
+					sfp04_gpio00_loss {
+						reg-map = <0x40 (1 << 3)>;
+						gpio-num = <9>;
+					};
+					sfp04_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 3)>;
+						gpio-num = <10>;
+					};
+					sfp04_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 3)>;
+						gpio-num = <11>;
+					};
+					/* sfp5 */
+					sfp05_gpio00_loss {
+						reg-map = <0x40 (1 << 4)>;
+						gpio-num = <12>;
+					};
+					sfp05_gpio01_pres {
+						reg-map = <0x3a (1 << 4)>;
+						gpio-num = <13>;
+					};
+					sfp05_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 4)>;
+						gpio-num = <14>;
+					};
+					/* sfp6 */
+					sfp06_gpio00_sfp_loss {
+						reg-map = <0x40 (1 << 5)>;
+						gpio-num = <15>;
+					};
+					sfp06_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 5)>;
+						gpio-num = <16>;
+					};
+					sfp06_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 5)>;
+						gpio-num = <17>;
+					};
+					/* sfp7 */
+					sfp07_gpio00_loss {
+						reg-map = <0x40 (1 << 6)>;
+						gpio-num = <18>;
+					};
+					sfp07_gpio01_pres {
+						reg-map = <0x3a (1 << 6)>;
+						gpio-num = <19>;
+					};
+					sfp07_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 6)>;
+						gpio-num = <20>;
+					};
+					/* sfp8 */
+					sfp08_gpio00_loss {
+						reg-map = <0x40 (1 << 7)>;
+						gpio-num = <21>;
+					};
+					sfp08_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 7)>;
+						gpio-num = <22>;
+					};
+					sfp08_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 7)>;
+						gpio-num = <23>;
+					};
+					/* sfp9 */
+					sfp09_gpio00_loss {
+						reg-map = <0x41 (1 << 0)>;
+						gpio-num = <24>;
+					};
+					sfp09_gpio01_pres {
+						reg-map = <0x3b (1 << 0)>;
+						gpio-num = <25>;
+					};
+					sfp09_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 0)>;
+						gpio-num = <26>;
+					};
+					/* sfp10 */
+					sfp10_gpio00_sfp_loss {
+						reg-map = <0x41 (1 << 1)>;
+						gpio-num = <27>;
+					};
+					sfp10_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 1)>;
+						gpio-num = <28>;
+					};
+					sfp10_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 1)>;
+						gpio-num = <29>;
+					};
+					/* sfp11 */
+					sfp11_gpio00_loss {
+						reg-map = <0x41 (1 << 2)>;
+						gpio-num = <30>;
+					};
+					sfp11_gpio01_pres {
+						reg-map = <0x3b (1 << 2)>;
+						gpio-num = <31>;
+					};
+					sfp11_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 2)>;
+						gpio-num = <32>;
+					};
+					/* sfp12 */
+					sfp12_gpio00_loss {
+						reg-map = <0x41 (1 << 3)>;
+						gpio-num = <33>;
+					};
+					sfp12_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 3)>;
+						gpio-num = <34>;
+					};
+					sfp12_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 3)>;
+						gpio-num = <35>;
+					};
+					/* sfp13 */
+					sfp13_gpio00_loss {
+						reg-map = <0x41 (1 << 4)>;
+						gpio-num = <36>;
+					};
+					sfp13_gpio01_pres {
+						reg-map = <0x3b (1 << 4)>;
+						gpio-num = <37>;
+					};
+					sfp13_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 4)>;
+						gpio-num = <38>;
+					};
+					/* sfp14 */
+					sfp14_gpio00_sfp_loss {
+						reg-map = <0x41 (1 << 5)>;
+						gpio-num = <39>;
+					};
+					sfp14_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 5)>;
+						gpio-num = <40>;
+					};
+					sfp14_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 5)>;
+						gpio-num = <41>;
+					};
+					/* sfp15 */
+					sfp15_gpio00_loss {
+						reg-map = <0x41 (1 << 6)>;
+						gpio-num = <42>;
+					};
+					sfp15_gpio01_pres {
+						reg-map = <0x3b (1 << 6)>;
+						gpio-num = <43>;
+					};
+					sfp15_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 6)>;
+						gpio-num = <44>;
+					};
+					/* sfp16 */
+					sfp16_gpio00_loss {
+						reg-map = <0x41 (1 << 7)>;
+						gpio-num = <45>;
+					};
+					sfp16_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 7)>;
+						gpio-num = <46>;
+					};
+					sfp16_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 7)>;
+						gpio-num = <47>;
+					};
+					/* sfp17 */
+					sfp17_gpio00_loss {
+						reg-map = <0x42 (1 << 0)>;
+						gpio-num = <48>;
+					};
+					sfp17_gpio01_pres {
+						reg-map = <0x3c (1 << 0)>;
+						gpio-num = <49>;
+					};
+					sfp17_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 0)>;
+						gpio-num = <50>;
+					};
+					/* sfp18 */
+					sfp18_gpio00_sfp_loss {
+						reg-map = <0x42 (1 << 1)>;
+						gpio-num = <51>;
+					};
+					sfp18_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 1)>;
+						gpio-num = <52>;
+					};
+					sfp18_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 1)>;
+						gpio-num = <53>;
+					};
+					/* sfp19 */
+					sfp19_gpio00_loss {
+						reg-map = <0x42 (1 << 2)>;
+						gpio-num = <54>;
+					};
+					sfp19_gpio01_pres {
+						reg-map = <0x3c (1 << 2)>;
+						gpio-num = <55>;
+					};
+					sfp19_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 2)>;
+						gpio-num = <56>;
+					};
+					/* sfp20 */
+					sfp20_gpio00_loss {
+						reg-map = <0x42 (1 << 3)>;
+						gpio-num = <57>;
+					};
+					sfp20_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 3)>;
+						gpio-num = <58>;
+					};
+					sfp20_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 3)>;
+						gpio-num = <59>;
+					};
+					/* sfp21 */
+					sfp21_gpio00_loss {
+						reg-map = <0x42 (1 << 4)>;
+						gpio-num = <60>;
+					};
+					sfp21_gpio01_pres {
+						reg-map = <0x3c (1 << 4)>;
+						gpio-num = <61>;
+					};
+					sfp21_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 4)>;
+						gpio-num = <62>;
+					};
+					/* sfp22 */
+					sfp22_gpio00_sfp_loss {
+						reg-map = <0x42 (1 << 5)>;
+						gpio-num = <63>;
+					};
+					sfp22_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 5)>;
+						gpio-num = <64>;
+					};
+					sfp22_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 5)>;
+						gpio-num = <65>;
+					};
+					/* sfp23 */
+					sfp23_gpio00_loss {
+						reg-map = <0x42 (1 << 6)>;
+						gpio-num = <66>;
+					};
+					sfp23_gpio01_pres {
+						reg-map = <0x3c (1 << 6)>;
+						gpio-num = <67>;
+					};
+					sfp23_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 6)>;
+						gpio-num = <68>;
+					};
+					/* sfp24 */
+					sfp24_gpio00_loss {
+						reg-map = <0x42 (1 << 7)>;
+						gpio-num = <69>;
+					};
+					sfp24_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 7)>;
+						gpio-num = <70>;
+					};
+					sfp24_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 7)>;
+						gpio-num = <71>;
+					};
+					/* sfp25 */
+					sfp25_gpio00_loss {
+						reg-map = <0x43 (1 << 0)>;
+						gpio-num = <72>;
+					};
+					sfp25_gpio01_pres {
+						reg-map = <0x3d (1 << 0)>;
+						gpio-num = <73>;
+					};
+					sfp25_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 0)>;
+						gpio-num = <74>;
+					};
+					/* sfp26 */
+					sfp26_gpio00_sfp_loss {
+						reg-map = <0x43 (1 << 1)>;
+						gpio-num = <75>;
+					};
+					sfp26_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 1)>;
+						gpio-num = <76>;
+					};
+					sfp26_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 1)>;
+						gpio-num = <77>;
+					};
+					/* sfp27 */
+					sfp27_gpio00_loss {
+						reg-map = <0x43 (1 << 2)>;
+						gpio-num = <78>;
+					};
+					sfp27_gpio01_pres {
+						reg-map = <0x3d (1 << 2)>;
+						gpio-num = <79>;
+					};
+					sfp27_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 2)>;
+						gpio-num = <80>;
+					};
+					/* sfp28 */
+					sfp28_gpio00_loss {
+						reg-map = <0x43 (1 << 3)>;
+						gpio-num = <81>;
+					};
+					sfp28_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 3)>;
+						gpio-num = <82>;
+					};
+					sfp28_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 3)>;
+						gpio-num = <83>;
+					};
+					/* sfp29 */
+					sfp29_gpio00_loss {
+						reg-map = <0x43 (1 << 4)>;
+						gpio-num = <84>;
+					};
+					sfp29_gpio01_pres {
+						reg-map = <0x3d (1 << 4)>;
+						gpio-num = <85>;
+					};
+					sfp29_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 4)>;
+						gpio-num = <86>;
+					};
+					/* sfp30 */
+					sfp30_gpio00_sfp_loss {
+						reg-map = <0x43 (1 << 5)>;
+						gpio-num = <87>;
+					};
+					sfp30_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 5)>;
+						gpio-num = <88>;
+					};
+					sfp30_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 5)>;
+						gpio-num = <89>;
+					};
+					/* sfp31 */
+					sfp31_gpio00_loss {
+						reg-map = <0x43 (1 << 6)>;
+						gpio-num = <90>;
+					};
+					sfp31_gpio01_pres {
+						reg-map = <0x3d (1 << 6)>;
+						gpio-num = <91>;
+					};
+					sfp31_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 6)>;
+						gpio-num = <92>;
+					};
+					/* sfp32 */
+					sfp32_gpio00_loss {
+						reg-map = <0x43 (1 << 7)>;
+						gpio-num = <93>;
+					};
+					sfp32_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 7)>;
+						gpio-num = <94>;
+					};
+					sfp32_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 7)>;
+						gpio-num = <95>;
+					};
+					/* sfp33 */
+					sfp33_gpio00_loss {
+						reg-map = <0x44 (1 << 0)>;
+						gpio-num = <96>;
+					};
+					sfp33_gpio01_pres {
+						reg-map = <0x3e (1 << 0)>;
+						gpio-num = <97>;
+					};
+					sfp33_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 0)>;
+						gpio-num = <98>;
+					};
+					/* sfp34 */
+					sfp34_gpio00_sfp_loss {
+						reg-map = <0x44 (1 << 1)>;
+						gpio-num = <99>;
+					};
+					sfp34_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 1)>;
+						gpio-num = <100>;
+					};
+					sfp34_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 1)>;
+						gpio-num = <101>;
+					};
+					/* sfp35 */
+					sfp35_gpio00_loss {
+						reg-map = <0x44 (1 << 2)>;
+						gpio-num = <102>;
+					};
+					sfp35_gpio01_pres {
+						reg-map = <0x3e (1 << 2)>;
+						gpio-num = <103>;
+					};
+					sfp35_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 2)>;
+						gpio-num = <104>;
+					};
+					/* sfp36 */
+					sfp36_gpio00_loss {
+						reg-map = <0x44 (1 << 3)>;
+						gpio-num = <105>;
+					};
+					sfp36_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 3)>;
+						gpio-num = <106>;
+					};
+					sfp36_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 3)>;
+						gpio-num = <107>;
+					};
+					/* sfp37 */
+					sfp37_gpio00_loss {
+						reg-map = <0x44 (1 << 4)>;
+						gpio-num = <108>;
+					};
+					sfp37_gpio01_pres {
+						reg-map = <0x3e (1 << 4)>;
+						gpio-num = <109>;
+					};
+					sfp37_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 4)>;
+						gpio-num = <110>;
+					};
+					/* sfp38 */
+					sfp38_gpio00_sfp_loss {
+						reg-map = <0x44 (1 << 5)>;
+						gpio-num = <111>;
+					};
+					sfp38_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 5)>;
+						gpio-num = <112>;
+					};
+					sfp38_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 5)>;
+						gpio-num = <113>;
+					};
+					/* sfp39 */
+					sfp39_gpio00_loss {
+						reg-map = <0x44 (1 << 6)>;
+						gpio-num = <114>;
+					};
+					sfp39_gpio01_pres {
+						reg-map = <0x3e (1 << 6)>;
+						gpio-num = <115>;
+					};
+					sfp39_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 6)>;
+						gpio-num = <116>;
+					};
+					/* sfp40 */
+					sfp40_gpio00_loss {
+						reg-map = <0x44 (1 << 7)>;
+						gpio-num = <117>;
+					};
+					sfp40_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 7)>;
+						gpio-num = <118>;
+					};
+					sfp40_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 7)>;
+						gpio-num = <119>;
+					};
+					/* sfp41 */
+					sfp41_gpio00_loss {
+						reg-map = <0x45 (1 << 0)>;
+						gpio-num = <120>;
+					};
+					sfp41_gpio01_pres {
+						reg-map = <0x3f (1 << 0)>;
+						gpio-num = <121>;
+					};
+					sfp41_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 0)>;
+						gpio-num = <122>;
+					};
+					/* sfp42 */
+					sfp42_gpio00_sfp_loss {
+						reg-map = <0x45 (1 << 1)>;
+						gpio-num = <123>;
+					};
+					sfp42_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 1)>;
+						gpio-num = <124>;
+					};
+					sfp42_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 1)>;
+						gpio-num = <125>;
+					};
+					/* sfp43 */
+					sfp43_gpio00_loss {
+						reg-map = <0x45 (1 << 2)>;
+						gpio-num = <126>;
+					};
+					sfp43_gpio01_pres {
+						reg-map = <0x3f (1 << 2)>;
+						gpio-num = <127>;
+					};
+					sfp43_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 2)>;
+						gpio-num = <128>;
+					};
+					/* sfp44 */
+					sfp44_gpio00_loss {
+						reg-map = <0x45 (1 << 3)>;
+						gpio-num = <129>;
+					};
+					sfp44_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 3)>;
+						gpio-num = <130>;
+					};
+					sfp44_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 3)>;
+						gpio-num = <131>;
+					};
+					/* sfp45 */
+					sfp45_gpio00_loss {
+						reg-map = <0x45 (1 << 4)>;
+						gpio-num = <132>;
+					};
+					sfp45_gpio01_pres {
+						reg-map = <0x3f (1 << 4)>;
+						gpio-num = <133>;
+					};
+					sfp45_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 4)>;
+						gpio-num = <134>;
+					};
+					/* sfp46 */
+					sfp46_gpio00_sfp_loss {
+						reg-map = <0x45 (1 << 5)>;
+						gpio-num = <135>;
+					};
+					sfp46_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 5)>;
+						gpio-num = <136>;
+					};
+					sfp46_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 5)>;
+						gpio-num = <137>;
+					};
+					/* sfp47 */
+					sfp47_gpio00_loss {
+						reg-map = <0x45 (1 << 6)>;
+						gpio-num = <138>;
+					};
+					sfp47_gpio01_pres {
+						reg-map = <0x3f (1 << 6)>;
+						gpio-num = <139>;
+					};
+					sfp47_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 6)>;
+						gpio-num = <140>;
+					};
+					/* sfp48 */
+					sfp48_gpio00_loss {
+						reg-map = <0x45 (1 << 7)>;
+						gpio-num = <141>;
+					};
+					sfp48_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 7)>;
+						gpio-num = <142>;
+					};
+					sfp48_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 7)>;
+						gpio-num = <143>;
+					};
+				};
+			};
+		};
+		i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	tpm0: slb9670@0 {
+		compatible = "infineon,slb9670";
+		reg = <0>;
+		spi-max-frequency = <38000000>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+};
+
+&cp0_i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	i2c-mux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp1: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp2: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp3: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp4: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp5: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp6: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp7: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp8: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@71 {
+		compatible = "nxp,pca9548";
+		reg = <0x71>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp9: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp10: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp11: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp12: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp13: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp14: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp15: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp16: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@72 {
+		compatible = "nxp,pca9548";
+		reg = <0x72>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp17: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp18: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp19: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp20: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp21: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp22: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp23: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp24: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@73 {
+		compatible = "nxp,pca9548";
+		reg = <0x73>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp25: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp26: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp27: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp28: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp29: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp30: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp31: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp32: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@74 {
+		compatible = "nxp,pca9548";
+		reg = <0x74>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp33: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp34: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp35: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp36: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp37: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp38: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp39: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp40: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@75 {
+		compatible = "nxp,pca9548";
+		reg = <0x75>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp41: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp42: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp43: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp44: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp45: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp46: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp47: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp48: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+};
+
+&cp0_spi0 {
+	status = "okay";
+
+	spi-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x3f0000>;
+			};
+
+			partition@3f0000 {
+				label = "uboot-env";
+				reg = <0x3f0000 0x010000>;
+			};
+
+			partition@400000 {
+				label = "ONIE";
+				reg = <0x400000 0xc00000>;
+			};
+		};
+	};
+};
+
+&cp0_sata0 {
+	status = "okay";
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_mdio {
+	status = "okay";
+
+	OOB_E1512_PHY: ethernet-phy@1 {
+		reg = <0x0>;
+	};
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disabled";
+};
+
+&cp0_eth1 {
+	status = "disabled";
+};
+
+&cp0_eth2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "disabled";
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn4810m.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn4810m.dts
@@ -1,0 +1,1706 @@
+/*
+ * Delta TN48M/TN48M2/TN48M-POE Device Tree Source
+ *
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "delta,tn48m";
+	compatible = "delta,tn48m";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+		los-gpio = <&tn48xxm_cpld 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 2 GPIO_ACTIVE_HIGH>;
+	};
+	sfp2: sfp-2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+		los-gpio = <&tn48xxm_cpld 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 5 GPIO_ACTIVE_HIGH>;
+	};
+	sfp3: sfp-3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+		los-gpio = <&tn48xxm_cpld 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 8 GPIO_ACTIVE_HIGH>;
+	};
+	sfp4: sfp-4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+		los-gpio = <&tn48xxm_cpld 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 11 GPIO_ACTIVE_HIGH>;
+	};
+	sfp5: sfp-5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp5>;
+		los-gpio = <&tn48xxm_cpld 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 14 GPIO_ACTIVE_HIGH>;
+	};
+	sfp6: sfp-6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp6>;
+		los-gpio = <&tn48xxm_cpld 15 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 17 GPIO_ACTIVE_HIGH>;
+	};
+	sfp7: sfp-7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp7>;
+		los-gpio = <&tn48xxm_cpld 18 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 19 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 20 GPIO_ACTIVE_HIGH>;
+	};
+	sfp8: sfp-8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp8>;
+		los-gpio = <&tn48xxm_cpld 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 23 GPIO_ACTIVE_HIGH>;
+	};
+	sfp9: sfp-9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp9>;
+		los-gpio = <&tn48xxm_cpld 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 26 GPIO_ACTIVE_HIGH>;
+	};
+	sfp10: sfp-10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp10>;
+		los-gpio = <&tn48xxm_cpld 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 29 GPIO_ACTIVE_HIGH>;
+	};
+	sfp11: sfp-11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp11>;
+		los-gpio = <&tn48xxm_cpld 30 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 31 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 32 GPIO_ACTIVE_HIGH>;
+	};
+	sfp12: sfp-12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp12>;
+		los-gpio = <&tn48xxm_cpld 33 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 34 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 35 GPIO_ACTIVE_HIGH>;
+	};
+	sfp13: sfp-13 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp13>;
+		los-gpio = <&tn48xxm_cpld 36 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 37 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 38 GPIO_ACTIVE_HIGH>;
+	};
+	sfp14: sfp-14 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp14>;
+		los-gpio = <&tn48xxm_cpld 39 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 40 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 41 GPIO_ACTIVE_HIGH>;
+	};
+	sfp15: sfp-15 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp15>;
+		los-gpio = <&tn48xxm_cpld 42 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 43 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 44 GPIO_ACTIVE_HIGH>;
+	};
+	sfp16: sfp-16 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp16>;
+		los-gpio = <&tn48xxm_cpld 45 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 46 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 47 GPIO_ACTIVE_HIGH>;
+	};
+	sfp17: sfp-17 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp17>;
+		los-gpio = <&tn48xxm_cpld 48 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 49 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 50 GPIO_ACTIVE_HIGH>;
+	};
+	sfp18: sfp-18 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp18>;
+		los-gpio = <&tn48xxm_cpld 51 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 52 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 53 GPIO_ACTIVE_HIGH>;
+	};
+	sfp19: sfp-19 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp19>;
+		los-gpio = <&tn48xxm_cpld 54 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 55 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 56 GPIO_ACTIVE_HIGH>;
+	};
+	sfp20: sfp-20 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp20>;
+		los-gpio = <&tn48xxm_cpld 57 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 58 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 59 GPIO_ACTIVE_HIGH>;
+	};
+	sfp21: sfp-21 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp21>;
+		los-gpio = <&tn48xxm_cpld 60 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 61 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 62 GPIO_ACTIVE_HIGH>;
+	};
+	sfp22: sfp-22 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp22>;
+		los-gpio = <&tn48xxm_cpld 63 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 64 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 65 GPIO_ACTIVE_HIGH>;
+	};
+	sfp23: sfp-23 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp23>;
+		los-gpio = <&tn48xxm_cpld 66 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 67 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 68 GPIO_ACTIVE_HIGH>;
+	};
+	sfp24: sfp-24 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp24>;
+		los-gpio = <&tn48xxm_cpld 69 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 70 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 71 GPIO_ACTIVE_HIGH>;
+	};
+	sfp25: sfp-25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp25>;
+		los-gpio = <&tn48xxm_cpld 72 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 73 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 74 GPIO_ACTIVE_HIGH>;
+	};
+	sfp26: sfp-26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp26>;
+		los-gpio = <&tn48xxm_cpld 75 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 76 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 77 GPIO_ACTIVE_HIGH>;
+	};
+	sfp27: sfp-27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp27>;
+		los-gpio = <&tn48xxm_cpld 78 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 79 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 80 GPIO_ACTIVE_HIGH>;
+	};
+	sfp28: sfp-28 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp28>;
+		los-gpio = <&tn48xxm_cpld 81 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 82 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 83 GPIO_ACTIVE_HIGH>;
+	};
+	sfp29: sfp-29 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp29>;
+		los-gpio = <&tn48xxm_cpld 84 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 85 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 86 GPIO_ACTIVE_HIGH>;
+	};
+	sfp30: sfp-30 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp30>;
+		los-gpio = <&tn48xxm_cpld 87 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 88 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 89 GPIO_ACTIVE_HIGH>;
+	};
+	sfp31: sfp-31 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp31>;
+		los-gpio = <&tn48xxm_cpld 90 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 91 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 92 GPIO_ACTIVE_HIGH>;
+	};
+	sfp32: sfp-32 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp32>;
+		los-gpio = <&tn48xxm_cpld 93 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 94 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 95 GPIO_ACTIVE_HIGH>;
+	};
+	sfp33: sfp-33 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp33>;
+		los-gpio = <&tn48xxm_cpld 96 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 97 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 98 GPIO_ACTIVE_HIGH>;
+	};
+	sfp34: sfp-34 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp34>;
+		los-gpio = <&tn48xxm_cpld 99 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 100 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 101 GPIO_ACTIVE_HIGH>;
+	};
+	sfp35: sfp-35 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp35>;
+		los-gpio = <&tn48xxm_cpld 102 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 103 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 104 GPIO_ACTIVE_HIGH>;
+	};
+	sfp36: sfp-36 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp36>;
+		los-gpio = <&tn48xxm_cpld 105 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 106 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 107 GPIO_ACTIVE_HIGH>;
+	};
+	sfp37: sfp-37 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp37>;
+		los-gpio = <&tn48xxm_cpld 108 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 109 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 110 GPIO_ACTIVE_HIGH>;
+	};
+	sfp38: sfp-38 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp38>;
+		los-gpio = <&tn48xxm_cpld 111 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 112 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 113 GPIO_ACTIVE_HIGH>;
+	};
+	sfp39: sfp-39 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp39>;
+		los-gpio = <&tn48xxm_cpld 114 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 115 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 116 GPIO_ACTIVE_HIGH>;
+	};
+	sfp40: sfp-40 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp40>;
+		los-gpio = <&tn48xxm_cpld 117 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 118 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 119 GPIO_ACTIVE_HIGH>;
+	};
+	sfp41: sfp-41 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp41>;
+		los-gpio = <&tn48xxm_cpld 120 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 121 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 122 GPIO_ACTIVE_HIGH>;
+	};
+	sfp42: sfp-42 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp42>;
+		los-gpio = <&tn48xxm_cpld 123 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 124 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 125 GPIO_ACTIVE_HIGH>;
+	};
+	sfp43: sfp-43 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp43>;
+		los-gpio = <&tn48xxm_cpld 126 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 127 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 128 GPIO_ACTIVE_HIGH>;
+	};
+	sfp44: sfp-44 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp44>;
+		los-gpio = <&tn48xxm_cpld 129 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 130 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 131 GPIO_ACTIVE_HIGH>;
+	};
+	sfp45: sfp-45 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp45>;
+		los-gpio = <&tn48xxm_cpld 132 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 133 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 134 GPIO_ACTIVE_HIGH>;
+	};
+	sfp46: sfp-46 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp46>;
+		los-gpio = <&tn48xxm_cpld 135 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 136 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 137 GPIO_ACTIVE_HIGH>;
+	};
+	sfp47: sfp-47 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp47>;
+		los-gpio = <&tn48xxm_cpld 138 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 139 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 140 GPIO_ACTIVE_HIGH>;
+	};
+	sfp48: sfp-48 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp48>;
+		los-gpio = <&tn48xxm_cpld 141 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 142 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 143 GPIO_ACTIVE_HIGH>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		/*
+			Marvell Switchdev driver compatible the SFP number with the front-panel number. 
+		*/
+		ports {
+			port1 {
+				prestera,port-num = <1>;
+				sfp = <&sfp1>;
+			};
+			port2 {
+				prestera,port-num = <2>;
+				sfp = <&sfp2>;
+			};
+			port3 {
+				prestera,port-num = <3>;
+				sfp = <&sfp3>;
+			};
+			port4 {
+				prestera,port-num = <4>;
+				sfp = <&sfp4>;
+			};
+			port5 {
+				prestera,port-num = <5>;
+				sfp = <&sfp5>;
+			};
+			port6 {
+				prestera,port-num = <6>;
+				sfp = <&sfp6>;
+			};
+			port7 {
+				prestera,port-num = <7>;
+				sfp = <&sfp7>;
+			};
+			port8 {
+				prestera,port-num = <8>;
+				sfp = <&sfp8>;
+			};
+			port9 {
+				prestera,port-num = <9>;
+				sfp = <&sfp9>;
+			};
+			port10 {
+				prestera,port-num = <10>;
+				sfp = <&sfp10>;
+			};
+			port11 {
+				prestera,port-num = <11>;
+				sfp = <&sfp11>;
+			};
+			port12 {
+				prestera,port-num = <12>;
+				sfp = <&sfp12>;
+			};
+			port13 {
+				prestera,port-num = <13>;
+				sfp = <&sfp13>;
+			};
+			port14 {
+				prestera,port-num = <14>;
+				sfp = <&sfp14>;
+			};
+			port15 {
+				prestera,port-num = <15>;
+				sfp = <&sfp15>;
+			};
+			port16 {
+				prestera,port-num = <16>;
+				sfp = <&sfp16>;
+			};
+			port17 {
+				prestera,port-num = <17>;
+				sfp = <&sfp17>;
+			};
+			port18 {
+				prestera,port-num = <18>;
+				sfp = <&sfp18>;
+			};
+			port19 {
+				prestera,port-num = <19>;
+				sfp = <&sfp19>;
+			};
+			port20 {
+				prestera,port-num = <20>;
+				sfp = <&sfp20>;
+			};
+			port21 {
+				prestera,port-num = <21>;
+				sfp = <&sfp21>;
+			};
+			port22 {
+				prestera,port-num = <22>;
+				sfp = <&sfp22>;
+			};
+			port23 {
+				prestera,port-num = <23>;
+				sfp = <&sfp23>;
+			};
+			port24 {
+				prestera,port-num = <24>;
+				sfp = <&sfp24>;
+			};
+			port25 {
+				prestera,port-num = <25>;
+				sfp = <&sfp25>;
+			};
+			port26 {
+				prestera,port-num = <26>;
+				sfp = <&sfp26>;
+			};
+			port27 {
+				prestera,port-num = <27>;
+				sfp = <&sfp27>;
+			};
+			port28 {
+				prestera,port-num = <28>;
+				sfp = <&sfp28>;
+			};
+			port29 {
+				prestera,port-num = <29>;
+				sfp = <&sfp29>;
+			};
+			port30 {
+				prestera,port-num = <30>;
+				sfp = <&sfp30>;
+			};
+			port31 {
+				prestera,port-num = <31>;
+				sfp = <&sfp31>;
+			};
+			port32 {
+				prestera,port-num = <32>;
+				sfp = <&sfp32>;
+			};
+			port33 {
+				prestera,port-num = <33>;
+				sfp = <&sfp33>;
+			};
+			port34 {
+				prestera,port-num = <34>;
+				sfp = <&sfp34>;
+			};
+			port35 {
+				prestera,port-num = <35>;
+				sfp = <&sfp35>;
+			};
+			port36 {
+				prestera,port-num = <36>;
+				sfp = <&sfp36>;
+			};
+			port37 {
+				prestera,port-num = <37>;
+				sfp = <&sfp37>;
+			};
+			port38 {
+				prestera,port-num = <38>;
+				sfp = <&sfp38>;
+			};
+			port39 {
+				prestera,port-num = <39>;
+				sfp = <&sfp39>;
+			};
+			port40 {
+				prestera,port-num = <40>;
+				sfp = <&sfp40>;
+			};
+			port41 {
+				prestera,port-num = <41>;
+				sfp = <&sfp41>;
+			};
+			port42 {
+				prestera,port-num = <42>;
+				sfp = <&sfp42>;
+			};
+			port43 {
+				prestera,port-num = <43>;
+				sfp = <&sfp43>;
+			};
+			port44 {
+				prestera,port-num = <44>;
+				sfp = <&sfp44>;
+			};
+			port45 {
+				prestera,port-num = <45>;
+				sfp = <&sfp45>;
+			};
+			port46 {
+				prestera,port-num = <46>;
+				sfp = <&sfp46>;
+			};
+			port47 {
+				prestera,port-num = <47>;
+				sfp = <&sfp47>;
+			};
+			port48 {
+				prestera,port-num = <48>;
+				sfp = <&sfp48>;
+			};
+		};
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		base-mac-provider = <&onie_eeprom>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	i2c-mux@77 {
+		compatible = "nxp,pca9546";
+		reg = <0x77>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+
+			tn48xxm_cpld: tn48xxm-cpld@41 {
+				compatible = "dni,tn4810m_cpld";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x41>;  /* CPLD/MUX I2C address */
+
+				gpio-map {
+					/* sfp1 */
+					sfp01_gpio00_loss {
+						reg-map = <0x40 (1 << 0)>;
+						gpio-num = <0>;
+					};
+					sfp01_gpio01_pres {
+						reg-map = <0x3a (1 << 0)>;
+						gpio-num = <1>;
+					};
+					sfp01_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 0)>;
+						gpio-num = <2>;
+					};
+					/* sfp2 */
+					sfp02_gpio00_sfp_loss {
+						reg-map = <0x40 (1 << 1)>;
+						gpio-num = <3>;
+					};
+					sfp02_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 1)>;
+						gpio-num = <4>;
+					};
+					sfp02_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 1)>;
+						gpio-num = <5>;
+					};
+					/* sfp3 */
+					sfp03_gpio00_loss {
+						reg-map = <0x40 (1 << 2)>;
+						gpio-num = <6>;
+					};
+					sfp03_gpio01_pres {
+						reg-map = <0x3a (1 << 2)>;
+						gpio-num = <7>;
+					};
+					sfp03_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 2)>;
+						gpio-num = <8>;
+					};
+					/* sfp4 */
+					sfp04_gpio00_loss {
+						reg-map = <0x40 (1 << 3)>;
+						gpio-num = <9>;
+					};
+					sfp04_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 3)>;
+						gpio-num = <10>;
+					};
+					sfp04_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 3)>;
+						gpio-num = <11>;
+					};
+					/* sfp5 */
+					sfp05_gpio00_loss {
+						reg-map = <0x40 (1 << 4)>;
+						gpio-num = <12>;
+					};
+					sfp05_gpio01_pres {
+						reg-map = <0x3a (1 << 4)>;
+						gpio-num = <13>;
+					};
+					sfp05_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 4)>;
+						gpio-num = <14>;
+					};
+					/* sfp6 */
+					sfp06_gpio00_sfp_loss {
+						reg-map = <0x40 (1 << 5)>;
+						gpio-num = <15>;
+					};
+					sfp06_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 5)>;
+						gpio-num = <16>;
+					};
+					sfp06_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 5)>;
+						gpio-num = <17>;
+					};
+					/* sfp7 */
+					sfp07_gpio00_loss {
+						reg-map = <0x40 (1 << 6)>;
+						gpio-num = <18>;
+					};
+					sfp07_gpio01_pres {
+						reg-map = <0x3a (1 << 6)>;
+						gpio-num = <19>;
+					};
+					sfp07_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 6)>;
+						gpio-num = <20>;
+					};
+					/* sfp8 */
+					sfp08_gpio00_loss {
+						reg-map = <0x40 (1 << 7)>;
+						gpio-num = <21>;
+					};
+					sfp08_gpio01_sfp_pres {
+						reg-map = <0x3a (1 << 7)>;
+						gpio-num = <22>;
+					};
+					sfp08_gpio02_tx_dis {
+						reg-map = <0x31 (1 << 7)>;
+						gpio-num = <23>;
+					};
+					/* sfp9 */
+					sfp09_gpio00_loss {
+						reg-map = <0x41 (1 << 0)>;
+						gpio-num = <24>;
+					};
+					sfp09_gpio01_pres {
+						reg-map = <0x3b (1 << 0)>;
+						gpio-num = <25>;
+					};
+					sfp09_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 0)>;
+						gpio-num = <26>;
+					};
+					/* sfp10 */
+					sfp10_gpio00_sfp_loss {
+						reg-map = <0x41 (1 << 1)>;
+						gpio-num = <27>;
+					};
+					sfp10_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 1)>;
+						gpio-num = <28>;
+					};
+					sfp10_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 1)>;
+						gpio-num = <29>;
+					};
+					/* sfp11 */
+					sfp11_gpio00_loss {
+						reg-map = <0x41 (1 << 2)>;
+						gpio-num = <30>;
+					};
+					sfp11_gpio01_pres {
+						reg-map = <0x3b (1 << 2)>;
+						gpio-num = <31>;
+					};
+					sfp11_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 2)>;
+						gpio-num = <32>;
+					};
+					/* sfp12 */
+					sfp12_gpio00_loss {
+						reg-map = <0x41 (1 << 3)>;
+						gpio-num = <33>;
+					};
+					sfp12_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 3)>;
+						gpio-num = <34>;
+					};
+					sfp12_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 3)>;
+						gpio-num = <35>;
+					};
+					/* sfp13 */
+					sfp13_gpio00_loss {
+						reg-map = <0x41 (1 << 4)>;
+						gpio-num = <36>;
+					};
+					sfp13_gpio01_pres {
+						reg-map = <0x3b (1 << 4)>;
+						gpio-num = <37>;
+					};
+					sfp13_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 4)>;
+						gpio-num = <38>;
+					};
+					/* sfp14 */
+					sfp14_gpio00_sfp_loss {
+						reg-map = <0x41 (1 << 5)>;
+						gpio-num = <39>;
+					};
+					sfp14_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 5)>;
+						gpio-num = <40>;
+					};
+					sfp14_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 5)>;
+						gpio-num = <41>;
+					};
+					/* sfp15 */
+					sfp15_gpio00_loss {
+						reg-map = <0x41 (1 << 6)>;
+						gpio-num = <42>;
+					};
+					sfp15_gpio01_pres {
+						reg-map = <0x3b (1 << 6)>;
+						gpio-num = <43>;
+					};
+					sfp15_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 6)>;
+						gpio-num = <44>;
+					};
+					/* sfp16 */
+					sfp16_gpio00_loss {
+						reg-map = <0x41 (1 << 7)>;
+						gpio-num = <45>;
+					};
+					sfp16_gpio01_sfp_pres {
+						reg-map = <0x3b (1 << 7)>;
+						gpio-num = <46>;
+					};
+					sfp16_gpio02_tx_dis {
+						reg-map = <0x32 (1 << 7)>;
+						gpio-num = <47>;
+					};
+					/* sfp17 */
+					sfp17_gpio00_loss {
+						reg-map = <0x42 (1 << 0)>;
+						gpio-num = <48>;
+					};
+					sfp17_gpio01_pres {
+						reg-map = <0x3c (1 << 0)>;
+						gpio-num = <49>;
+					};
+					sfp17_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 0)>;
+						gpio-num = <50>;
+					};
+					/* sfp18 */
+					sfp18_gpio00_sfp_loss {
+						reg-map = <0x42 (1 << 1)>;
+						gpio-num = <51>;
+					};
+					sfp18_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 1)>;
+						gpio-num = <52>;
+					};
+					sfp18_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 1)>;
+						gpio-num = <53>;
+					};
+					/* sfp19 */
+					sfp19_gpio00_loss {
+						reg-map = <0x42 (1 << 2)>;
+						gpio-num = <54>;
+					};
+					sfp19_gpio01_pres {
+						reg-map = <0x3c (1 << 2)>;
+						gpio-num = <55>;
+					};
+					sfp19_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 2)>;
+						gpio-num = <56>;
+					};
+					/* sfp20 */
+					sfp20_gpio00_loss {
+						reg-map = <0x42 (1 << 3)>;
+						gpio-num = <57>;
+					};
+					sfp20_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 3)>;
+						gpio-num = <58>;
+					};
+					sfp20_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 3)>;
+						gpio-num = <59>;
+					};
+					/* sfp21 */
+					sfp21_gpio00_loss {
+						reg-map = <0x42 (1 << 4)>;
+						gpio-num = <60>;
+					};
+					sfp21_gpio01_pres {
+						reg-map = <0x3c (1 << 4)>;
+						gpio-num = <61>;
+					};
+					sfp21_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 4)>;
+						gpio-num = <62>;
+					};
+					/* sfp22 */
+					sfp22_gpio00_sfp_loss {
+						reg-map = <0x42 (1 << 5)>;
+						gpio-num = <63>;
+					};
+					sfp22_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 5)>;
+						gpio-num = <64>;
+					};
+					sfp22_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 5)>;
+						gpio-num = <65>;
+					};
+					/* sfp23 */
+					sfp23_gpio00_loss {
+						reg-map = <0x42 (1 << 6)>;
+						gpio-num = <66>;
+					};
+					sfp23_gpio01_pres {
+						reg-map = <0x3c (1 << 6)>;
+						gpio-num = <67>;
+					};
+					sfp23_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 6)>;
+						gpio-num = <68>;
+					};
+					/* sfp24 */
+					sfp24_gpio00_loss {
+						reg-map = <0x42 (1 << 7)>;
+						gpio-num = <69>;
+					};
+					sfp24_gpio01_sfp_pres {
+						reg-map = <0x3c (1 << 7)>;
+						gpio-num = <70>;
+					};
+					sfp24_gpio02_tx_dis {
+						reg-map = <0x33 (1 << 7)>;
+						gpio-num = <71>;
+					};
+					/* sfp25 */
+					sfp25_gpio00_loss {
+						reg-map = <0x43 (1 << 0)>;
+						gpio-num = <72>;
+					};
+					sfp25_gpio01_pres {
+						reg-map = <0x3d (1 << 0)>;
+						gpio-num = <73>;
+					};
+					sfp25_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 0)>;
+						gpio-num = <74>;
+					};
+					/* sfp26 */
+					sfp26_gpio00_sfp_loss {
+						reg-map = <0x43 (1 << 1)>;
+						gpio-num = <75>;
+					};
+					sfp26_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 1)>;
+						gpio-num = <76>;
+					};
+					sfp26_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 1)>;
+						gpio-num = <77>;
+					};
+					/* sfp27 */
+					sfp27_gpio00_loss {
+						reg-map = <0x43 (1 << 2)>;
+						gpio-num = <78>;
+					};
+					sfp27_gpio01_pres {
+						reg-map = <0x3d (1 << 2)>;
+						gpio-num = <79>;
+					};
+					sfp27_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 2)>;
+						gpio-num = <80>;
+					};
+					/* sfp28 */
+					sfp28_gpio00_loss {
+						reg-map = <0x43 (1 << 3)>;
+						gpio-num = <81>;
+					};
+					sfp28_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 3)>;
+						gpio-num = <82>;
+					};
+					sfp28_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 3)>;
+						gpio-num = <83>;
+					};
+					/* sfp29 */
+					sfp29_gpio00_loss {
+						reg-map = <0x43 (1 << 4)>;
+						gpio-num = <84>;
+					};
+					sfp29_gpio01_pres {
+						reg-map = <0x3d (1 << 4)>;
+						gpio-num = <85>;
+					};
+					sfp29_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 4)>;
+						gpio-num = <86>;
+					};
+					/* sfp30 */
+					sfp30_gpio00_sfp_loss {
+						reg-map = <0x43 (1 << 5)>;
+						gpio-num = <87>;
+					};
+					sfp30_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 5)>;
+						gpio-num = <88>;
+					};
+					sfp30_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 5)>;
+						gpio-num = <89>;
+					};
+					/* sfp31 */
+					sfp31_gpio00_loss {
+						reg-map = <0x43 (1 << 6)>;
+						gpio-num = <90>;
+					};
+					sfp31_gpio01_pres {
+						reg-map = <0x3d (1 << 6)>;
+						gpio-num = <91>;
+					};
+					sfp31_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 6)>;
+						gpio-num = <92>;
+					};
+					/* sfp32 */
+					sfp32_gpio00_loss {
+						reg-map = <0x43 (1 << 7)>;
+						gpio-num = <93>;
+					};
+					sfp32_gpio01_sfp_pres {
+						reg-map = <0x3d (1 << 7)>;
+						gpio-num = <94>;
+					};
+					sfp32_gpio02_tx_dis {
+						reg-map = <0x34 (1 << 7)>;
+						gpio-num = <95>;
+					};
+					/* sfp33 */
+					sfp33_gpio00_loss {
+						reg-map = <0x44 (1 << 0)>;
+						gpio-num = <96>;
+					};
+					sfp33_gpio01_pres {
+						reg-map = <0x3e (1 << 0)>;
+						gpio-num = <97>;
+					};
+					sfp33_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 0)>;
+						gpio-num = <98>;
+					};
+					/* sfp34 */
+					sfp34_gpio00_sfp_loss {
+						reg-map = <0x44 (1 << 1)>;
+						gpio-num = <99>;
+					};
+					sfp34_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 1)>;
+						gpio-num = <100>;
+					};
+					sfp34_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 1)>;
+						gpio-num = <101>;
+					};
+					/* sfp35 */
+					sfp35_gpio00_loss {
+						reg-map = <0x44 (1 << 2)>;
+						gpio-num = <102>;
+					};
+					sfp35_gpio01_pres {
+						reg-map = <0x3e (1 << 2)>;
+						gpio-num = <103>;
+					};
+					sfp35_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 2)>;
+						gpio-num = <104>;
+					};
+					/* sfp36 */
+					sfp36_gpio00_loss {
+						reg-map = <0x44 (1 << 3)>;
+						gpio-num = <105>;
+					};
+					sfp36_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 3)>;
+						gpio-num = <106>;
+					};
+					sfp36_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 3)>;
+						gpio-num = <107>;
+					};
+					/* sfp37 */
+					sfp37_gpio00_loss {
+						reg-map = <0x44 (1 << 4)>;
+						gpio-num = <108>;
+					};
+					sfp37_gpio01_pres {
+						reg-map = <0x3e (1 << 4)>;
+						gpio-num = <109>;
+					};
+					sfp37_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 4)>;
+						gpio-num = <110>;
+					};
+					/* sfp38 */
+					sfp38_gpio00_sfp_loss {
+						reg-map = <0x44 (1 << 5)>;
+						gpio-num = <111>;
+					};
+					sfp38_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 5)>;
+						gpio-num = <112>;
+					};
+					sfp38_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 5)>;
+						gpio-num = <113>;
+					};
+					/* sfp39 */
+					sfp39_gpio00_loss {
+						reg-map = <0x44 (1 << 6)>;
+						gpio-num = <114>;
+					};
+					sfp39_gpio01_pres {
+						reg-map = <0x3e (1 << 6)>;
+						gpio-num = <115>;
+					};
+					sfp39_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 6)>;
+						gpio-num = <116>;
+					};
+					/* sfp40 */
+					sfp40_gpio00_loss {
+						reg-map = <0x44 (1 << 7)>;
+						gpio-num = <117>;
+					};
+					sfp40_gpio01_sfp_pres {
+						reg-map = <0x3e (1 << 7)>;
+						gpio-num = <118>;
+					};
+					sfp40_gpio02_tx_dis {
+						reg-map = <0x35 (1 << 7)>;
+						gpio-num = <119>;
+					};
+					/* sfp41 */
+					sfp41_gpio00_loss {
+						reg-map = <0x45 (1 << 0)>;
+						gpio-num = <120>;
+					};
+					sfp41_gpio01_pres {
+						reg-map = <0x3f (1 << 0)>;
+						gpio-num = <121>;
+					};
+					sfp41_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 0)>;
+						gpio-num = <122>;
+					};
+					/* sfp42 */
+					sfp42_gpio00_sfp_loss {
+						reg-map = <0x45 (1 << 1)>;
+						gpio-num = <123>;
+					};
+					sfp42_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 1)>;
+						gpio-num = <124>;
+					};
+					sfp42_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 1)>;
+						gpio-num = <125>;
+					};
+					/* sfp43 */
+					sfp43_gpio00_loss {
+						reg-map = <0x45 (1 << 2)>;
+						gpio-num = <126>;
+					};
+					sfp43_gpio01_pres {
+						reg-map = <0x3f (1 << 2)>;
+						gpio-num = <127>;
+					};
+					sfp43_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 2)>;
+						gpio-num = <128>;
+					};
+					/* sfp44 */
+					sfp44_gpio00_loss {
+						reg-map = <0x45 (1 << 3)>;
+						gpio-num = <129>;
+					};
+					sfp44_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 3)>;
+						gpio-num = <130>;
+					};
+					sfp44_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 3)>;
+						gpio-num = <131>;
+					};
+					/* sfp45 */
+					sfp45_gpio00_loss {
+						reg-map = <0x45 (1 << 4)>;
+						gpio-num = <132>;
+					};
+					sfp45_gpio01_pres {
+						reg-map = <0x3f (1 << 4)>;
+						gpio-num = <133>;
+					};
+					sfp45_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 4)>;
+						gpio-num = <134>;
+					};
+					/* sfp46 */
+					sfp46_gpio00_sfp_loss {
+						reg-map = <0x45 (1 << 5)>;
+						gpio-num = <135>;
+					};
+					sfp46_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 5)>;
+						gpio-num = <136>;
+					};
+					sfp46_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 5)>;
+						gpio-num = <137>;
+					};
+					/* sfp47 */
+					sfp47_gpio00_loss {
+						reg-map = <0x45 (1 << 6)>;
+						gpio-num = <138>;
+					};
+					sfp47_gpio01_pres {
+						reg-map = <0x3f (1 << 6)>;
+						gpio-num = <139>;
+					};
+					sfp47_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 6)>;
+						gpio-num = <140>;
+					};
+					/* sfp48 */
+					sfp48_gpio00_loss {
+						reg-map = <0x45 (1 << 7)>;
+						gpio-num = <141>;
+					};
+					sfp48_gpio01_sfp_pres {
+						reg-map = <0x3f (1 << 7)>;
+						gpio-num = <142>;
+					};
+					sfp48_gpio02_tx_dis {
+						reg-map = <0x36 (1 << 7)>;
+						gpio-num = <143>;
+					};
+				};
+			};
+		};
+		i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	tpm0: slb9670@0 {
+		compatible = "infineon,slb9670";
+		reg = <0>;
+		spi-max-frequency = <38000000>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+};
+
+&cp0_i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	i2c-mux@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp1: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp2: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp3: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp4: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp5: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp6: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp7: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp8: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@71 {
+		compatible = "nxp,pca9548";
+		reg = <0x71>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp9: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp10: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp11: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp12: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp13: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp14: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp15: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp16: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@72 {
+		compatible = "nxp,pca9548";
+		reg = <0x72>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp17: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp18: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp19: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp20: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp21: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp22: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp23: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp24: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@73 {
+		compatible = "nxp,pca9548";
+		reg = <0x73>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp25: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp26: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp27: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp28: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp29: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp30: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp31: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp32: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@74 {
+		compatible = "nxp,pca9548";
+		reg = <0x74>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp33: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp34: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp35: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp36: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp37: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp38: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp39: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp40: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+	i2c-mux@75 {
+		compatible = "nxp,pca9548";
+		reg = <0x75>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c1_sfp41: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+		i2c1_sfp42: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c1_sfp43: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+		i2c1_sfp44: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+		i2c1_sfp45: i2c@4 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <4>;
+		};
+		i2c1_sfp46: i2c@5 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <5>;
+		};
+		i2c1_sfp47: i2c@6 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <6>;
+		};
+		i2c1_sfp48: i2c@7 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <7>;
+		};
+	};
+};
+
+&cp0_spi0 {
+	status = "okay";
+
+	spi-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x3f0000>;
+			};
+
+			partition@3f0000 {
+				label = "uboot-env";
+				reg = <0x3f0000 0x010000>;
+			};
+
+			partition@400000 {
+				label = "ONIE";
+				reg = <0x400000 0xc00000>;
+			};
+		};
+	};
+};
+
+&cp0_sata0 {
+	status = "okay";
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_mdio {
+	status = "okay";
+
+	OOB_E1512_PHY: ethernet-phy@1 {
+		reg = <0x0>;
+	};
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disabled";
+};
+
+&cp0_eth1 {
+	status = "disabled";
+};
+
+&cp0_eth2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "disabled";
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m-dn.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m-dn.dts
@@ -1,0 +1,368 @@
+/*
+ * Delta TN48M-DN/TN48M-POE-DN Device Tree Source
+ *
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "delta,tn48m-dn";
+	compatible = "delta,tn48m-dn";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	sfp49: sfp-49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+		los-gpio = <&tn48xxm_dn_cpld 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 2 GPIO_ACTIVE_HIGH>;
+	};
+	sfp50: sfp-50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+		los-gpio = <&tn48xxm_dn_cpld 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 5 GPIO_ACTIVE_HIGH>;
+	};
+	sfp51: sfp-51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+		los-gpio = <&tn48xxm_dn_cpld 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 8 GPIO_ACTIVE_HIGH>;
+	};
+	sfp52: sfp-52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+		los-gpio = <&tn48xxm_dn_cpld 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_dn_cpld 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_dn_cpld 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	i2cmux {
+		compatible = "i2c-mux-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mux-gpios = <&cp0_gpio2 22 0 &cp0_gpio2 23 0>;
+		i2c-parent = <&cp0_i2c1>;
+
+		i2c1_sfp1: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp2: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp3: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp4: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		ports {
+			port49 {
+				prestera,port-num = <49>;
+				sfp = <&sfp49>;
+			};
+			port50 {
+				prestera,port-num = <50>;
+				sfp = <&sfp50>;
+			};
+			port51 {
+				prestera,port-num = <51>;
+				sfp = <&sfp51>;
+			};
+			port52 {
+				prestera,port-num = <52>;
+				sfp = <&sfp52>;
+			};
+		};
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		base-mac-provider = <&onie_eeprom>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	tn48xxm_dn_cpld: tn48xxm-dn-cpld@41 {
+		compatible = "dni,tn48m_dn_cpld";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x41>;  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp1 */
+			sfp01_gpio00_loss {
+				reg-map = <0x40 (1 << 0)>; /* 0x40=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp01_gpio01_pres {
+				reg-map = <0x3a (1 << 0)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 0)>; /* reg mask */
+				gpio-num = <2>;
+			};
+			/* sfp2 */
+			sfp02_gpio00_sfp_loss {
+				reg-map = <0x40 (1 << 1)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp02_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 1)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp02_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 1)>; /* reg mask */
+				gpio-num = <5>;
+			};
+			/* sfp3 */
+			sfp03_gpio00_loss {
+				reg-map = <0x40 (1 << 2)>; /* reg mask */
+				gpio-num = <6>;
+			};
+			sfp03_gpio01_pres {
+				reg-map = <0x3a (1 << 2)>; /* reg mask */
+				gpio-num = <7>;
+			};
+			sfp03_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 2)>; /* reg mask */
+				gpio-num = <8>;
+			};
+			/* sfp4 */
+			sfp04_gpio00_loss {
+				reg-map = <0x40 (1 << 3)>; /* reg mask */
+				gpio-num = <9>;
+			};
+			sfp04_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 3)>; /* reg mask */
+				gpio-num = <10>;
+			};
+			sfp04_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 3)>; /* reg mask */
+				gpio-num = <11>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	tpm0: slb9670@0 {
+		compatible = "infineon,slb9670";
+		reg = <0>;
+		spi-max-frequency = <38000000>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+};
+
+&cp0_i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_spi0 {
+	status = "okay";
+
+	spi-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x3f0000>;
+			};
+
+			partition@3f0000 {
+				label = "uboot-env";
+				reg = <0x3f0000 0x010000>;
+			};
+
+			partition@400000 {
+				label = "ONIE";
+				reg = <0x400000 0xc00000>;
+			};
+		};
+	};
+};
+
+&cp0_sata0 {
+	status = "okay";
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_mdio {
+	status = "okay";
+
+	OOB_E1512_PHY: ethernet-phy@1 {
+		reg = <0x0>;
+	};
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disabled";
+};
+
+&cp0_eth1 {
+	status = "disabled";
+};
+
+&cp0_eth2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "disabled";
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m.dts
@@ -1,0 +1,368 @@
+/*
+ * Delta TN48M/TN48M2/TN48M-POE Device Tree Source
+ *
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "delta,tn48m";
+	compatible = "delta,tn48m";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	sfp49: sfp-49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+		los-gpio = <&tn48xxm_cpld 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 2 GPIO_ACTIVE_HIGH>;
+	};
+	sfp50: sfp-50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+		los-gpio = <&tn48xxm_cpld 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 5 GPIO_ACTIVE_HIGH>;
+	};
+	sfp51: sfp-51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+		los-gpio = <&tn48xxm_cpld 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 8 GPIO_ACTIVE_HIGH>;
+	};
+	sfp52: sfp-52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+		los-gpio = <&tn48xxm_cpld 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	i2cmux {
+		compatible = "i2c-mux-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mux-gpios = <&cp0_gpio2 22 0 &cp0_gpio2 23 0>;
+		i2c-parent = <&cp0_i2c1>;
+
+		i2c1_sfp1: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp2: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp3: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp4: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		ports {
+			port49 {
+				prestera,port-num = <49>;
+				sfp = <&sfp49>;
+			};
+			port50 {
+				prestera,port-num = <50>;
+				sfp = <&sfp50>;
+			};
+			port51 {
+				prestera,port-num = <51>;
+				sfp = <&sfp51>;
+			};
+			port52 {
+				prestera,port-num = <52>;
+				sfp = <&sfp52>;
+			};
+		};
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		base-mac-provider = <&onie_eeprom>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	tn48xxm_cpld: tn48xxm-cpld@41 {
+		compatible = "dni,tn48m_cpld";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x41>;  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp1 */
+			sfp01_gpio00_loss {
+				reg-map = <0x40 (1 << 0)>; /* 0x40=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp01_gpio01_pres {
+				reg-map = <0x3a (1 << 0)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 0)>; /* reg mask */
+				gpio-num = <2>;
+			};
+			/* sfp2 */
+			sfp02_gpio00_sfp_loss {
+				reg-map = <0x40 (1 << 1)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp02_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 1)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp02_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 1)>; /* reg mask */
+				gpio-num = <5>;
+			};
+			/* sfp3 */
+			sfp03_gpio00_loss {
+				reg-map = <0x40 (1 << 2)>; /* reg mask */
+				gpio-num = <6>;
+			};
+			sfp03_gpio01_pres {
+				reg-map = <0x3a (1 << 2)>; /* reg mask */
+				gpio-num = <7>;
+			};
+			sfp03_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 2)>; /* reg mask */
+				gpio-num = <8>;
+			};
+			/* sfp4 */
+			sfp04_gpio00_loss {
+				reg-map = <0x40 (1 << 3)>; /* reg mask */
+				gpio-num = <9>;
+			};
+			sfp04_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 3)>; /* reg mask */
+				gpio-num = <10>;
+			};
+			sfp04_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 3)>; /* reg mask */
+				gpio-num = <11>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	tpm0: slb9670@0 {
+		compatible = "infineon,slb9670";
+		reg = <0>;
+		spi-max-frequency = <38000000>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+};
+
+&cp0_i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_spi0 {
+	status = "okay";
+
+	spi-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x3f0000>;
+			};
+
+			partition@3f0000 {
+				label = "uboot-env";
+				reg = <0x3f0000 0x010000>;
+			};
+
+			partition@400000 {
+				label = "ONIE";
+				reg = <0x400000 0xc00000>;
+			};
+		};
+	};
+};
+
+&cp0_sata0 {
+	status = "okay";
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_mdio {
+	status = "okay";
+
+	OOB_E1512_PHY: ethernet-phy@1 {
+		reg = <0x0>;
+	};
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disabled";
+};
+
+&cp0_eth1 {
+	status = "disabled";
+};
+
+&cp0_eth2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "disabled";
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m2-swdev.dts
+++ b/packages/base/any/kernels/5.15-lts/files/arch/arm64/boot/dts/marvell/delta-tn48m2-swdev.dts
@@ -1,0 +1,368 @@
+/*
+ * Delta TN48M2-SWDEV Device Tree Source
+ *
+ * Copyright (C) 2016 Marvell Technology Group Ltd.
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPLv2 or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dt-bindings/gpio/gpio.h>
+#include "armada-7040.dtsi"
+
+/ {
+	model = "delta,tn48m2-swdev";
+	compatible = "delta,tn48m";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x80000000>;
+	};
+
+	aliases {
+		ethernet0 = &cp0_eth0;
+		ethernet1 = &cp0_eth1;
+		ethernet2 = &cp0_eth2;
+	};
+
+	switch-cpu {
+		compatible = "marvell,prestera-switch-rxtx-sdma";
+		status = "okay";
+	};
+
+	sfp49: sfp-49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp1>;
+		los-gpio = <&tn48xxm_cpld 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 2 GPIO_ACTIVE_HIGH>;
+	};
+	sfp50: sfp-50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp2>;
+		los-gpio = <&tn48xxm_cpld 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 5 GPIO_ACTIVE_HIGH>;
+	};
+	sfp51: sfp-51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp3>;
+		los-gpio = <&tn48xxm_cpld 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 8 GPIO_ACTIVE_HIGH>;
+	};
+	sfp52: sfp-52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sfp4>;
+		los-gpio = <&tn48xxm_cpld 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&tn48xxm_cpld 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&tn48xxm_cpld 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	i2cmux {
+		compatible = "i2c-mux-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		mux-gpios = <&cp0_gpio2 22 0 &cp0_gpio2 23 0>;
+		i2c-parent = <&cp0_i2c1>;
+
+		i2c1_sfp1: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp2: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp3: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		i2c1_sfp4: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		ports {
+			port49 {
+				prestera,port-num = <49>;
+				sfp = <&sfp49>;
+			};
+			port50 {
+				prestera,port-num = <50>;
+				sfp = <&sfp50>;
+			};
+			port51 {
+				prestera,port-num = <51>;
+				sfp = <&sfp51>;
+			};
+			port52 {
+				prestera,port-num = <52>;
+				sfp = <&sfp52>;
+			};
+		};
+	};
+
+	onie_eeprom: onie-eeprom {
+		compatible = "onie-nvmem-cells";
+		status = "okay";
+
+		nvmem = <&eeprom_at24>;
+	};
+
+	prestera {
+		compatible = "marvell,prestera";
+		status = "okay";
+
+		base-mac-provider = <&onie_eeprom>;
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	tn48xxm_cpld: tn48xxm-cpld@41 {
+		compatible = "dni,tn48m_cpld";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		reg = <0x41>;  /* CPLD/MUX I2C address */
+
+		gpio-map {
+			/* sfp1 */
+			sfp01_gpio00_loss {
+				reg-map = <0x40 (1 << 0)>; /* 0x40=register in the CPLD, (1 << 0)=Selected bit */
+				gpio-num = <0>;  /* Logical number used by: los-gpio, mod-def0-gpio and tx-disable-gpio */
+			};
+			sfp01_gpio01_pres {
+				reg-map = <0x3a (1 << 0)>; /* reg mask */
+				gpio-num = <1>;
+			};
+			sfp01_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 0)>; /* reg mask */
+				gpio-num = <2>;
+			};
+			/* sfp2 */
+			sfp02_gpio00_sfp_loss {
+				reg-map = <0x40 (1 << 1)>; /* reg mask */
+				gpio-num = <3>;
+			};
+			sfp02_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 1)>; /* reg mask */
+				gpio-num = <4>;
+			};
+			sfp02_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 1)>; /* reg mask */
+				gpio-num = <5>;
+			};
+			/* sfp3 */
+			sfp03_gpio00_loss {
+				reg-map = <0x40 (1 << 2)>; /* reg mask */
+				gpio-num = <6>;
+			};
+			sfp03_gpio01_pres {
+				reg-map = <0x3a (1 << 2)>; /* reg mask */
+				gpio-num = <7>;
+			};
+			sfp03_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 2)>; /* reg mask */
+				gpio-num = <8>;
+			};
+			/* sfp4 */
+			sfp04_gpio00_loss {
+				reg-map = <0x40 (1 << 3)>; /* reg mask */
+				gpio-num = <9>;
+			};
+			sfp04_gpio01_sfp_pres {
+				reg-map = <0x3a (1 << 3)>; /* reg mask */
+				gpio-num = <10>;
+			};
+			sfp04_gpio02_tx_dis {
+				reg-map = <0x31 (1 << 3)>; /* reg mask */
+				gpio-num = <11>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	tpm0: slb9670@0 {
+		compatible = "infineon,slb9670";
+		reg = <0>;
+		spi-max-frequency = <38000000>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&cp0_i2c0 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	eeprom_at24: at24@56 {
+		compatible = "atmel,24c64";
+		reg = <0x56>;
+	};
+};
+
+&cp0_i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+&cp0_spi0 {
+	status = "okay";
+
+	spi-flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "uboot";
+				reg = <0x0 0x3f0000>;
+			};
+
+			partition@3f0000 {
+				label = "uboot-env";
+				reg = <0x3f0000 0x010000>;
+			};
+
+			partition@400000 {
+				label = "ONIE";
+				reg = <0x400000 0x3c00000>;
+			};
+		};
+	};
+};
+
+&cp0_sata0 {
+	status = "okay";
+};
+
+&cp0_usb3_0 {
+	status = "okay";
+};
+
+&cp0_usb3_1 {
+	status = "okay";
+};
+
+&ap_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_sdhci0 {
+	status = "okay";
+	bus-width = <4>;
+	no-1-8-v;
+	non-removable;
+};
+
+&cp0_mdio {
+	status = "okay";
+
+	OOB_E1512_PHY: ethernet-phy@1 {
+		reg = <0x0>;
+	};
+};
+
+&cp0_ethernet {
+	status = "okay";
+};
+
+&cp0_eth0 {
+	status = "disabled";
+};
+
+&cp0_eth1 {
+	status = "disabled";
+};
+
+&cp0_eth2 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	phy = <&OOB_E1512_PHY>;
+	phys = <&cp0_comphy5 2>;
+};
+
+&cp0_crypto {
+	status = "disabled";
+};
+
+&cp0_pcie0 {
+	dma-ranges = <0x42000000 0x0 0x00000000 0x0 0x00000000 0x0 0x40000000>;
+	ranges = <0x81000000 0x0 0xfb000000 0x0 0xfb000000 0x0 0xf0000
+		0x82000000 0x0 0xf6000000 0x0 0xf6000000 0x0 0x0f00000
+		0x82000000 0x0 0xf9000000 0x0 0xf9000000 0x0 0x100000>;
+	phys = <&cp0_comphy0 0>;
+	status = "okay";
+};
+

--- a/packages/base/any/kernels/5.15-lts/kconfig.mk
+++ b/packages/base/any/kernels/5.15-lts/kconfig.mk
@@ -4,6 +4,7 @@ K_PATCH_LEVEL := 15
 K_SUB_LEVEL := 11
 K_SUFFIX :=
 K_PATCH_DIR := $(THIS_DIR)/patches
+K_FILES_DIR := $(THIS_DIR)/files
 K_MODSYNCLIST := tools/objtool
 K_GIT := 1
 K_GIT_URL := https://github.com/dentproject/linux.git


### PR DESCRIPTION
The DentOS own DTS files are in no shape to be upstreamed, and there
likely is no one willing to spend the effort to do so, so there is no
good reason to carry them as commits for the kernel source.

Instead provide them within the build system, as they are independent
from the kernel.

This also makes it easier to provide new device support without the need
to update the kernel, or atomic changes of device drivers and the
associated device trees.